### PR TITLE
Add support for where filter and text wrap in license policy command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,7 @@
             "databind",
             "Debugf",
             "defn",
+            "deserializers",
             "DHTML",
             "EMEA",
             "Exploitability",

--- a/README.md
+++ b/README.md
@@ -454,9 +454,27 @@ allow         Apache                        Apache-2.0                    Apache
 
 ##### Wrap flag
 
-Use the `--wrap` flag to toggle the wrapping of text within columns of the license policy report output using the values `true` or `false`. The default value is `false`.
+Use the `--wrap` flag to toggle the wrapping of text within columns of the license policy report (`txt` format only) output using the values `true` or `false`. The default value is `false`.
 
-###### Example: list summary
+##### Where flag
+
+The list command results can be filtered using the `--where` flag using the column names in the report. These include `usage-policy`, `family`, `id`, `name`, `annotations` and `notes`.
+
+###### Example: policy with where filter
+
+The following example shows filtering of  license policies using the `id` column:
+
+```bash
+./sbom-utility license policy --where id=Apache
+```
+
+```bash
+usage-policy  family  id          name                annotations  aliases                            notes
+------------  ------  --          ----                -----------  -------                            -----
+allow         Apache  Apache-1.0  Apache v1.0         APPROVED
+allow         Apache  Apache-1.1  Apache v1.1         APPROVED                                        This license has been su (24/54)
+allow         Apache  Apache-2.0  Apache License 2.0  APPROVED     Apache License, Version  (24/105)
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ allow         Apache                        Apache-2.0                    Apache
 - **Note**:
   - Currently, the default `license.json` file does not contain an entry for the complete SPDX 3.2 license templates. An issue [12](https://github.com/CycloneDX/sbom-utility/issues/12) is open to add parity.
   - Annotations can be defined within the `license.json` file and one or more assigned each license entry.
-  - Column data is, by default, truncated in `txt` format views only. In these cases, the number of characters shown out of the total available will be displayed at the point of truncation (e.g., `(24/26` would indicate 24 out of 26b characters were displayed).
+  - Column data is, by default, truncated in `txt` format views only. In these cases, the number of characters shown out of the total available will be displayed at the point of truncation (e.g., seeing `(24/26)` in a column would indicate 24 out of 26b characters were displayed).
 
 ##### Wrap flag
 

--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ allow         Apache                        Apache-2.0                    Apache
 - **Note**:
   - Currently, the default `license.json` file does not contain an entry for the complete SPDX 3.2 license templates. An issue [12](https://github.com/CycloneDX/sbom-utility/issues/12) is open to add parity.
   - Annotations can be defined within the `license.json` file and one or more assigned each license entry.
+  - Column data is, by default, truncated in `txt` format views only. In these cases, the number of characters shown out of the total available will be displayed at the point of truncation (e.g., `(24/26` would indicate 24 out of 26b characters were displayed).
 
 ##### Wrap flag
 

--- a/README.md
+++ b/README.md
@@ -811,7 +811,7 @@ Currently, all `vulnerability list` command results are sorted by vulnerability 
 ```
 
 ```bash
-id              bom-ref  source-name  source-url                                      created                   published                 updated                   rejected  description
+id              bom-ref  source-name source-url                                      created                   published                 updated                   rejected  description
 --              -------  ----------  -----------                                      -------                   ---------                 -------                   --------  -----------
 CVE-2020-25649           NVD         https://nvd.nist.gov/vuln/detail/CVE-2020-25649  2020-12-03T00:00:00.000Z  2020-12-03T00:00:00.000Z  2023-02-02T00:00:00.000Z            com.fasterxml.jackson.core:jackson-databind is a library which contains the general-purpose data-binding functionality and tree-model for Jackson Data Processor.  Affected versions of this package are vulnerable to XML External Entity (XXE) Injection.
 CVE-2022-42003           NVD         https://nvd.nist.gov/vuln/detail/CVE-2022-42003  2022-10-02T00:00:00.000Z  2022-10-02T00:00:00.000Z  2022-10-02T00:00:00.000Z            In FasterXML jackson-databind before 2.14.0-rc1, resource exhaustion can occur because of a lack of a check in primitive value deserializers to avoid deep wrapper array nesting, when the UNWRAP_SINGLE_VALUE_ARRAYS feature is enabled.
@@ -825,7 +825,7 @@ CVE-2022-42004           NVD         https://nvd.nist.gov/vuln/detail/CVE-2022-4
 ```
 
 ```bash
-id              bom-ref  source-name  source-url                                      created                   published                 updated                   rejected  description
+id              bom-ref  source-name source-url                                      created                   published                 updated                   rejected  description
 --              -------  ----------  -----------                                      -------                   ---------                 -------                   --------  -----------
 CVE-2020-25649           NVD         https://nvd.nist.gov/vuln/detail/CVE-2020-25649  2020-12-03T00:00:00.000Z  2020-12-03T00:00:00.000Z  2023-02-02T00:00:00.000Z            com.fasterxml.jackson.core:jackson-databind is a library which contains the general-purpose data-binding functionality and tree-model for Jackson Data Processor.  Affected versions of this package are vulnerable to XML External Entity (XXE) Injection.
 ```

--- a/README.md
+++ b/README.md
@@ -450,6 +450,12 @@ allow         Apache           Apache-2.0            Apache License 2.0    APPRO
   - Currently, the default `license.json` file does not contain an entry for the complete SPDX 3.2 license templates. An issue [12](https://github.com/CycloneDX/sbom-utility/issues/12) is open to add parity.
   - Annotations can be defined within the `license.json` file and one or more assigned each license entry.
 
+##### Wrap flag
+
+Use the `--wrap` flag to toggle the wrapping of text within columns of the license policy report output using the values `true` or `false`. The default value is `false`.
+
+###### Example: list summary
+
 ---
 
 ### Query

--- a/README.md
+++ b/README.md
@@ -435,14 +435,15 @@ To view a report listing the contents of the current policy file (i.e., [`licens
 ```
 
 ```bash
-Policy        Family           SPDX ID               Name                  Annotations
-------        ------           -------               ----                  -----------
-allow         0BSD             0BSD                  BSD Zero Clause Lice  APPROVED
-allow         AFL              AFL-3.0               Academic Free Licens  APPROVED
-needs-review  AGPL             AGPL-3.0-or-later     Affero General Publi  NEEDS-APPROVAL
-needs-review  APSL             APSL-2.0              Apple Public Source   NEEDS-APPROVAL
-allow         Adobe            Adobe-2006            Adobe Systems Incorp  APPROVED
-allow         Apache           Apache-2.0            Apache License 2.0    APPROVED
+usage-policy  family                        spdx-id                       name                          annotations                       aliases                            notes
+------------  ------                        -------                       ----                          -----------                       -------                            -----
+allow         0BSD                          0BSD                          BSD Zero Clause Lice (20/23)  APPROVED                          Free Public License 1.0. (24/25)
+needs-review  ADSL                          ADSL                          Amazon Digital Servi (20/31)  NEEDS-APPROVAL
+allow         AFL                           AFL-1.1                       Academic Free Licens (20/26)  APPROVED
+needs-review  AGPL                          AGPL-1.0                      Affero General Publi (20/34)  NEEDS-APPROVAL,AGPL-WARN (24/38)
+needs-review  APSL                          APSL-1.0                      Apple Public Source  (20/27)  NEEDS-APPROVAL
+allow         Adobe                         Adobe-2006                    Adobe Systems Incorp (20/56)  APPROVED
+allow         Apache                        Apache-2.0                    Apache License 2.0            APPROVED                          Apache License, Version  (24/105)
 ...
 ```
 

--- a/cmd/license.go
+++ b/cmd/license.go
@@ -94,7 +94,7 @@ func ClearGlobalLicenseData() {
 }
 
 func HashLicenseInfo(key string, licenseInfo LicenseInfo, whereFilters []WhereFilter) {
-	// Append to slice
+	// Find license usage policy by either license Id, Name or Expression
 	policy, err := FindPolicy(licenseInfo)
 
 	if err != nil {
@@ -173,8 +173,6 @@ func loadDocumentLicenses(document *schema.Sbom, whereFilters []WhereFilter) (er
 
 	// NOTE: DEBUG: use this to debug license policy hashmaps have appropriate # of entries
 	//licensePolicyConfig.Debug()
-
-	// TODO Support processing of []WhereFilter
 
 	// At this time, fail SPDX format SBOMs as "unsupported" (for "any" format)
 	if !document.FormatInfo.IsCycloneDx() {

--- a/cmd/license_list.go
+++ b/cmd/license_list.go
@@ -36,15 +36,12 @@ import (
 // TODO: Support a new --sort <column> flag
 const (
 	FLAG_LICENSE_SUMMARY = "summary"
-	FLAG_LICENSE_EXCLUDE = "exclude" // TODO
 )
 
 // License list command flag help messages
 const (
 	FLAG_LICENSE_LIST_OUTPUT_FORMAT_HELP = "format output using the specified format type"
 	FLAG_LICENSE_LIST_SUMMARY_HELP       = "summarize licenses and component references in table format (see --format flag help for supported types)"
-	FLAG_LICENSE_LIST_EXCLUDE_HELP       = "exclude policy column from summary listing" // TODO
-	FLAG_LICENSE_LIST_POLICY_HELP        = "filter license summary by usage policy (i.e., allow|deny|needs-review|UNDEFINED)"
 )
 
 // License list command informational messages
@@ -108,10 +105,6 @@ func NewCommandList() *cobra.Command {
 		&utils.GlobalFlags.LicenseFlags.Summary,
 		FLAG_LICENSE_SUMMARY, "", false,
 		FLAG_LICENSE_LIST_SUMMARY_HELP)
-	// command.Flags().StringVarP(
-	// 	&utils.GlobalFlags.LicenseFlags.Policy,
-	// 	FLAG_LICENSE_POLICY, "", "",
-	// 	FLAG_LICENSE_LIST_POLICY_HELP)
 	command.Flags().StringP(FLAG_REPORT_WHERE, "", "", FLAG_REPORT_WHERE_HELP)
 	command.RunE = listCmdImpl
 	command.PreRunE = func(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/license_list.go
+++ b/cmd/license_list.go
@@ -36,24 +36,21 @@ import (
 // TODO: Support a new --sort <column> flag
 const (
 	FLAG_LICENSE_SUMMARY = "summary"
-	FLAG_LICENSE_EXCLUDE = "exclude"
-	FLAG_LICENSE_POLICY  = "policy" // policy-match, policy-filter, etc.
+	FLAG_LICENSE_EXCLUDE = "exclude" // TODO
 )
 
 // License list command flag help messages
 const (
 	FLAG_LICENSE_LIST_OUTPUT_FORMAT_HELP = "format output using the specified format type"
 	FLAG_LICENSE_LIST_SUMMARY_HELP       = "summarize licenses and component references in table format (see --format flag help for supported types)"
-	FLAG_LICENSE_LIST_EXCLUDE_HELP       = "exclude policy column from summary listing"
+	FLAG_LICENSE_LIST_EXCLUDE_HELP       = "exclude policy column from summary listing" // TODO
 	FLAG_LICENSE_LIST_POLICY_HELP        = "filter license summary by usage policy (i.e., allow|deny|needs-review|UNDEFINED)"
 )
 
 // License list command informational messages
 const (
-	MSG_OUTPUT_NO_LICENSES_FOUND            = "No licenses found in BOM document"
-	MSG_OUTPUT_NO_LICENSES_ONLY_NOASSERTION = "No valid licenses found in BOM document (only licenses marked NOASSERTION)"
-	MSG_OUTPUT_NO_SCHEMAS_FOUND             = "[WARN] no schemas found in configuration (i.e., \"config.json\")"
-	MSG_OUTPUT_NO_RESOURCES_FOUND           = "[WARN] no matching resources found for query"
+	MSG_OUTPUT_NO_LICENSES_FOUND            = "no licenses found in BOM document"
+	MSG_OUTPUT_NO_LICENSES_ONLY_NOASSERTION = "no valid licenses found in BOM document (only licenses marked NOASSERTION)"
 )
 
 //"Type", "ID/Name/Expression", "Component(s)", "BOM ref.", "Document location"
@@ -111,22 +108,15 @@ func NewCommandList() *cobra.Command {
 		&utils.GlobalFlags.LicenseFlags.Summary,
 		FLAG_LICENSE_SUMMARY, "", false,
 		FLAG_LICENSE_LIST_SUMMARY_HELP)
-	command.Flags().StringVarP(
-		&utils.GlobalFlags.LicenseFlags.Policy,
-		FLAG_LICENSE_POLICY, "", "",
-		FLAG_LICENSE_LIST_POLICY_HELP)
+	// command.Flags().StringVarP(
+	// 	&utils.GlobalFlags.LicenseFlags.Policy,
+	// 	FLAG_LICENSE_POLICY, "", "",
+	// 	FLAG_LICENSE_LIST_POLICY_HELP)
 	command.Flags().StringP(FLAG_REPORT_WHERE, "", "", FLAG_REPORT_WHERE_HELP)
 	command.RunE = listCmdImpl
 	command.PreRunE = func(cmd *cobra.Command, args []string) (err error) {
 		if len(args) != 0 {
 			return getLogger().Errorf("Too many arguments provided: %v", args)
-		}
-
-		// Validate command line flag combinations
-		// TODO: document this flag relationship more clearly
-		bSummary := utils.GlobalFlags.LicenseFlags.Summary
-		if utils.GlobalFlags.LicenseFlags.Policy != "" && !bSummary {
-			return getLogger().Errorf("`%s` flag not valid without `%s` flag", FLAG_LICENSE_POLICY, FLAG_LICENSE_SUMMARY)
 		}
 
 		// Test for required flags (parameters)

--- a/cmd/license_list.go
+++ b/cmd/license_list.go
@@ -490,11 +490,11 @@ func DisplayLicenseListSummaryCSV(output io.Writer) (err error) {
 			// which is automatically done by the CSV writer
 			currentRow = append(currentRow,
 				licenseInfo.Policy.UsagePolicy,
-				licenseInfo.LicenseChoiceType, //LC_TYPE_NAMES[licenseInfo.LicenseChoiceTypeValue],
+				licenseInfo.LicenseChoiceType,
 				licenseName.(string),
 				licenseInfo.ResourceName,
 				licenseInfo.BomRef,
-				licenseInfo.BomLocation, //CDX_LICENSE_LOCATION_NAMES[licenseInfo.BomLocationValue]
+				licenseInfo.BomLocation,
 			)
 
 			if errWrite := w.Write(currentRow); errWrite != nil {
@@ -545,11 +545,11 @@ func DisplayLicenseListSummaryMarkdown(output io.Writer) {
 			// Format line and write to output
 			line = append(line,
 				licenseInfo.Policy.UsagePolicy,
-				licenseInfo.LicenseChoiceType, // LC_TYPE_NAMES[licenseInfo.LicenseChoiceTypeValue],
+				licenseInfo.LicenseChoiceType,
 				licenseName.(string),
 				licenseInfo.ResourceName,
 				licenseInfo.BomRef,
-				licenseInfo.BomLocation, // CDX_LICENSE_LOCATION_NAMES[licenseInfo.BomLocationValue]
+				licenseInfo.BomLocation,
 			)
 
 			lineRow = createMarkdownRow(line)

--- a/cmd/license_policy.go
+++ b/cmd/license_policy.go
@@ -361,15 +361,16 @@ func DisplayLicensePoliciesTabbedText(output io.Writer) (err error) {
 			lines := wrapOutputLines(policy.UsagePolicy, policy.Family, policy.Id, policy.Name,
 				policy.Aliases, policy.AnnotationRefs, policy.Notes)
 
-			for i, _ := range lines {
+			for _, line := range lines {
+
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-					truncateString(lines[i][0], 16, true), // usage-policy
-					truncateString(lines[i][1], 20, true), // family
-					truncateString(lines[i][2], 20, true), // id
-					truncateString(lines[i][3], 20, true), // name
-					truncateString(lines[i][4], 24, true), // alias
-					truncateString(lines[i][5], 24, true), // annotation
-					truncateString(lines[i][6], 24, true), // note
+					truncateString(line[0], 16, true), // usage-policy
+					truncateString(line[1], 20, true), // family
+					truncateString(line[2], 20, true), // id
+					truncateString(line[3], 20, true), // name
+					truncateString(line[4], 24, true), // alias
+					truncateString(line[5], 24, true), // annotation
+					truncateString(line[6], 24, true), // note
 				)
 			}
 		}
@@ -530,7 +531,7 @@ func wrapOutputLines(usage string,
 	lines := make([][]string, numRows)
 
 	for i, line := range lines {
-
+		// create line slice sized to number of columns
 		line = make([]string, 7)
 		lines[i] = line
 

--- a/cmd/license_policy.go
+++ b/cmd/license_policy.go
@@ -33,6 +33,12 @@ import (
 
 var VALID_SUBCOMMANDS_POLICY = []string{SUBCOMMAND_RESOURCE_LIST}
 
+// Subcommand flags
+// TODO: Support a new --sort <column> flag
+const (
+	FLAG_POLICY_REPORT_LINE_WRAP = "wrap"
+)
+
 // filter keys
 const (
 	POLICY_FILTER_KEY_USAGE_POLICY = "usage-policy"
@@ -65,7 +71,8 @@ var VALID_POLICY_WHERE_FILTER_KEYS = []string{
 
 // Subcommand flags
 const (
-	FLAG_POLICY_OUTPUT_FORMAT_HELP = "format output using the specified type"
+	FLAG_POLICY_OUTPUT_FORMAT_HELP    = "format output using the specified type"
+	FLAG_POLICY_REPORT_LINE_WRAP_HELP = "toggles the wrapping of text within report column output (default: false)"
 )
 
 // License list policy command informational messages
@@ -88,6 +95,10 @@ func NewCommandPolicy() *cobra.Command {
 	command.Flags().StringVarP(&utils.GlobalFlags.OutputFormat, FLAG_FILE_OUTPUT_FORMAT, "", FORMAT_TEXT,
 		FLAG_POLICY_OUTPUT_FORMAT_HELP+LICENSE_POLICY_SUPPORTED_FORMATS)
 	command.Flags().StringP(FLAG_REPORT_WHERE, "", "", FLAG_REPORT_WHERE_HELP)
+	command.Flags().BoolVarP(
+		&utils.GlobalFlags.LicenseFlags.ListLineWrap,
+		FLAG_POLICY_REPORT_LINE_WRAP, "", false,
+		FLAG_POLICY_REPORT_LINE_WRAP_HELP)
 	command.RunE = policyCmdImpl
 	command.PreRunE = func(cmd *cobra.Command, args []string) (err error) {
 		if len(args) != 0 {

--- a/cmd/license_policy.go
+++ b/cmd/license_policy.go
@@ -504,6 +504,8 @@ func DisplayLicensePoliciesMarkdown(output io.Writer) (err error) {
 	return
 }
 
+// TODO make a generic function that takes interface{} and checks type for either string or []string
+// and processes wrap accordingly dependent on type (i.e., wrap only on []string)
 func wrapOutputLines(usage string,
 	family string, id string, name string,
 	aliases []string,
@@ -520,10 +522,6 @@ func wrapOutputLines(usage string,
 	if numRows < len(notes) {
 		numRows = len(notes)
 	}
-
-	// if numRows > 1 {
-	// 	fmt.Printf("numRows: %v", numRows)
-	// }
 
 	var alias string
 	var annotation string
@@ -567,12 +565,7 @@ func wrapOutputLines(usage string,
 			line[5] = annotation
 			line[6] = note
 		}
-		//fmt.Printf("lines[%d]: %v", i, line)
 	}
-
-	// if len(lines) > 1 {
-	// 	fmt.Printf("lines: %v", lines)
-	// }
 
 	return lines
 }

--- a/cmd/license_policy.go
+++ b/cmd/license_policy.go
@@ -530,9 +530,9 @@ func wrapOutputLines(usage string,
 
 	lines := make([][]string, numRows)
 
-	for i, line := range lines {
+	for i := range lines {
 		// create line slice sized to number of columns
-		line = make([]string, 7)
+		line := make([]string, 7)
 		lines[i] = line
 
 		if i < len(aliases) {

--- a/cmd/license_policy_config.go
+++ b/cmd/license_policy_config.go
@@ -81,6 +81,18 @@ type LicenseComplianceConfig struct {
 	licenseIdMap         *slicemultimap.MultiMap
 }
 
+func (config *LicenseComplianceConfig) Reset() {
+	config.policyConfigFile = DEFAULT_LICENSE_POLICIES
+	config.PolicyList = nil
+	config.Annotations = nil
+	if config.licenseFamilyNameMap != nil {
+		config.licenseFamilyNameMap.Clear()
+	}
+	if config.licenseIdMap != nil {
+		config.licenseIdMap.Clear()
+	}
+}
+
 func (config *LicenseComplianceConfig) Debug() {
 	fmt.Printf(">> policyConfigFile: %s\n", config.policyConfigFile)
 	fmt.Printf(">> PolicyList (length): %v\n", len(config.PolicyList))
@@ -117,6 +129,9 @@ func (config *LicenseComplianceConfig) LoadLicensePolicies(filename string) (err
 func (config *LicenseComplianceConfig) innerLoadLicensePolicies(filename string) (err error) {
 	getLogger().Enter(filename)
 	defer getLogger().Exit()
+
+	// Always reset the config
+	config.Reset()
 
 	// locate the license policy file
 	config.policyConfigFile, err = utils.FindVerifyConfigFileAbsPath(getLogger(), filename)

--- a/cmd/license_policy_test.go
+++ b/cmd/license_policy_test.go
@@ -553,7 +553,7 @@ func TestLicensePolicyMatchByFamilyNameBadExpression(t *testing.T) {
 	}
 }
 
-func TestLicensePolicyListText(t *testing.T) {
+func TestLicensePolicyListTextFirstEntry0BSD(t *testing.T) {
 	var buffer bytes.Buffer
 	writer := bufio.NewWriter(&buffer)
 	ListPolicies(writer)

--- a/cmd/license_policy_test.go
+++ b/cmd/license_policy_test.go
@@ -20,8 +20,11 @@ package cmd
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/CycloneDX/sbom-utility/utils"
 )
 
 const (
@@ -44,6 +47,151 @@ const (
 	LICENSE_ID_MAYBE = "Maybe"
 )
 
+// -------------------------------------------
+// license test helper functions
+// -------------------------------------------
+
+func NewLicensePolicyTestInfoBasic(format string, wrapLines bool) *LicenseTestInfo {
+	lti := NewLicenseTestInfo("", format, "", false, false, "", LTI_DEFAULT_LINE_COUNT, nil)
+	lti.ListLineWrap = wrapLines
+	return lti
+}
+
+func loadHashCustomPolicyFile(policyFile string) (err error) {
+	err = licensePolicyConfig.innerLoadLicensePolicies(policyFile)
+	if err != nil {
+		return
+	}
+	// Note: the HashLicensePolicies function creates new id and name hashmaps
+	// therefore there is no need to clear them
+	err = licensePolicyConfig.innerHashLicensePolicies()
+	return
+}
+
+func innerTestLicensePolicyListCustomAndBuffered(t *testing.T, testInfo *LicenseTestInfo, whereFilters []WhereFilter) (outputBuffer bytes.Buffer, err error) {
+	// Declare an output outputBuffer/outputWriter to use used during tests
+	var outputWriter = bufio.NewWriter(&outputBuffer)
+	// ensure all data is written to buffer before further validation
+	defer outputWriter.Flush()
+
+	if testInfo.PolicyFile != "" && testInfo.PolicyFile != DEFAULT_LICENSE_POLICIES {
+		// !!! IMPORTANT !!! restore default policy file to default for all other tests
+		loadHashCustomPolicyFile(testInfo.PolicyFile)
+	}
+
+	// Use the test data to set the BOM input file and output format
+	utils.GlobalFlags.InputFile = testInfo.InputFile
+	utils.GlobalFlags.OutputFormat = testInfo.Format
+
+	// Invoke the actual List command (API)
+	err = ListLicensePolicies(outputWriter, whereFilters)
+
+	if testInfo.PolicyFile != "" && testInfo.PolicyFile != DEFAULT_LICENSE_POLICIES {
+		// !!! IMPORTANT !!! restore default policy file to default for all other tests
+		loadHashCustomPolicyFile(DEFAULT_LICENSE_POLICIES)
+	}
+
+	return
+}
+
+func innerTestLicensePolicyList(t *testing.T, testInfo *LicenseTestInfo) (outputBuffer bytes.Buffer, err error) {
+
+	// Prepare WHERE filters from where clause
+	var whereFilters []WhereFilter = nil
+	if testInfo.WhereClause != "" {
+		whereFilters, err = retrieveWhereFilters(testInfo.WhereClause)
+		if err != nil {
+			getLogger().Error(err)
+			t.Errorf("test failed: %s: detail: %s ", testInfo, err.Error())
+			return
+		}
+	}
+
+	// Perform the test with buffered output
+	outputBuffer, err = innerTestLicensePolicyListCustomAndBuffered(t, testInfo, whereFilters)
+
+	// TEST: Expected error matches actual error
+	if testInfo.ExpectedError != nil {
+		// NOTE: err = nil will also fail if error was expected
+		if !ErrorTypesMatch(err, testInfo.ExpectedError) {
+			t.Errorf("expected error: %T, actual error: %T", testInfo.ExpectedError, err)
+		}
+		// Always return the expected error
+		return
+	}
+
+	// Unexpected error: return immediately/do not test output/results
+	if err != nil {
+		t.Errorf("test failed: %s: detail: %s ", testInfo, err.Error())
+		return
+	}
+
+	// TEST: Output contains string(s)
+	// TODO: Support []string
+	var outputResults string
+	if testInfo.ResultContainsValue != "" {
+		outputResults = outputBuffer.String()
+		getLogger().Debugf("output: \"%s\"", outputResults)
+
+		if !strings.Contains(outputResults, testInfo.ResultContainsValue) {
+			err = getLogger().Errorf("output did not contain expected value: `%s`", testInfo.ResultContainsValue)
+			t.Errorf("%s: input file: `%s`, where clause: `%s`",
+				err.Error(),
+				testInfo.InputFile,
+				testInfo.WhereClause)
+			return
+		}
+	}
+
+	// TEST: Line contains a set of string values
+	if len(testInfo.ResultContainsValues) > 0 {
+		matchFoundLine, matchFound := lineContainsValues(outputBuffer, testInfo.ResultExpectedAtLineNum, testInfo.ResultContainsValues...)
+		if !matchFound {
+			t.Errorf("policy file does not contain expected values: %v", testInfo.ResultContainsValues)
+			return
+		} else {
+			getLogger().Tracef("policy file contains expected values: %v on line: %v\n", testInfo.ResultContainsValues, matchFoundLine)
+		}
+	}
+
+	// TEST: Expected Line Count
+	if testInfo.ResultExpectedLineCount != LTI_DEFAULT_LINE_COUNT {
+		if outputResults == "" {
+			outputResults = outputBuffer.String()
+		}
+		outputLineCount := strings.Count(outputResults, "\n")
+		if outputLineCount != testInfo.ResultExpectedLineCount {
+			err = getLogger().Errorf("output did not contain expected line count: %v/%v (expected/actual)", testInfo.ResultExpectedLineCount, outputLineCount)
+			t.Errorf("%s: input file: `%s`, where clause: `%s`: \n%s",
+				err.Error(),
+				testInfo.InputFile,
+				testInfo.WhereClause,
+				outputResults,
+			)
+			return
+		}
+	}
+
+	// TEST: valid JSON if format JSON
+	// TODO the marshalled bytes is an array of CDX LicenseChoice (struct)
+	// TODO: add general validation for CSV and Markdown formats
+	if testInfo.ValidateJson {
+		if testInfo.Format == FORMAT_JSON {
+			// Use Marshal to test for validity
+			if !utils.IsValidJsonRaw(outputBuffer.Bytes()) {
+				t.Errorf("output did not contain valid JSON")
+				t.Logf("%s", outputBuffer.String())
+				return
+			}
+		}
+	}
+
+	return
+}
+
+//-----------------------------------
+// Usage Policy: allowed value tests
+//-----------------------------------
 func TestLicensePolicyUsageValueAllow(t *testing.T) {
 	value := POLICY_ALLOW
 	if !IsValidUsagePolicy(value) {
@@ -78,6 +226,10 @@ func TestLicensePolicyUsageInvalidValue(t *testing.T) {
 		t.Errorf("isValidUsagePolicy(): returned: %t; expected: %t", true, false)
 	}
 }
+
+//------------------------------------
+// Policy Family: allowed value tests
+//------------------------------------
 
 func TestLicensePolicyInvalidFamily1(t *testing.T) {
 	value := "CONFLICT"
@@ -140,64 +292,9 @@ func TestLicensePolicyInvalidFamilyKeywords2(t *testing.T) {
 	}
 }
 
-func TestLicensePolicyInvalidFamilyLowerCase2(t *testing.T) {
-	value := "conflict"
-	if IsValidFamilyKey(value) {
-		t.Errorf("isValidUsagePolicy(): returned: %t; expected: %t", true, false)
-	}
-}
-
-func TestLicensePolicyMatchByIdAllow(t *testing.T) {
-	ID := "Apache-2.0"
-	EXPECTED_POLICY := POLICY_ALLOW
-
-	value, policy := FindPolicyBySpdxId(ID)
-
-	if value != EXPECTED_POLICY {
-		t.Errorf("FindPolicyBySpdxId(): id: %s, returned: %v; expected: %v", ID, value, EXPECTED_POLICY)
-	} else {
-		getLogger().Tracef("FindPolicyBySpdxId(): id: %s (%s), policy: %s\n", ID, policy.Name, value)
-	}
-}
-
-func TestLicensePolicyMatchByIdDeny(t *testing.T) {
-	ID := "CC-BY-NC-1.0"
-	EXPECTED_POLICY := POLICY_DENY
-
-	value, policy := FindPolicyBySpdxId(ID)
-
-	if value != EXPECTED_POLICY {
-		t.Errorf("FindPolicyBySpdxId(): id: %s, returned: %v; expected: %v", ID, value, EXPECTED_POLICY)
-	} else {
-		getLogger().Tracef("FindPolicyBySpdxId(): id: %s (%s), policy: %s\n", ID, policy.Name, value)
-	}
-}
-
-func TestLicensePolicyMatchByIdFailureEmpty(t *testing.T) {
-	ID := ""
-	EXPECTED_POLICY := POLICY_UNDEFINED
-
-	value, policy := FindPolicyBySpdxId(ID)
-
-	if value != EXPECTED_POLICY {
-		t.Errorf("FindPolicyBySpdxId(): id: %s, returned: %v; expected: %v", ID, value, EXPECTED_POLICY)
-	} else {
-		getLogger().Tracef("FindPolicyBySpdxId(): id: %s (%s), policy: %s\n", ID, policy.Name, value)
-	}
-}
-
-func TestLicensePolicyMatchByIdFailureFoo(t *testing.T) {
-	ID := "Foo"
-	EXPECTED_POLICY := POLICY_UNDEFINED
-
-	value, policy := FindPolicyBySpdxId(ID)
-
-	if value != EXPECTED_POLICY {
-		t.Errorf("FindPolicyBySpdxId(): id: %s, returned: %v; expected: %v", ID, value, EXPECTED_POLICY)
-	} else {
-		getLogger().Tracef("FindPolicyBySpdxId(): id: %s (%s), policy: %s\n", ID, policy.Name, value)
-	}
-}
+//------------------------------------------------
+// Policy Expression: parser & usage policy tests
+//------------------------------------------------
 
 func TestLicensePolicyMatchByExpFailureInvalidRightExp(t *testing.T) {
 
@@ -241,62 +338,11 @@ func TestLicensePolicyMatchByExpFailureInvalidLeftExp(t *testing.T) {
 	}
 }
 
-func TestLicensePolicyList(t *testing.T) {
-	// Reset the license (policy) configuration to our test file and load it
-	licensePolicyConfig = new(LicenseComplianceConfig)
-	errPolicies := licensePolicyConfig.LoadLicensePolicies(POLICY_FILE_GOOD_BAD_MAYBE)
-	if errPolicies != nil {
-		t.Errorf(errPolicies.Error())
-	}
-
-	// Declare an output outputBuffer/outputWriter to use used during tests
-	var outputBuffer bytes.Buffer
-	var outputWriter = bufio.NewWriter(&outputBuffer)
-
-	// Test the actual list function
-	errDisplay := DisplayLicensePoliciesTabbedText(outputWriter)
-	if errDisplay != nil {
-		t.Errorf(errDisplay.Error())
-	}
-
-	// The list routine uses other "writers" and flushes them
-	// we must flush our "backing" writer (in this case to our byte buffer)
-	// BEFORE testing the buffer contents
-	outputWriter.Flush()
-
-	// verify entries (by default sorted by license family name) are correct
-	listing := outputBuffer.String()
-	values := strings.Split(listing, "\n")
-
-	// Skip over list entries titles and separator rows in
-	// TODO: actually test all titles are present (in a dyn. loop)
-	if value := values[0]; !strings.Contains(value, POLICY_LIST_TITLES[0]) {
-		t.Errorf("DisplayLicensePolicies(): returned entry: %s; expected it to contain: `%s`", value, POLICY_LIST_TITLES[0])
-	}
-
-	if value := values[1]; !strings.Contains(value, REPORT_LIST_TITLE_ROW_SEPARATOR) {
-		t.Errorf("DisplayLicensePolicies(): returned entry: %s; expected it to contain: `%s`", value, REPORT_LIST_TITLE_ROW_SEPARATOR)
-	}
-
-	// validate policy rows listing (i.e., indexes 0 and 1)
-	if value := values[2]; !strings.Contains(value, LICENSE_ID_BAD) || !strings.Contains(value, POLICY_DENY) {
-		t.Errorf("DisplayLicensePolicies(): returned entry: %s; expected ID and policy: `%s`, `%s`", value, LICENSE_ID_BAD, POLICY_DENY)
-	}
-	if value := values[3]; !strings.Contains(value, LICENSE_ID_GOOD) || !strings.Contains(value, POLICY_ALLOW) {
-		t.Errorf("DisplayLicensePolicies(): returned entry: %s; expected ID and policy: `%s`, `%s`", value, LICENSE_ID_GOOD, POLICY_ALLOW)
-	}
-	if value := values[4]; !strings.Contains(value, LICENSE_ID_MAYBE) || !strings.Contains(value, POLICY_NEEDS_REVIEW) {
-		t.Errorf("DisplayLicensePolicies(): returned entry: %s; expected ID and policy: `%s`, `%s`", value, LICENSE_ID_MAYBE, POLICY_NEEDS_REVIEW)
-	}
-
-	// !!! IMPORTANT !!!!
-	// Reset the license (policy) to default file (or other tests in package will fail)
-	licensePolicyConfig = new(LicenseComplianceConfig)
-	errPolicies = licensePolicyConfig.LoadLicensePolicies(DEFAULT_LICENSE_POLICIES)
-	if errPolicies != nil {
-		t.Errorf(errPolicies.Error())
-	}
-}
+//------------------------------------------------------
+// Policy Expression: test 3-state logic combinations
+// NOTE: uses a custom policy file with min. number
+//       of entries to represent the 3 supported states
+//------------------------------------------------------
 
 // The policy config. has 3 states: { "allow", "deny", "needs-review" }; n=3
 // which are always paired with a conjunctions; r=2
@@ -309,11 +355,10 @@ func TestLicensePolicyList(t *testing.T) {
 // 5. POLICY_NEEDS_REVIEW AND POLICY_NEEDS_REVIEW
 // 6. POLICY_ALLOW AND POLICY_ALLOW
 func TestLicensePolicyUsageConjunctionsANDCombinations(t *testing.T) {
-	// Reset the license (policy) configuration to our test file and load it
-	licensePolicyConfig = new(LicenseComplianceConfig)
-	errPolicies := licensePolicyConfig.LoadLicensePolicies(POLICY_FILE_GOOD_BAD_MAYBE)
-	if errPolicies != nil {
-		t.Errorf(errPolicies.Error())
+	// Set the policy file to the reduced, 3-entry policy file used to test the 3 policy states
+	err := loadHashCustomPolicyFile(POLICY_FILE_GOOD_BAD_MAYBE)
+	if err != nil {
+		t.Errorf(err.Error())
 	}
 
 	// 1. POLICY_DENY AND POLICY_ALLOW
@@ -388,13 +433,8 @@ func TestLicensePolicyUsageConjunctionsANDCombinations(t *testing.T) {
 		t.Errorf("parseExpression(): \"%s\" returned: `%s`; expected: `%s`", EXP, resolvedPolicy, EXPECTED_USAGE_POLICY)
 	}
 
-	// !!! IMPORTANT !!!!
-	// Reset the license (policy) to default file (or other tests in package will fail)
-	licensePolicyConfig = new(LicenseComplianceConfig)
-	errPolicies = licensePolicyConfig.LoadLicensePolicies(DEFAULT_LICENSE_POLICIES)
-	if errPolicies != nil {
-		t.Errorf(errPolicies.Error())
-	}
+	// !!! IMPORTANT !!! restore default policy file to default for all other tests
+	loadHashCustomPolicyFile(utils.GlobalFlags.ConfigLicensePolicyFile)
 }
 
 // The policy config. has 3 states: { "allow", "deny", "needs-review" }; n=3
@@ -408,11 +448,11 @@ func TestLicensePolicyUsageConjunctionsANDCombinations(t *testing.T) {
 // 5. POLICY_NEEDS_REVIEW OR POLICY_NEEDS_REVIEW
 // 6. POLICY_DENY OR POLICY_DENY
 func TestLicensePolicyUsageConjunctionsORCombinations(t *testing.T) {
-	// Reset the license (policy) configuration to our test file and load it
-	licensePolicyConfig = new(LicenseComplianceConfig)
-	errPolicies := licensePolicyConfig.LoadLicensePolicies(POLICY_FILE_GOOD_BAD_MAYBE)
-	if errPolicies != nil {
-		t.Errorf(errPolicies.Error())
+	// Set the policy file to the reduced, 3-entry policy file used to test the 3 policy states
+	err := loadHashCustomPolicyFile(POLICY_FILE_GOOD_BAD_MAYBE)
+
+	if err != nil {
+		t.Errorf(err.Error())
 	}
 
 	// 1. POLICY_ALLOW OR POLICY_DENY
@@ -487,34 +527,144 @@ func TestLicensePolicyUsageConjunctionsORCombinations(t *testing.T) {
 		t.Errorf("parseExpression(): \"%s\" returned: `%s`; expected: `%s`", EXP, resolvedPolicy, EXPECTED_USAGE_POLICY)
 	}
 
-	// !!! IMPORTANT !!!!
-	// Reset the license (policy) to default file (or other tests in package will fail)
-	licensePolicyConfig = new(LicenseComplianceConfig)
-	errPolicies = licensePolicyConfig.LoadLicensePolicies(DEFAULT_LICENSE_POLICIES)
-	if errPolicies != nil {
-		t.Errorf(errPolicies.Error())
+	// !!! IMPORTANT !!! restore default policy file to default for all other tests
+	loadHashCustomPolicyFile(utils.GlobalFlags.ConfigLicensePolicyFile)
+}
+
+//--------------------------------------------------------------
+// Custom policy file tests (i.e., loads non-default policy files)
+//--------------------------------------------------------------
+
+// Use test file "test/policy/license-policy-family-name-usage-conflict.json"
+// TODO: to confirm this conflict is caught at hash time (not load time)
+func TestLicensePolicyFamilyUsagePolicyConflict(t *testing.T) {
+	// Load custom policy file that contains a license usage policy conflict
+	err := loadHashCustomPolicyFile(POLICY_FILE_FAMILY_NAME_USAGE_CONFLICT)
+
+	// Note: the conflict is only encountered on the "hash"; load only loads what policies are defined in the config.
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// !!! IMPORTANT !!! restore default policy file to default for all other tests
+	loadHashCustomPolicyFile(utils.GlobalFlags.ConfigLicensePolicyFile)
+}
+
+func TestLicensePolicyList(t *testing.T) {
+	// Set the license (policy) configuration to our test file and load it
+	err := loadHashCustomPolicyFile(POLICY_FILE_GOOD_BAD_MAYBE)
+
+	// Note: the conflict is only encountered on the "hash"; load only loads what policies are defined in the config.
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// Declare an output outputBuffer/outputWriter to use used during tests
+	var outputBuffer bytes.Buffer
+	var outputWriter = bufio.NewWriter(&outputBuffer)
+
+	// Test the actual list function
+	errDisplay := DisplayLicensePoliciesTabbedText(outputWriter)
+	if errDisplay != nil {
+		t.Errorf(errDisplay.Error())
+	}
+
+	// The list routine uses other "writers" and flushes them
+	// we must flush our "backing" writer (in this case to our byte buffer)
+	// BEFORE testing the buffer contents
+	outputWriter.Flush()
+
+	// verify entries (by default sorted by license family name) are correct
+	listing := outputBuffer.String()
+	values := strings.Split(listing, "\n")
+	fmt.Printf("values: %v", strings.Join(values, "\n"))
+
+	// Skip over list entries titles and separator rows in
+	// TODO: actually test all titles are present (in a dyn. loop)
+	if value := values[0]; !strings.Contains(value, POLICY_LIST_TITLES[0]) {
+		t.Errorf("DisplayLicensePolicies(): returned entry: %s; expected it to contain: `%s`", value, POLICY_LIST_TITLES[0])
+	}
+
+	if value := values[1]; !strings.Contains(value, REPORT_LIST_TITLE_ROW_SEPARATOR) {
+		t.Errorf("DisplayLicensePolicies(): returned entry: %s; expected it to contain: `%s`", value, REPORT_LIST_TITLE_ROW_SEPARATOR)
+	}
+
+	// validate policy rows listing (i.e., indexes 0 and 1)
+	if value := values[2]; !strings.Contains(value, LICENSE_ID_BAD) || !strings.Contains(value, POLICY_DENY) {
+		t.Errorf("DisplayLicensePolicies(): returned entry: %s; expected ID and policy: `%s`, `%s`", value, LICENSE_ID_BAD, POLICY_DENY)
+	}
+	if value := values[3]; !strings.Contains(value, LICENSE_ID_GOOD) || !strings.Contains(value, POLICY_ALLOW) {
+		t.Errorf("DisplayLicensePolicies(): returned entry: %s; expected ID and policy: `%s`, `%s`", value, LICENSE_ID_GOOD, POLICY_ALLOW)
+	}
+	if value := values[4]; !strings.Contains(value, LICENSE_ID_MAYBE) || !strings.Contains(value, POLICY_NEEDS_REVIEW) {
+		t.Errorf("DisplayLicensePolicies(): returned entry: %s; expected ID and policy: `%s`, `%s`", value, LICENSE_ID_MAYBE, POLICY_NEEDS_REVIEW)
+	}
+
+	// !!! IMPORTANT !!! restore default policy file to default for all other tests
+	loadHashCustomPolicyFile(utils.GlobalFlags.ConfigLicensePolicyFile)
+}
+
+//------------------------------------------------------
+// Policy Find: by ID tests
+// - NOTE: uses the default policy file (license.json)
+//------------------------------------------------------
+
+func TestLicensePolicyMatchByIdAllow(t *testing.T) {
+	ID := "Apache-2.0"
+	EXPECTED_POLICY := POLICY_ALLOW
+
+	value, policy := FindPolicyBySpdxId(ID)
+
+	if value != EXPECTED_POLICY {
+		t.Errorf("FindPolicyBySpdxId(): id: %s, returned: %v; expected: %v", ID, value, EXPECTED_POLICY)
+	} else {
+		getLogger().Tracef("FindPolicyBySpdxId(): id: %s (%s), policy: %s\n", ID, policy.Name, value)
 	}
 }
 
-// Use test file "test/policy/license-policy-family-name-usage-conflict.json"
-// TODO: to confirm this conflict is caught at has time AND
-// TODO: to confirm this conflict is caught as part of "license list" command
-func TestLicensePolicyFamilyUsagePolicyConflict(t *testing.T) {
-	// Reset the license (policy) configuration to our test file and load it
-	licensePolicyConfig = new(LicenseComplianceConfig)
-	errPolicies := licensePolicyConfig.LoadLicensePolicies(POLICY_FILE_FAMILY_NAME_USAGE_CONFLICT)
-	// Note: the conflict is only encountered on the "hash"; load only loads what policies are defined in the config.
-	if errPolicies != nil {
-		t.Errorf(errPolicies.Error())
-	}
-	// !!! IMPORTANT !!!!
-	// Reset the license (policy) to default file (or other tests in package will fail)
-	licensePolicyConfig = new(LicenseComplianceConfig)
-	errPolicies = licensePolicyConfig.LoadLicensePolicies(DEFAULT_LICENSE_POLICIES)
-	if errPolicies != nil {
-		t.Errorf(errPolicies.Error())
+func TestLicensePolicyMatchByIdDeny(t *testing.T) {
+	ID := "CC-BY-NC-1.0"
+	EXPECTED_POLICY := POLICY_DENY
+
+	value, policy := FindPolicyBySpdxId(ID)
+
+	if value != EXPECTED_POLICY {
+		t.Errorf("FindPolicyBySpdxId(): id: %s, returned: %v; expected: %v", ID, value, EXPECTED_POLICY)
+	} else {
+		getLogger().Tracef("FindPolicyBySpdxId(): id: %s (%s), policy: %s\n", ID, policy.Name, value)
 	}
 }
+
+func TestLicensePolicyMatchByIdFailureEmpty(t *testing.T) {
+	ID := ""
+	EXPECTED_POLICY := POLICY_UNDEFINED
+
+	value, policy := FindPolicyBySpdxId(ID)
+
+	if value != EXPECTED_POLICY {
+		t.Errorf("FindPolicyBySpdxId(): id: %s, returned: %v; expected: %v", ID, value, EXPECTED_POLICY)
+	} else {
+		getLogger().Tracef("FindPolicyBySpdxId(): id: %s (%s), policy: %s\n", ID, policy.Name, value)
+	}
+}
+
+func TestLicensePolicyMatchByIdFailureFoo(t *testing.T) {
+	ID := "Foo"
+	EXPECTED_POLICY := POLICY_UNDEFINED
+
+	value, policy := FindPolicyBySpdxId(ID)
+
+	if value != EXPECTED_POLICY {
+		t.Errorf("FindPolicyBySpdxId(): id: %s, returned: %v; expected: %v", ID, value, EXPECTED_POLICY)
+	} else {
+		getLogger().Tracef("FindPolicyBySpdxId(): id: %s (%s), policy: %s\n", ID, policy.Name, value)
+	}
+}
+
+//------------------------------------------------------
+// Policy Find: by Family Name tests
+// - NOTE: uses the default policy file (license.json)
+//------------------------------------------------------
 
 func TestLicensePolicyMatchByFamilyNameBadExpression(t *testing.T) {
 	// Assure OR appearance results in UNDEFINED
@@ -553,17 +703,26 @@ func TestLicensePolicyMatchByFamilyNameBadExpression(t *testing.T) {
 	}
 }
 
-func TestLicensePolicyListTextFirstEntry0BSD(t *testing.T) {
-	var buffer bytes.Buffer
-	writer := bufio.NewWriter(&buffer)
-	ListPolicies(writer)
-	VALUES := []string{"0BSD"}
-	LINE := 2
+//---------------------------------------------------------
+// Policy "list" command tests (using default policy file)
+//---------------------------------------------------------
 
-	i, contains := lineContainsValues(buffer, LINE, VALUES...)
-	if !contains {
-		t.Errorf("policy file does not contain expected values: %v", VALUES)
-	} else {
-		getLogger().Tracef("policy file contains values: %v on line: %v\n", VALUES, i)
-	}
+func TestLicensePolicyListTextNoWrap(t *testing.T) {
+	lti := NewLicensePolicyTestInfoBasic(FORMAT_TEXT, true)
+	lti.ResultExpectedLineCount = 250 // title and data rows
+	innerTestLicensePolicyList(t, lti)
+}
+
+func TestLicensePolicyListTextWrap(t *testing.T) {
+	lti := NewLicensePolicyTestInfoBasic(FORMAT_TEXT, true)
+	lti.ResultExpectedLineCount = 402 // title and data rows
+	utils.GlobalFlags.LicenseFlags.ListLineWrap = true
+	innerTestLicensePolicyList(t, lti)
+}
+
+func TestLicensePolicyListTextFirstEntry0BSD(t *testing.T) {
+	lti := NewLicensePolicyTestInfoBasic(FORMAT_TEXT, true)
+	lti.ResultExpectedAtLineNum = 2
+	lti.ResultContainsValues = []string{"0BSD"}
+	innerTestLicensePolicyList(t, lti)
 }

--- a/cmd/license_policy_test.go
+++ b/cmd/license_policy_test.go
@@ -552,8 +552,7 @@ func TestLicensePolicyFamilyUsagePolicyConflict(t *testing.T) {
 	loadHashCustomPolicyFile(utils.GlobalFlags.ConfigLicensePolicyFile)
 }
 
-func TestLicensePolicyList(t *testing.T) {
-
+func TestLicensePolicyListGoodBadMaybe(t *testing.T) {
 	lti := NewLicensePolicyTestInfoBasic(FORMAT_TEXT, true)
 	lti.PolicyFile = POLICY_FILE_GOOD_BAD_MAYBE
 	// Assure all titles appear in output
@@ -715,10 +714,23 @@ func TestLicensePolicyMatchByFamilyNameBadExpression(t *testing.T) {
 // Policy "list" command tests (using default policy file)
 //---------------------------------------------------------
 
+func TestLicensePolicyListTextBasic(t *testing.T) {
+	lti := NewLicensePolicyTestInfoBasic(FORMAT_TEXT, false)
+	lti.WhereClause = "id=0B"
+	lti.ResultExpectedLineCount = 3
+	innerTestLicensePolicyList(t, lti)
+}
+
 func TestLicensePolicyListTextNoWrap(t *testing.T) {
 	lti := NewLicensePolicyTestInfoBasic(FORMAT_TEXT, true)
 	lti.ResultExpectedLineCount = 250 // title and data rows
 	innerTestLicensePolicyList(t, lti)
+
+	// Verify first data row has expected values
+	lti.ResultExpectedAtLineNum = 2
+	lti.ResultContainsValues = []string{"0BSD", POLICY_ALLOW}
+
+	// TODO spot check MORE row values
 }
 
 func TestLicensePolicyListTextWrap(t *testing.T) {
@@ -726,11 +738,36 @@ func TestLicensePolicyListTextWrap(t *testing.T) {
 	lti.ResultExpectedLineCount = 402 // title and data rows
 	utils.GlobalFlags.LicenseFlags.ListLineWrap = true
 	innerTestLicensePolicyList(t, lti)
+	// TODO spot check row values
 }
 
-func TestLicensePolicyListTextFirstEntry0BSD(t *testing.T) {
+func TestLicensePolicyListWhereUsagePolicyDeny(t *testing.T) {
 	lti := NewLicensePolicyTestInfoBasic(FORMAT_TEXT, true)
-	lti.ResultExpectedAtLineNum = 2
-	lti.ResultContainsValues = []string{"0BSD"}
+	lti.WhereClause = "usage-policy=deny"
+	lti.ResultExpectedLineCount = 5
+	innerTestLicensePolicyList(t, lti)
+}
+
+func TestLicensePolicyListWhereTestUsagePolicyAllow(t *testing.T) {
+	lti := NewLicensePolicyTestInfoBasic(FORMAT_TEXT, true)
+	lti.PolicyFile = POLICY_FILE_GOOD_BAD_MAYBE
+	lti.WhereClause = "usage-policy=allow"
+	lti.ResultExpectedLineCount = 3
+	innerTestLicensePolicyList(t, lti)
+}
+
+func TestLicensePolicyListWhereTestUsagePolicyDeny(t *testing.T) {
+	lti := NewLicensePolicyTestInfoBasic(FORMAT_TEXT, true)
+	lti.PolicyFile = POLICY_FILE_GOOD_BAD_MAYBE
+	lti.WhereClause = "usage-policy=deny"
+	lti.ResultExpectedLineCount = 3
+	innerTestLicensePolicyList(t, lti)
+}
+
+func TestLicensePolicyListWhereTestUsagePolicyNeedsReview(t *testing.T) {
+	lti := NewLicensePolicyTestInfoBasic(FORMAT_TEXT, true)
+	lti.PolicyFile = POLICY_FILE_GOOD_BAD_MAYBE
+	lti.WhereClause = "usage-policy=needs-review"
+	lti.ResultExpectedLineCount = 3
 	innerTestLicensePolicyList(t, lti)
 }

--- a/cmd/license_policy_test.go
+++ b/cmd/license_policy_test.go
@@ -156,7 +156,7 @@ func TestLicensePolicyMatchByIdAllow(t *testing.T) {
 	if value != EXPECTED_POLICY {
 		t.Errorf("FindPolicyBySpdxId(): id: %s, returned: %v; expected: %v", ID, value, EXPECTED_POLICY)
 	} else {
-		getLogger().Tracef("FindPolicyBySpdxId(): id: %s (%s), policy: %s, ", ID, policy.Name, value)
+		getLogger().Tracef("FindPolicyBySpdxId(): id: %s (%s), policy: %s\n", ID, policy.Name, value)
 	}
 }
 
@@ -169,7 +169,7 @@ func TestLicensePolicyMatchByIdDeny(t *testing.T) {
 	if value != EXPECTED_POLICY {
 		t.Errorf("FindPolicyBySpdxId(): id: %s, returned: %v; expected: %v", ID, value, EXPECTED_POLICY)
 	} else {
-		getLogger().Tracef("FindPolicyBySpdxId(): id: %s (%s), policy: %s, ", ID, policy.Name, value)
+		getLogger().Tracef("FindPolicyBySpdxId(): id: %s (%s), policy: %s\n", ID, policy.Name, value)
 	}
 }
 
@@ -182,7 +182,7 @@ func TestLicensePolicyMatchByIdFailureEmpty(t *testing.T) {
 	if value != EXPECTED_POLICY {
 		t.Errorf("FindPolicyBySpdxId(): id: %s, returned: %v; expected: %v", ID, value, EXPECTED_POLICY)
 	} else {
-		getLogger().Tracef("FindPolicyBySpdxId(): id: %s (%s), policy: %s, ", ID, policy.Name, value)
+		getLogger().Tracef("FindPolicyBySpdxId(): id: %s (%s), policy: %s\n", ID, policy.Name, value)
 	}
 }
 
@@ -195,7 +195,7 @@ func TestLicensePolicyMatchByIdFailureFoo(t *testing.T) {
 	if value != EXPECTED_POLICY {
 		t.Errorf("FindPolicyBySpdxId(): id: %s, returned: %v; expected: %v", ID, value, EXPECTED_POLICY)
 	} else {
-		getLogger().Tracef("FindPolicyBySpdxId(): id: %s (%s), policy: %s, ", ID, policy.Name, value)
+		getLogger().Tracef("FindPolicyBySpdxId(): id: %s (%s), policy: %s\n", ID, policy.Name, value)
 	}
 }
 
@@ -216,7 +216,7 @@ func TestLicensePolicyMatchByExpFailureInvalidRightExp(t *testing.T) {
 	if resolvedPolicy != EXPECTED_POLICY {
 		t.Errorf("FindPolicyBySpdxId(): expression: %s, returned: %v; expected: %v", EXP, resolvedPolicy, EXPECTED_POLICY)
 	} else {
-		getLogger().Tracef("FindPolicyBySpdxId(): id: %s, policy: %s, ", EXP, resolvedPolicy)
+		getLogger().Tracef("FindPolicyBySpdxId(): id: %s, policy: %s\n", EXP, resolvedPolicy)
 	}
 }
 
@@ -237,7 +237,7 @@ func TestLicensePolicyMatchByExpFailureInvalidLeftExp(t *testing.T) {
 	if resolvedPolicy != EXPECTED_POLICY {
 		t.Errorf("FindPolicyBySpdxId(): expression: %s, returned: %v; expected: %v", EXP, resolvedPolicy, EXPECTED_POLICY)
 	} else {
-		getLogger().Tracef("FindPolicyBySpdxId(): id: %s, policy: %s, ", EXP, resolvedPolicy)
+		getLogger().Tracef("FindPolicyBySpdxId(): id: %s, policy: %s\n", EXP, resolvedPolicy)
 	}
 }
 
@@ -527,7 +527,7 @@ func TestLicensePolicyMatchByFamilyNameBadExpression(t *testing.T) {
 	if value != EXPECTED_POLICY {
 		t.Errorf("FindPolicyByFamilyName(): contains expression: %s, returned: %v; expected: %v", NAME, value, EXPECTED_POLICY)
 	} else {
-		getLogger().Tracef("FindPolicyByFamilyName(): contains expression: %s, policy: %s, ", NAME, value)
+		getLogger().Tracef("FindPolicyByFamilyName(): contains expression: %s, policy: %s\n", NAME, value)
 	}
 
 	// Assure AND appearance results in UNDEFINED
@@ -538,7 +538,7 @@ func TestLicensePolicyMatchByFamilyNameBadExpression(t *testing.T) {
 	if value != EXPECTED_POLICY {
 		t.Errorf("FindPolicyByFamilyName(): contains expression: %s, returned: %v; expected: %v", NAME, value, EXPECTED_POLICY)
 	} else {
-		getLogger().Tracef("FindPolicyByFamilyName(): contains expression: %s, policy: %s, ", NAME, value)
+		getLogger().Tracef("FindPolicyByFamilyName(): contains expression: %s, policy: %s\n", NAME, value)
 	}
 
 	// Assure WITH appearance results in UNDEFINED
@@ -549,7 +549,7 @@ func TestLicensePolicyMatchByFamilyNameBadExpression(t *testing.T) {
 	if value != EXPECTED_POLICY {
 		t.Errorf("FindPolicyByFamilyName(): contains expression: %s, returned: %v; expected: %v", NAME, value, EXPECTED_POLICY)
 	} else {
-		getLogger().Tracef("FindPolicyByFamilyName(): contains expression: %s, policy: %s, ", NAME, value)
+		getLogger().Tracef("FindPolicyByFamilyName(): contains expression: %s, policy: %s\n", NAME, value)
 	}
 }
 
@@ -557,4 +557,13 @@ func TestLicensePolicyListText(t *testing.T) {
 	var buffer bytes.Buffer
 	writer := bufio.NewWriter(&buffer)
 	ListPolicies(writer)
+	VALUES := []string{"0BSD"}
+	LINE := 2
+
+	i, contains := lineContainsValues(buffer, LINE, VALUES...)
+	if !contains {
+		t.Errorf("policy file does not contain expected values: %v", VALUES)
+	} else {
+		getLogger().Tracef("policy file contains values: %v on line: %v\n", VALUES, i)
+	}
 }

--- a/cmd/license_policy_test.go
+++ b/cmd/license_policy_test.go
@@ -34,8 +34,8 @@ const (
 // Alternative license policy files for testing
 const (
 	POLICY_FILE_GOOD_BAD_MAYBE = "test/policy/license-policy-license-expression-test-data.json"
-	// TODO: to confirm this conflict is caught at has time AND
-	// TODO: to confirm this conflict is caught as part of "license list" command
+	// TODO: to confirm this conflict is caught as part of "license policy" command
+	// TODO: to confirm this conflict is caught as part of "license list" command (with AND/OR as well)
 	POLICY_FILE_FAMILY_NAME_USAGE_CONFLICT = "test/policy/license-policy-family-name-usage-conflict.json"
 )
 

--- a/cmd/license_policy_test.go
+++ b/cmd/license_policy_test.go
@@ -20,7 +20,6 @@ package cmd
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -577,7 +576,8 @@ func TestLicensePolicyList(t *testing.T) {
 	// verify entries (by default sorted by license family name) are correct
 	listing := outputBuffer.String()
 	values := strings.Split(listing, "\n")
-	fmt.Printf("values: %v", strings.Join(values, "\n"))
+	// Debug list output:
+	// getLogger().Debugf("values: %v", strings.Join(values, "\n"))
 
 	// Skip over list entries titles and separator rows in
 	// TODO: actually test all titles are present (in a dyn. loop)

--- a/cmd/license_policy_test.go
+++ b/cmd/license_policy_test.go
@@ -771,3 +771,19 @@ func TestLicensePolicyListWhereTestUsagePolicyNeedsReview(t *testing.T) {
 	lti.ResultExpectedLineCount = 3
 	innerTestLicensePolicyList(t, lti)
 }
+
+func TestLicensePolicyListCSVWhereTestUsagePolicyAllow(t *testing.T) {
+	lti := NewLicensePolicyTestInfoBasic(FORMAT_CSV, true)
+	lti.PolicyFile = POLICY_FILE_GOOD_BAD_MAYBE
+	lti.WhereClause = "usage-policy=allow"
+	lti.ResultExpectedLineCount = 2
+	innerTestLicensePolicyList(t, lti)
+}
+
+func TestLicensePolicyListMarkdownWhereTestUsagePolicyAllow(t *testing.T) {
+	lti := NewLicensePolicyTestInfoBasic(FORMAT_MARKDOWN, true)
+	lti.PolicyFile = POLICY_FILE_GOOD_BAD_MAYBE
+	lti.WhereClause = "usage-policy=allow"
+	lti.ResultExpectedLineCount = 3
+	innerTestLicensePolicyList(t, lti)
+}

--- a/cmd/license_policy_test.go
+++ b/cmd/license_policy_test.go
@@ -270,8 +270,8 @@ func TestLicensePolicyList(t *testing.T) {
 
 	// Skip over list entries titles and separator rows in
 	// TODO: actually test all titles are present (in a dyn. loop)
-	if value := values[0]; !strings.Contains(value, LICENSE_POLICY_SUMMARY_TITLES[0]) {
-		t.Errorf("DisplayLicensePolicies(): returned entry: %s; expected it to contain: `%s`", value, LICENSE_POLICY_SUMMARY_TITLES[0])
+	if value := values[0]; !strings.Contains(value, POLICY_LIST_TITLES[0]) {
+		t.Errorf("DisplayLicensePolicies(): returned entry: %s; expected it to contain: `%s`", value, POLICY_LIST_TITLES[0])
 	}
 
 	if value := values[1]; !strings.Contains(value, REPORT_LIST_TITLE_ROW_SEPARATOR) {
@@ -551,4 +551,10 @@ func TestLicensePolicyMatchByFamilyNameBadExpression(t *testing.T) {
 	} else {
 		getLogger().Tracef("FindPolicyByFamilyName(): contains expression: %s, policy: %s, ", NAME, value)
 	}
+}
+
+func TestLicensePolicyListText(t *testing.T) {
+	var buffer bytes.Buffer
+	writer := bufio.NewWriter(&buffer)
+	ListPolicies(writer)
 }

--- a/cmd/license_test.go
+++ b/cmd/license_test.go
@@ -49,14 +49,16 @@ const (
 )
 
 type LicenseTestInfo struct {
-	InputFile       string
-	Format          string
-	WhereClause     string
-	ExpectedError   error
-	ResultContains  string
-	ResultLineCount int
-	Summary         bool
-	ValidateJson    bool
+	InputFile               string
+	Format                  string
+	WhereClause             string
+	ExpectedError           error
+	ResultContainsValues    []string
+	ResultContainsValue     string
+	ResultExpectedAtLineNum int
+	ResultExpectedLineCount int
+	Summary                 bool
+	ValidateJson            bool
 }
 
 // Stringer interface for ResourceTestInfo (just display subset of key values)
@@ -72,8 +74,8 @@ func NewLicenseTestInfo(inputFile string, format string, whereClause string, sum
 	lti.InputFile = inputFile
 	lti.Format = format
 	lti.WhereClause = whereClause
-	lti.ResultContains = resultContains
-	lti.ResultLineCount = resultLines
+	lti.ResultContainsValue = resultContains
+	lti.ResultExpectedLineCount = resultLines
 	lti.ExpectedError = expectedError
 	lti.Summary = summary
 	lti.ValidateJson = validateJson
@@ -138,12 +140,12 @@ func innerTestLicenseList(t *testing.T, testInfo *LicenseTestInfo) (outputBuffer
 	// TEST: Output contains string(s)
 	// TODO: Support []string
 	var outputResults string
-	if testInfo.ResultContains != "" {
+	if testInfo.ResultContainsValue != "" {
 		outputResults = outputBuffer.String()
 		getLogger().Debugf("output: \"%s\"", outputResults)
 
-		if !strings.Contains(outputResults, testInfo.ResultContains) {
-			err = getLogger().Errorf("output did not contain expected value: `%s`", testInfo.ResultContains)
+		if !strings.Contains(outputResults, testInfo.ResultContainsValue) {
+			err = getLogger().Errorf("output did not contain expected value: `%s`", testInfo.ResultContainsValue)
 			t.Errorf("%s: input file: `%s`, where clause: `%s`",
 				err.Error(),
 				testInfo.InputFile,
@@ -153,13 +155,13 @@ func innerTestLicenseList(t *testing.T, testInfo *LicenseTestInfo) (outputBuffer
 	}
 
 	// TEST: Line Count
-	if testInfo.ResultLineCount != LTI_DEFAULT_LINE_COUNT {
+	if testInfo.ResultExpectedLineCount != LTI_DEFAULT_LINE_COUNT {
 		if outputResults == "" {
 			outputResults = outputBuffer.String()
 		}
 		outputLineCount := strings.Count(outputResults, "\n")
-		if outputLineCount != testInfo.ResultLineCount {
-			err = getLogger().Errorf("output did not contain expected line count: %v/%v (expected/actual)", testInfo.ResultLineCount, outputLineCount)
+		if outputLineCount != testInfo.ResultExpectedLineCount {
+			err = getLogger().Errorf("output did not contain expected line count: %v/%v (expected/actual)", testInfo.ResultExpectedLineCount, outputLineCount)
 			t.Errorf("%s: input file: `%s`, where clause: `%s`: \n%s",
 				err.Error(),
 				testInfo.InputFile,
@@ -294,46 +296,46 @@ func TestLicenseListFormatUnsupportedSPDX2(t *testing.T) {
 func TestLicenseListCdx13JsonNoneFound(t *testing.T) {
 	// Test CDX 1.3 document
 	lti := NewLicenseTestInfoBasic(TEST_LICENSE_LIST_CDX_1_3_NONE_FOUND, FORMAT_JSON, false)
-	lti.ResultLineCount = 1 // null (valid json)
+	lti.ResultExpectedLineCount = 1 // null (valid json)
 	innerTestLicenseList(t, lti)
 }
 func TestLicenseListCdx14JsonNoneFound(t *testing.T) {
 	lti := NewLicenseTestInfoBasic(TEST_LICENSE_LIST_CDX_1_4_NONE_FOUND, FORMAT_JSON, false)
-	lti.ResultLineCount = 1 // null (valid json)
+	lti.ResultExpectedLineCount = 1 // null (valid json)
 	innerTestLicenseList(t, lti)
 }
 
 func TestLicenseListCdx13CsvNoneFound(t *testing.T) {
 	// Test CDX 1.3 document
 	lti := NewLicenseTestInfoBasic(TEST_LICENSE_LIST_CDX_1_3_NONE_FOUND, FORMAT_CSV, false)
-	lti.ResultLineCount = 1 // title only
+	lti.ResultExpectedLineCount = 1 // title only
 	innerTestLicenseList(t, lti)
 }
 
 func TestLicenseListCdx14CsvNoneFound(t *testing.T) {
 	// Test CDX 1.4 document
 	lti := NewLicenseTestInfoBasic(TEST_LICENSE_LIST_CDX_1_4_NONE_FOUND, FORMAT_CSV, false)
-	lti.ResultLineCount = 1 // title only
+	lti.ResultExpectedLineCount = 1 // title only
 	innerTestLicenseList(t, lti)
 }
 
 func TestLicenseListCdx13MarkdownNoneFound(t *testing.T) {
 	// Test CDX 1.3 document
 	lti := NewLicenseTestInfoBasic(TEST_LICENSE_LIST_CDX_1_3_NONE_FOUND, FORMAT_MARKDOWN, false)
-	lti.ResultLineCount = 2 // title and separator rows
+	lti.ResultExpectedLineCount = 2 // title and separator rows
 	innerTestLicenseList(t, lti)
 }
 
 func TestLicenseListCdx14MarkdownNoneFound(t *testing.T) {
 	// Test CDX 1.4 document
 	lti := NewLicenseTestInfoBasic(TEST_LICENSE_LIST_CDX_1_4_NONE_FOUND, FORMAT_MARKDOWN, false)
-	lti.ResultLineCount = 2 // title and separator rows
+	lti.ResultExpectedLineCount = 2 // title and separator rows
 	innerTestLicenseList(t, lti)
 }
 
 func TestLicenseListCdx13Json(t *testing.T) {
 	lti := NewLicenseTestInfoBasic(TEST_LICENSE_LIST_CDX_1_3, FORMAT_JSON, false)
-	lti.ResultLineCount = 210 // array of LicenseChoice JSON objects
+	lti.ResultExpectedLineCount = 210 // array of LicenseChoice JSON objects
 	innerTestLicenseList(t, lti)
 }
 
@@ -344,27 +346,27 @@ func TestLicenseListCdx13Json(t *testing.T) {
 // Assure listing (report) works with summary flag (i.e., format: "txt")
 func TestLicenseListSummaryCdx13Text(t *testing.T) {
 	lti := NewLicenseTestInfoBasic(TEST_LICENSE_LIST_CDX_1_3, FORMAT_TEXT, true)
-	lti.ResultLineCount = 20 // title, separator and data rows
+	lti.ResultExpectedLineCount = 20 // title, separator and data rows
 	innerTestLicenseList(t, lti)
 }
 
 func TestLicenseListSummaryCdx13Markdown(t *testing.T) {
 	lti := NewLicenseTestInfoBasic(TEST_LICENSE_LIST_CDX_1_3, FORMAT_MARKDOWN, true)
-	lti.ResultLineCount = 20 // title, separator and data rows
+	lti.ResultExpectedLineCount = 20 // title, separator and data rows
 	innerTestLicenseList(t, lti)
 }
 
 func TestLicenseListSummaryCdx13Csv(t *testing.T) {
 	lti := NewLicenseTestInfoBasic(TEST_LICENSE_LIST_CDX_1_3, FORMAT_CSV, true)
-	lti.ResultLineCount = 19 // title and data rows
+	lti.ResultExpectedLineCount = 19 // title and data rows
 	innerTestLicenseList(t, lti)
 }
 
 func TestLicenseListTextSummaryCdx14ContainsUndefined(t *testing.T) {
 
 	lti := NewLicenseTestInfoBasic(TEST_LICENSE_LIST_CDX_1_4_NONE_FOUND, FORMAT_DEFAULT, true)
-	lti.ResultContains = POLICY_UNDEFINED
-	lti.ResultLineCount = 4 // 2 title, 2 with UNDEFINED
+	lti.ResultContainsValue = POLICY_UNDEFINED
+	lti.ResultExpectedLineCount = 4 // 2 title, 2 with UNDEFINED
 	innerTestLicenseList(t, lti)
 }
 
@@ -404,21 +406,21 @@ func TestLicenseListPolicyCdx14InvalidLicenseName(t *testing.T) {
 func TestLicenseListSummaryTextCdx13WhereUsageNeedsReview(t *testing.T) {
 	lti := NewLicenseTestInfoBasic(TEST_LICENSE_LIST_CDX_1_3, FORMAT_TEXT, true)
 	lti.WhereClause = "usage-policy=needs-review"
-	lti.ResultLineCount = 8 // title and data rows
+	lti.ResultExpectedLineCount = 8 // title and data rows
 	innerTestLicenseList(t, lti)
 }
 
 func TestLicenseListSummaryTextCdx13WhereUsageUndefined(t *testing.T) {
 	lti := NewLicenseTestInfoBasic(TEST_LICENSE_LIST_CDX_1_3, FORMAT_TEXT, true)
 	lti.WhereClause = "usage-policy=UNDEFINED"
-	lti.ResultLineCount = 4 // title and data rows
+	lti.ResultExpectedLineCount = 4 // title and data rows
 	innerTestLicenseList(t, lti)
 }
 
 func TestLicenseListSummaryTextCdx13WhereLicenseTypeName(t *testing.T) {
 	lti := NewLicenseTestInfoBasic(TEST_LICENSE_LIST_CDX_1_3, FORMAT_TEXT, true)
 	lti.WhereClause = "license-type=name"
-	lti.ResultLineCount = 8 // title and data rows
+	lti.ResultExpectedLineCount = 8 // title and data rows
 	innerTestLicenseList(t, lti)
 }
 

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -558,7 +558,7 @@ func whereFilterMatch(mapObject map[string]interface{}, whereFilters []WhereFilt
 
 		key = filter.key
 		value, present := mapObject[key]
-		getLogger().Tracef("testing object map[%s]: `%v`", key, value)
+		getLogger().Debugf("testing object map[%s]: `%v`", key, value)
 
 		if !present {
 			match = false

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -18,6 +18,7 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -50,6 +51,18 @@ const (
 	MD_ALIGN_CENTER     = "-:-"
 	MD_ALIGN_RIGHT      = "--:"
 )
+
+// Helper function in case displayed table columns become too wide
+func truncateString(value string, maxLength int, showDetail bool) string {
+	length := len(value)
+	if length > maxLength {
+		value = value[:maxLength]
+		if showDetail {
+			value = fmt.Sprintf("%s (%v/%v)", value, maxLength, length)
+		}
+	}
+	return value
+}
 
 func createMarkdownColumnAlignment(titles []string) (alignment []string) {
 	for range titles {

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -155,9 +155,10 @@ func retrieveWhereFilters(whereValues string) (whereFilters []WhereFilter, err e
 func wrapTableRowText(maxChars int, joinChar string, columns ...interface{}) (tableData [][]string, err error) {
 
 	// Assure separator char is set and ONLY a single character
-	if joinChar == "" || len(joinChar) > 1 {
-		joinChar = ","
-	}
+	// TODO
+	// if joinChar == "" || len(joinChar) > 1 {
+	// 	joinChar = ","
+	// }
 
 	// calculate column dimension needed as max of slice sizes
 	numColumns := len(columns)

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -18,6 +18,7 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -62,6 +63,38 @@ func truncateString(value string, maxLength int, showDetail bool) string {
 		}
 	}
 	return value
+}
+
+const REPORT_LINE_CONTAINS_ANY = -1
+
+func lineContainsValues(buffer bytes.Buffer, lineNum int, values ...string) (int, bool) {
+	lines := strings.Split(buffer.String(), "\n")
+	getLogger().Tracef("output: %s", lines)
+	//var lineContainsValue bool = false
+
+	for curLineNum, line := range lines {
+
+		// if ths is a line we need to test
+		if lineNum == REPORT_LINE_CONTAINS_ANY || curLineNum == lineNum {
+			// test that all values occur in the current line
+			for iValue, value := range values {
+				if !strings.Contains(line, value) {
+					// if we failed to match all values on the specified line return failure
+					if curLineNum == lineNum {
+						return curLineNum, false
+					}
+					// else, keep checking next line
+					break
+				}
+
+				// If this is the last value to test for, then all values have matched
+				if iValue+1 == len(values) {
+					return curLineNum, true
+				}
+			}
+		}
+	}
+	return REPORT_LINE_CONTAINS_ANY, false
 }
 
 func createMarkdownColumnAlignment(titles []string) (alignment []string) {

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -38,13 +38,22 @@ const (
 
 var VALID_SUBCOMMANDS_RESOURCE = []string{SUBCOMMAND_RESOURCE_LIST}
 
-var RESOURCE_LIST_TITLES = []string{
+// filter keys
+const (
+	RESOURCE_FILTER_KEY_TYPE    = "type"
+	RESOURCE_FILTER_KEY_NAME    = "name"
+	RESOURCE_FILTER_KEY_VERSION = "version"
+	RESOURCE_FILTER_KEY_BOMREF  = "bom-ref"
+)
+
+var VALID_RESOURCE_FILTER_KEYS = []string{
 	RESOURCE_FILTER_KEY_TYPE,
 	RESOURCE_FILTER_KEY_NAME,
 	RESOURCE_FILTER_KEY_VERSION,
 	RESOURCE_FILTER_KEY_BOMREF,
 }
-var VALID_RESOURCE_WHERE_FILTER_KEYS = []string{
+
+var RESOURCE_LIST_TITLES = []string{
 	RESOURCE_FILTER_KEY_TYPE,
 	RESOURCE_FILTER_KEY_NAME,
 	RESOURCE_FILTER_KEY_VERSION,
@@ -55,6 +64,10 @@ var VALID_RESOURCE_WHERE_FILTER_KEYS = []string{
 const (
 	FLAG_RESOURCE_TYPE      = "type"
 	FLAG_RESOURCE_TYPE_HELP = "filter output by resource type (i.e., component | service"
+)
+
+const (
+	MSG_OUTPUT_NO_RESOURCES_FOUND = "[WARN] no matching resources found for query"
 )
 
 // Command help formatting
@@ -73,21 +86,6 @@ const (
 )
 
 var VALID_RESOURCE_TYPES = []string{RESOURCE_TYPE_DEFAULT, RESOURCE_TYPE_COMPONENT, RESOURCE_TYPE_SERVICE}
-
-// filter keys
-const (
-	RESOURCE_FILTER_KEY_TYPE    = "type"
-	RESOURCE_FILTER_KEY_NAME    = "name"
-	RESOURCE_FILTER_KEY_VERSION = "version"
-	RESOURCE_FILTER_KEY_BOMREF  = "bom-ref"
-)
-
-var VALID_RESOURCE_FILTER_KEYS = []string{
-	RESOURCE_FILTER_KEY_TYPE,
-	RESOURCE_FILTER_KEY_NAME,
-	RESOURCE_FILTER_KEY_VERSION,
-	RESOURCE_FILTER_KEY_BOMREF,
-}
 
 // TODO: need to strip `-` from `bom-ref` for where filter
 type ResourceInfo struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -296,13 +296,3 @@ func createOutputFile(outputFilename string) (outputFile *os.File, writer io.Wri
 	}
 	return
 }
-
-// TODO: Move to use new experimental Go 1.18 experimental package slices which uses generics
-// func sliceContains(slice []string, value string) bool {
-// 	for _, candidate := range slice {
-// 		if value == candidate {
-// 			return true
-// 		}
-// 	}
-// 	return false
-// }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,7 +51,7 @@ const (
 	CMD_USAGE_VALIDATE           = CMD_VALIDATE + " -i input_file" + " [--variant variant_name]" + " [ --force schema_file]"
 	CMD_USAGE_QUERY              = CMD_QUERY + " -i input_filename [--select * | field1[,fieldN]] [--from [key1[.keyN]] [--where key=regex[,...]]"
 	CMD_USAGE_LICENSE_LIST       = SUBCOMMAND_LICENSE_LIST + " -i input_file [[--summary] [--format json|txt|csv|md]"
-	CMD_USAGE_LICENSE_POLICY     = SUBCOMMAND_LICENSE_POLICY + " -i input_file [--format json|txt|csv|md]"
+	CMD_USAGE_LICENSE_POLICY     = SUBCOMMAND_LICENSE_POLICY + " [--format json|txt|csv|md] [-wrap=true|false]"
 	CMD_USAGE_RESOURCE_LIST      = CMD_RESOURCE + " -i input_file [--type component|service] [--where key=regex[,...]] [--format json|txt|csv|md] [-o output_filename]"
 	CMD_USAGE_SCHEMA_LIST        = CMD_SCHEMA + " [--format txt|csv|md]"
 	CMD_USAGE_VULNERABILITY_LIST = CMD_VULNERABILITY + " " + SUBCOMMAND_VULNERABILITY_LIST + " -i input_file [--format json|txt|csv|md]"

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -34,6 +34,10 @@ const (
 	SUBCOMMAND_SCHEMA_LIST = "list"
 )
 
+const (
+	MSG_OUTPUT_NO_SCHEMAS_FOUND = "[WARN] no schemas found in configuration (i.e., \"config.json\")"
+)
+
 var VALID_SUBCOMMANDS_SCHEMA = []string{SUBCOMMAND_SCHEMA_LIST}
 
 // Subcommand flags

--- a/cmd/vulnerability.go
+++ b/cmd/vulnerability.go
@@ -360,14 +360,13 @@ func DisplayVulnListText(output io.Writer) {
 	for _, entry := range entries {
 		value := entry.Value
 		vulnInfo = value.(VulnerabilityInfo)
-		// CSV interprets line feeds as new cells, fix by enclosing in double quotes
+
 		var description = ""
 		if vulnInfo.Description != "" {
+			// For tabbed text tables, replace line feeds with spaces
 			description = strings.ReplaceAll(vulnInfo.Description, "\n", " ")
 			// TODO: make "truncate" length configurable (via flag or config file)
-			if len(description) > VULNERABILITY_TRUNCATE_TEXT_LENGTH {
-				description = description[:VULNERABILITY_TRUNCATE_TEXT_LENGTH]
-			}
+			description = truncateString(description, VULNERABILITY_TRUNCATE_TEXT_LENGTH, true)
 		}
 
 		// Format line and write to output
@@ -514,7 +513,7 @@ func DisplayVulnListMarkdown(output io.Writer) (err error) {
 	return
 }
 
-// Output filtered list of Vulns. as JSON
+// Output filtered list of vulnerabilities as JSON
 func DisplayVulnListJson(output io.Writer) {
 	getLogger().Enter()
 	defer getLogger().Exit()

--- a/go.mod
+++ b/go.mod
@@ -19,10 +19,6 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/tidwall/gjson v1.14.3 // indirect
-	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.1 // indirect
-	github.com/wI2L/jsondiff v0.3.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	golang.org/x/sys v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,15 +36,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tidwall/gjson v1.14.3 h1:9jvXn7olKEHU1S9vwoMGliaT8jq1vJ7IH/n9zD9Dnlw=
-github.com/tidwall/gjson v1.14.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
-github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
-github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
-github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
-github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
-github.com/wI2L/jsondiff v0.3.0 h1:iTzQ9u/d86GE9RsBzVHX88f2EA1vQUboHwLhSQFc1s4=
-github.com/wI2L/jsondiff v0.3.0/go.mod h1:y1IMzNNjlSsk3IUoJdRJO7VRBtzMvRgyo4Vu0LdHpTc=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/utils/convert.go
+++ b/utils/convert.go
@@ -58,6 +58,8 @@ func ConvertAnyToAny(values ...interface{}) {
 	for index, value := range values {
 		fmt.Printf("value[%d] (%T): %+v\n", index, value, value)
 		switch t := value.(type) {
+		case nil:
+			fmt.Println("Type is nil.")
 		case int:
 		case uint:
 		case int32:
@@ -69,8 +71,6 @@ func ConvertAnyToAny(values ...interface{}) {
 			fmt.Println("Type is a float:", t)
 		case string:
 			fmt.Println("Type is a string:", t)
-		case nil:
-			fmt.Println("Type is nil.")
 		case bool:
 			fmt.Println("Type is a bool:", t)
 		default:

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -66,10 +66,8 @@ type CommandFlags struct {
 }
 
 type LicenseCommandFlags struct {
-	Summary   bool
-	Policy    string
-	NoLicense bool
-	NoPolicy  bool
+	Summary      bool
+	ListLineWrap bool
 }
 
 type CustomValidationFlags struct {


### PR DESCRIPTION
- add flag `--wrap=true|false` support (format `txt` only)
- add flag `--where` support to allow filtering on any column name for all formats