### PR TITLE
Support schema error results to be ouptut in JSON format including custom format flags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
-        extra_files: LICENSE config.json license.json custom.json ${{env.SBOM_NAME}}
+        extra_files: LICENSE README.md config.json license.json custom.json ${{env.SBOM_NAME}}
         # "auto" will use ZIP for Windows, otherwise default is TAR
         compress_assets: auto
         # NOTE: This verbose flag may be removed

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,6 +62,7 @@
             "multimap",
             "myservices",
             "NOASSERTION",
+            "nolint",
             "nosec",
             "NTIA",
             "Nyffenegger",
@@ -102,5 +103,8 @@
       ],
       "files.watcherExclude": {
             "**/target": true
-      }
+      },
+      "cSpell.ignoreWords": [
+            "iancoleman"
+      ]
 }

--- a/README.md
+++ b/README.md
@@ -808,11 +808,11 @@ Use the `--error-limit x` (default: `10`) flag to reduce the formatted error res
 
 ##### `--error-value` flag
 
-Use the `--error-value=true|false` (default: `true`)flag to reduce the formatted error result output by not showing the `value` field which shows detailed information about the failing data in the BOM.
+Use the `--error-value=true|false` (default: `true`) flag to reduce the formatted error result output by not showing the `value` field which shows detailed information about the failing data in the BOM.
 
 ##### `--colorize` flag
 
-Use the `--colorize=true|false` (default: `true`) flag to add/remove color formatting to error result `txt` formatted output.  By default, `txt` formatted error output is colorized to help with human readability; for automated use, it can be turned off.
+Use the `--colorize=true|false` (default: `false`) flag to add/remove color formatting to error result `txt` formatted output.  By default, `txt` formatted error output is colorized to help with human readability; for automated use, it can be turned off.
 
 #### Validate Examples
 

--- a/README.md
+++ b/README.md
@@ -804,11 +804,15 @@ The following flags can be used to improve performance when formatting error out
 
 ##### `--error-limit` flag
 
-Use the `--error-limit x` flag to reduce the formatted error result output to the first `x` errors.  By default, only the first 10 errors are output with an informational messaging indicating `x/y` errors were shown.
+Use the `--error-limit x` (default: `10`) flag to reduce the formatted error result output to the first `x` errors.  By default, only the first 10 errors are output with an informational messaging indicating `x/y` errors were shown.
+
+##### `--error-value` flag
+
+Use the `--error-value=true|false` (default: `true`)flag to reduce the formatted error result output by not showing the `value` field which shows detailed information about the failing data in the BOM.
 
 ##### `--colorize` flag
 
-Use the `--colorize=true|false` flag to add/remove color formatting to error result output.  By default, formatted error output is colorized to help with human readability; for automated use, it can be turned off.
+Use the `--colorize=true|false` (default: `true`) flag to add/remove color formatting to error result `txt` formatted output.  By default, `txt` formatted error output is colorized to help with human readability; for automated use, it can be turned off.
 
 #### Validate Examples
 
@@ -909,6 +913,108 @@ The details include the full context of the failing `metadata.properties` object
 	    "value": "This SBOM is Confidential Information. Do not distribute."
 	  }
 	]]
+```
+
+#### Example: Validate using "JSON" format
+
+The JSON format will provide an `array` of schema error results that can be post-processed as part of validation toolchain.
+
+```bash
+./sbom-utility validate -i test/validation/cdx-1-4-validate-err-components-unique-items-1.json --format json --quiet
+```
+
+```json
+[
+    {
+        "type": "unique",
+        "field": "components",
+        "context": "(root).components",
+        "description": "array items[1,2] must be unique",
+        "value": {
+            "type": "array",
+            "index": 1,
+            "item": {
+                "bom-ref": "pkg:npm/body-parser@1.19.0",
+                "description": "Node.js body parsing middleware",
+                "hashes": [
+                    {
+                        "alg": "SHA-1",
+                        "content": "96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
+                    }
+                ],
+                "licenses": [
+                    {
+                        "license": {
+                            "id": "MIT"
+                        }
+                    }
+                ],
+                "name": "body-parser",
+                "purl": "pkg:npm/body-parser@1.19.0",
+                "type": "library",
+                "version": "1.19.0"
+            }
+        }
+    },
+    {
+        "type": "unique",
+        "field": "components",
+        "context": "(root).components",
+        "description": "array items[2,4] must be unique",
+        "value": {
+            "type": "array",
+            "index": 2,
+            "item": {
+                "bom-ref": "pkg:npm/body-parser@1.19.0",
+                "description": "Node.js body parsing middleware",
+                "hashes": [
+                    {
+                        "alg": "SHA-1",
+                        "content": "96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
+                    }
+                ],
+                "licenses": [
+                    {
+                        "license": {
+                            "id": "MIT"
+                        }
+                    }
+                ],
+                "name": "body-parser",
+                "purl": "pkg:npm/body-parser@1.19.0",
+                "type": "library",
+                "version": "1.19.0"
+            }
+        }
+    }
+]
+```
+
+##### Reducing output size using `error-value=false` flag
+
+In many cases, BOMs may have many errors and having the `value` information details included can be too verbose and lead to large output files to inspect.  In those cases, simply set the `error-value` flag to `false`.
+
+Rerunning the same command with this flag set to false yields a reduced set of information.
+
+```bash
+./sbom-utility validate -i test/validation/cdx-1-4-validate-err-components-unique-items-1.json --format json --error-value=false --quiet
+```
+
+```json
+[
+    {
+        "type": "unique",
+        "field": "components",
+        "context": "(root).components",
+        "description": "array items[1,2] must be unique"
+    },
+    {
+        "type": "unique",
+        "field": "components",
+        "context": "(root).components",
+        "description": "array items[2,4] must be unique"
+    }
+]
 ```
 
 ---

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -20,7 +20,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -144,7 +143,7 @@ func Diff(flags utils.CommandFlags) (err error) {
 
 	getLogger().Infof("Reading file (--input-file): `%s` ...", baseFilename)
 	// #nosec G304 (suppress warning)
-	bBaseData, errReadBase := ioutil.ReadFile(baseFilename)
+	bBaseData, errReadBase := os.ReadFile(baseFilename)
 	if errReadBase != nil {
 		getLogger().Debugf("%v", bBaseData[:255])
 		err = getLogger().Errorf("Failed to ReadFile '%s': %s\n", utils.GlobalFlags.InputFile, err.Error())
@@ -153,7 +152,7 @@ func Diff(flags utils.CommandFlags) (err error) {
 
 	getLogger().Infof("Reading file (--input-revision): `%s` ...", deltaFilename)
 	// #nosec G304 (suppress warning)
-	bRevisedData, errReadDelta := ioutil.ReadFile(deltaFilename)
+	bRevisedData, errReadDelta := os.ReadFile(deltaFilename)
 	if errReadDelta != nil {
 		getLogger().Debugf("%v", bRevisedData[:255])
 		err = getLogger().Errorf("Failed to ReadFile '%s': %s\n", utils.GlobalFlags.InputFile, err.Error())

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -50,7 +50,7 @@ func NewCommandDiff() *cobra.Command {
 	command.Use = CMD_USAGE_DIFF
 	command.Short = "Report on differences between two BOM files using RFC 6902 format"
 	command.Long = "Report on differences between two BOM files using RFC 6902 format"
-	command.Flags().StringVarP(&utils.GlobalFlags.OutputFormat, FLAG_FILE_OUTPUT_FORMAT, "", FORMAT_TEXT,
+	command.Flags().StringVarP(&utils.GlobalFlags.PersistentFlags.OutputFormat, FLAG_FILE_OUTPUT_FORMAT, "", FORMAT_TEXT,
 		FLAG_DIFF_OUTPUT_FORMAT_HELP+DIFF_OUTPUT_SUPPORTED_FORMATS)
 	command.Flags().StringVarP(&utils.GlobalFlags.DiffFlags.RevisedFile,
 		FLAG_DIFF_FILENAME_REVISION,
@@ -74,7 +74,7 @@ func preRunTestForFiles(cmd *cobra.Command, args []string) error {
 	getLogger().Tracef("args: %v", args)
 
 	// Make sure the base (input) file is present and exists
-	baseFilename := utils.GlobalFlags.InputFile
+	baseFilename := utils.GlobalFlags.PersistentFlags.InputFile
 	if baseFilename == "" {
 		return getLogger().Errorf("Missing required argument(s): %s", FLAG_FILENAME_INPUT)
 	} else if _, err := os.Stat(baseFilename); err != nil {
@@ -97,7 +97,8 @@ func diffCmdImpl(cmd *cobra.Command, args []string) (err error) {
 	defer getLogger().Exit()
 
 	// Create output writer
-	outputFile, writer, err := createOutputFile(utils.GlobalFlags.OutputFile)
+	outputFilename := utils.GlobalFlags.PersistentFlags.OutputFile
+	outputFile, writer, err := createOutputFile(outputFilename)
 	getLogger().Tracef("outputFile: `%v`; writer: `%v`", outputFile, writer)
 
 	// use function closure to assure consistent error output based upon error type
@@ -108,7 +109,7 @@ func diffCmdImpl(cmd *cobra.Command, args []string) (err error) {
 			if err != nil {
 				return
 			}
-			getLogger().Infof("Closed output file: `%s`", utils.GlobalFlags.OutputFile)
+			getLogger().Infof("Closed output file: `%s`", utils.GlobalFlags.PersistentFlags.OutputFile)
 		}
 	}()
 
@@ -122,11 +123,11 @@ func Diff(flags utils.CommandFlags) (err error) {
 	defer getLogger().Exit()
 
 	// create locals
-	format := utils.GlobalFlags.OutputFormat
-	baseFilename := utils.GlobalFlags.InputFile
-	outputFilename := utils.GlobalFlags.OutputFile
-	outputFormat := utils.GlobalFlags.OutputFormat
-	deltaFilename := utils.GlobalFlags.DiffFlags.RevisedFile
+	format := utils.GlobalFlags.PersistentFlags.OutputFormat
+	inputFilename := utils.GlobalFlags.PersistentFlags.InputFile
+	outputFilename := utils.GlobalFlags.PersistentFlags.OutputFile
+	outputFormat := utils.GlobalFlags.PersistentFlags.OutputFormat
+	revisedFilename := utils.GlobalFlags.DiffFlags.RevisedFile
 	deltaColorize := utils.GlobalFlags.DiffFlags.Colorize
 
 	// Create output writer
@@ -137,31 +138,31 @@ func Diff(flags utils.CommandFlags) (err error) {
 		// always close the output file
 		if outputFile != nil {
 			err = outputFile.Close()
-			getLogger().Infof("Closed output file: `%s`", utils.GlobalFlags.OutputFile)
+			getLogger().Infof("Closed output file: `%s`", outputFilename)
 		}
 	}()
 
-	getLogger().Infof("Reading file (--input-file): `%s` ...", baseFilename)
+	getLogger().Infof("Reading file (--input-file): `%s` ...", inputFilename)
 	// #nosec G304 (suppress warning)
-	bBaseData, errReadBase := os.ReadFile(baseFilename)
+	bBaseData, errReadBase := os.ReadFile(inputFilename)
 	if errReadBase != nil {
 		getLogger().Debugf("%v", bBaseData[:255])
-		err = getLogger().Errorf("Failed to ReadFile '%s': %s\n", utils.GlobalFlags.InputFile, err.Error())
+		err = getLogger().Errorf("Failed to ReadFile '%s': %s\n", inputFilename, err.Error())
 		return
 	}
 
-	getLogger().Infof("Reading file (--input-revision): `%s` ...", deltaFilename)
+	getLogger().Infof("Reading file (--input-revision): `%s` ...", revisedFilename)
 	// #nosec G304 (suppress warning)
-	bRevisedData, errReadDelta := os.ReadFile(deltaFilename)
+	bRevisedData, errReadDelta := os.ReadFile(revisedFilename)
 	if errReadDelta != nil {
 		getLogger().Debugf("%v", bRevisedData[:255])
-		err = getLogger().Errorf("Failed to ReadFile '%s': %s\n", utils.GlobalFlags.InputFile, err.Error())
+		err = getLogger().Errorf("Failed to ReadFile '%s': %s\n", inputFilename, err.Error())
 		return
 	}
 
 	// Compare the base with the revision
 	differ := diff.New()
-	getLogger().Infof("Comparing files: `%s` (base) to `%s` (revised) ...", baseFilename, deltaFilename)
+	getLogger().Infof("Comparing files: `%s` (base) to `%s` (revised) ...", inputFilename, revisedFilename)
 	d, err := differ.Compare(bBaseData, bRevisedData)
 	if err != nil {
 		err = getLogger().Errorf("Failed to Compare data: %s\n", err.Error())
@@ -177,7 +178,7 @@ func Diff(flags utils.CommandFlags) (err error) {
 			err = json.Unmarshal(bBaseData, &aJson)
 
 			if err != nil {
-				err = getLogger().Errorf("json.Unmarshal() failed '%s': %s\n", utils.GlobalFlags.InputFile, err.Error())
+				err = getLogger().Errorf("json.Unmarshal() failed '%s': %s\n", inputFilename, err.Error())
 				return
 			}
 
@@ -200,8 +201,7 @@ func Diff(flags utils.CommandFlags) (err error) {
 
 	} else {
 		getLogger().Infof("No deltas found. baseFilename: `%s`, revisedFilename=`%s` match.",
-			utils.GlobalFlags.InputFile,
-			utils.GlobalFlags.DiffFlags.RevisedFile)
+			inputFilename, revisedFilename)
 	}
 
 	return

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -48,15 +48,15 @@ func innerDiffError(t *testing.T, baseFilename string, revisedFilename string, f
 	defer getLogger().Exit()
 
 	// Copy the test filename to the command line flags where the code looks for it
-	utils.GlobalFlags.OutputFormat = format
-	utils.GlobalFlags.InputFile = baseFilename
+	utils.GlobalFlags.PersistentFlags.OutputFormat = format
+	utils.GlobalFlags.PersistentFlags.InputFile = baseFilename
 	utils.GlobalFlags.DiffFlags.RevisedFile = revisedFilename
 	utils.GlobalFlags.DiffFlags.Colorize = true
 
 	actualError = Diff(utils.GlobalFlags)
 
 	getLogger().Tracef("baseFilename: `%s`, revisedFilename=`%s`, actualError=`%T`",
-		utils.GlobalFlags.InputFile,
+		utils.GlobalFlags.PersistentFlags.InputFile,
 		utils.GlobalFlags.DiffFlags.RevisedFile,
 		actualError)
 

--- a/cmd/document.go
+++ b/cmd/document.go
@@ -28,26 +28,28 @@ func LoadInputSbomFileAndDetectSchema() (document *schema.Sbom, err error) {
 	getLogger().Enter()
 	defer getLogger().Exit()
 
+	inputFile := utils.GlobalFlags.PersistentFlags.InputFile
+
 	// check for required fields on command
-	getLogger().Tracef("utils.Flags.InputFile: `%s`", utils.GlobalFlags.InputFile)
-	if utils.GlobalFlags.InputFile == "" {
-		return nil, fmt.Errorf("invalid input file (-%s): `%s` ", FLAG_FILENAME_INPUT_SHORT, utils.GlobalFlags.InputFile)
+	getLogger().Tracef("utils.Flags.InputFile: `%s`", inputFile)
+	if inputFile == "" {
+		return nil, fmt.Errorf("invalid input file (-%s): `%s` ", FLAG_FILENAME_INPUT_SHORT, inputFile)
 	}
 
 	// Construct an Sbom object around the input file
-	document = schema.NewSbom(utils.GlobalFlags.InputFile)
+	document = schema.NewSbom(inputFile)
 
 	// Load the raw, candidate SBOM (file) as JSON data
-	getLogger().Infof("Attempting to load and unmarshal file `%s`...", utils.GlobalFlags.InputFile)
+	getLogger().Infof("Attempting to load and unmarshal file `%s`...", inputFile)
 	err = document.UnmarshalSBOMAsJsonMap() // i.e., utils.Flags.InputFile
 	if err != nil {
 		return
 	}
-	getLogger().Infof("Successfully unmarshalled data from: `%s`", utils.GlobalFlags.InputFile)
+	getLogger().Infof("Successfully unmarshalled data from: `%s`", inputFile)
 
 	// Search the document keys/values for known SBOM formats and schema in the config. file
 	getLogger().Infof("Determining file's SBOM format and version...")
-	err = document.FindFormatAndSchema()
+	err = document.FindFormatAndSchema(utils.GlobalFlags.PersistentFlags.InputFile)
 	if err != nil {
 		return
 	}

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -116,10 +116,11 @@ func (err BaseError) Error() string {
 	return formattedMessage
 }
 
+//nolint:all
 func (base BaseError) AppendMessage(addendum string) {
 	// Ignore (invalid) static linting message:
 	// "ineffective assignment to field (SA4005)"
-	base.Message += addendum
+	base.Message += addendum //nolint:staticcheck
 }
 
 type UtilityError struct {

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -116,11 +116,10 @@ func (err BaseError) Error() string {
 	return formattedMessage
 }
 
-//nolint:all
-func (base BaseError) AppendMessage(addendum string) {
-	// Ignore (invalid) static linting message:
-	// "ineffective assignment to field (SA4005)"
-	base.Message += addendum //nolint:staticcheck
+func (err *BaseError) AppendMessage(addendum string) {
+	if addendum != "" {
+		err.Message += addendum
+	}
 }
 
 type UtilityError struct {

--- a/cmd/license_list.go
+++ b/cmd/license_list.go
@@ -50,7 +50,7 @@ const (
 	MSG_OUTPUT_NO_LICENSES_ONLY_NOASSERTION = "no valid licenses found in BOM document (only licenses marked NOASSERTION)"
 )
 
-//"Type", "ID/Name/Expression", "Component(s)", "BOM ref.", "Document location"
+// "Type", "ID/Name/Expression", "Component(s)", "BOM ref.", "Document location"
 // filter keys
 const (
 	LICENSE_FILTER_KEY_USAGE_POLICY  = "usage-policy"
@@ -106,7 +106,7 @@ func NewCommandList() *cobra.Command {
 	command.Use = CMD_USAGE_LICENSE_LIST
 	command.Short = "List licenses found in the BOM input file"
 	command.Long = "List licenses and associated policies found in the BOM input file"
-	command.Flags().StringVarP(&utils.GlobalFlags.OutputFormat, FLAG_FILE_OUTPUT_FORMAT, "", "",
+	command.Flags().StringVarP(&utils.GlobalFlags.PersistentFlags.OutputFormat, FLAG_FILE_OUTPUT_FORMAT, "", "",
 		FLAG_LICENSE_LIST_OUTPUT_FORMAT_HELP+
 			LICENSE_LIST_SUPPORTED_FORMATS+
 			LICENSE_LIST_SUMMARY_SUPPORTED_FORMATS)
@@ -162,14 +162,15 @@ func listCmdImpl(cmd *cobra.Command, args []string) (err error) {
 	defer getLogger().Exit()
 
 	// Create output writer
-	outputFile, writer, err := createOutputFile(utils.GlobalFlags.OutputFile)
+	outputFilename := utils.GlobalFlags.PersistentFlags.OutputFile
+	outputFile, writer, err := createOutputFile(outputFilename)
 
 	// use function closure to assure consistent error output based upon error type
 	defer func() {
 		// always close the output file
 		if outputFile != nil {
 			err = outputFile.Close()
-			getLogger().Infof("Closed output file: `%s`", utils.GlobalFlags.OutputFile)
+			getLogger().Infof("Closed output file: `%s`", outputFilename)
 		}
 	}()
 
@@ -177,7 +178,7 @@ func listCmdImpl(cmd *cobra.Command, args []string) (err error) {
 	whereFilters, err := processWhereFlag(cmd)
 
 	if err == nil {
-		err = ListLicenses(writer, utils.GlobalFlags.OutputFormat, whereFilters, utils.GlobalFlags.LicenseFlags.Summary)
+		err = ListLicenses(writer, utils.GlobalFlags.PersistentFlags.OutputFormat, whereFilters, utils.GlobalFlags.LicenseFlags.Summary)
 	}
 
 	return

--- a/cmd/license_policy.go
+++ b/cmd/license_policy.go
@@ -122,7 +122,7 @@ func NewCommandPolicy() *cobra.Command {
 	command.Use = CMD_USAGE_LICENSE_POLICY
 	command.Short = "List policies associated with known licenses"
 	command.Long = "List caller-supplied, \"allow/deny\"-style policies associated with known software, hardware or data licenses"
-	command.Flags().StringVarP(&utils.GlobalFlags.OutputFormat, FLAG_FILE_OUTPUT_FORMAT, "", FORMAT_TEXT,
+	command.Flags().StringVarP(&utils.GlobalFlags.PersistentFlags.OutputFormat, FLAG_FILE_OUTPUT_FORMAT, "", FORMAT_TEXT,
 		FLAG_POLICY_OUTPUT_FORMAT_HELP+LICENSE_POLICY_SUPPORTED_FORMATS)
 	command.Flags().BoolVarP(
 		&utils.GlobalFlags.LicenseFlags.Summary, // re-use license flag
@@ -161,14 +161,14 @@ func policyCmdImpl(cmd *cobra.Command, args []string) (err error) {
 	getLogger().Enter(args)
 	defer getLogger().Exit()
 
-	outputFile, writer, err := createOutputFile(utils.GlobalFlags.OutputFile)
+	outputFile, writer, err := createOutputFile(utils.GlobalFlags.PersistentFlags.OutputFile)
 
 	// use function closure to assure consistent error output based upon error type
 	defer func() {
 		// always close the output file
 		if outputFile != nil {
 			err = outputFile.Close()
-			getLogger().Infof("Closed output file: `%s`", utils.GlobalFlags.OutputFile)
+			getLogger().Infof("Closed output file: `%s`", utils.GlobalFlags.PersistentFlags.OutputFile)
 		}
 	}()
 
@@ -211,7 +211,7 @@ func ListLicensePolicies(writer io.Writer, whereFilters []WhereFilter, flags uti
 	}
 
 	// default output (writer) to standard out
-	switch utils.GlobalFlags.OutputFormat {
+	switch utils.GlobalFlags.PersistentFlags.OutputFormat {
 	case FORMAT_DEFAULT:
 		// defaults to text if no explicit `--format` parameter
 		err = DisplayLicensePoliciesTabbedText(writer, filteredMap, flags)
@@ -224,7 +224,7 @@ func ListLicensePolicies(writer io.Writer, whereFilters []WhereFilter, flags uti
 	default:
 		// default to text format for anything else
 		getLogger().Warningf("Unsupported format: `%s`; using default format.",
-			utils.GlobalFlags.OutputFormat)
+			utils.GlobalFlags.PersistentFlags.OutputFormat)
 		err = DisplayLicensePoliciesTabbedText(writer, filteredMap, flags)
 	}
 	return

--- a/cmd/license_policy_config.go
+++ b/cmd/license_policy_config.go
@@ -42,16 +42,18 @@ var VALID_USAGE_POLICIES = []string{POLICY_ALLOW, POLICY_DENY, POLICY_NEEDS_REVI
 var ALL_USAGE_POLICIES = []string{POLICY_ALLOW, POLICY_DENY, POLICY_NEEDS_REVIEW, POLICY_UNDEFINED, POLICY_CONFLICT}
 
 // Note: the SPDX spec. does not provide regex for an SPDX ID, but provides the following in ABNF:
-//     string = 1*(ALPHA / DIGIT / "-" / "." )
+//
+//	string = 1*(ALPHA / DIGIT / "-" / "." )
+//
 // Currently, the regex below tests composition of of only
 // alphanum, "-", and "." characters and disallows empty strings
 // TODO:
-// - First and last chars are not "-" or "."
-// - Enforce reasonable min/max lengths
-//   In theory, we can check overall length with positive lookahead
-//   (e.g., min 3 max 128):  (?=.{3,128}$)
-//   However, this does not appear to be supported in `regexp` package
-//   or perhaps it must be a compiled expression TBD
+//   - First and last chars are not "-" or "."
+//   - Enforce reasonable min/max lengths
+//     In theory, we can check overall length with positive lookahead
+//     (e.g., min 3 max 128):  (?=.{3,128}$)
+//     However, this does not appear to be supported in `regexp` package
+//     or perhaps it must be a compiled expression TBD
 const (
 	REGEX_VALID_SPDX_ID = "^[a-zA-Z0-9.-]+$"
 )

--- a/cmd/license_policy_test.go
+++ b/cmd/license_policy_test.go
@@ -81,8 +81,8 @@ func innerTestLicensePolicyListCustomAndBuffered(t *testing.T, testInfo *License
 	}
 
 	// Use the test data to set the BOM input file and output format
-	utils.GlobalFlags.InputFile = testInfo.InputFile
-	utils.GlobalFlags.OutputFormat = testInfo.ListFormat
+	utils.GlobalFlags.PersistentFlags.InputFile = testInfo.InputFile
+	utils.GlobalFlags.PersistentFlags.OutputFormat = testInfo.ListFormat
 	utils.GlobalFlags.LicenseFlags.Summary = testInfo.ListSummary
 
 	// TODO: pass GlobalConfig to every Command to allow per-instance changes for tests
@@ -118,9 +118,9 @@ func innerTestLicensePolicyList(t *testing.T, testInfo *LicenseTestInfo) (output
 	return
 }
 
-//-----------------------------------
+// -----------------------------------
 // Usage Policy: allowed value tests
-//-----------------------------------
+// -----------------------------------
 func TestLicensePolicyUsageValueAllow(t *testing.T) {
 	value := POLICY_ALLOW
 	if !IsValidUsagePolicy(value) {

--- a/cmd/license_test.go
+++ b/cmd/license_test.go
@@ -92,7 +92,7 @@ func innerTestLicenseListBuffered(t *testing.T, testInfo *LicenseTestInfo, where
 	defer outputWriter.Flush()
 
 	// Use a test input SBOM formatted in SPDX
-	utils.GlobalFlags.InputFile = testInfo.InputFile
+	utils.GlobalFlags.PersistentFlags.InputFile = testInfo.InputFile
 
 	// Invoke the actual List command (API)
 	err = ListLicenses(outputWriter, testInfo.ListFormat, whereFilters, testInfo.ListSummary)
@@ -288,9 +288,9 @@ func TestLicenseListPolicyCdx14InvalidLicenseName(t *testing.T) {
 	innerTestLicenseList(t, lti)
 }
 
-//---------------------------
+// ---------------------------
 // Where filter tests
-//---------------------------
+// ---------------------------
 func TestLicenseListSummaryTextCdx13WhereUsageNeedsReview(t *testing.T) {
 	lti := NewLicenseTestInfoBasic(TEST_LICENSE_LIST_CDX_1_3, FORMAT_TEXT, true)
 	lti.WhereClause = "usage-policy=needs-review"

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -64,13 +64,20 @@ var QUERY_SUPPORTED_FORMATS = MSG_SUPPORTED_OUTPUT_FORMATS_HELP +
 
 // query JSON map and return selected subset
 // SELECT
-//    <key.1>, <key.2>, ... // "firstname, lastname, email" || * (default)
+//
+//	<key.1>, <key.2>, ... // "firstname, lastname, email" || * (default)
+//
 // FROM
-//    <key path>            // "product.customers"
+//
+//	<key path>            // "product.customers"
+//
 // WHERE
-//    <key.X> == <value>    // "country='Germany'"
+//
+//	<key.X> == <value>    // "country='Germany'"
+//
 // ORDER BY
-//    <key.N>               // "lastname"
+//
+//	<key.N>               // "lastname"
 //
 // e.g.,SELECT * FROM product.customers WHERE country="Germany";
 type QueryRequest struct {
@@ -138,7 +145,7 @@ func initCommandQuery(command *cobra.Command) {
 	defer getLogger().Exit()
 
 	// Add local flags to command
-	command.PersistentFlags().StringVar(&utils.GlobalFlags.OutputFormat, FLAG_OUTPUT_FORMAT, FORMAT_JSON,
+	command.PersistentFlags().StringVar(&utils.GlobalFlags.PersistentFlags.OutputFormat, FLAG_OUTPUT_FORMAT, FORMAT_JSON,
 		FLAG_QUERY_OUTPUT_FORMAT_HELP+QUERY_SUPPORTED_FORMATS)
 	command.Flags().StringP(FLAG_QUERY_SELECT, "", QUERY_TOKEN_WILDCARD, FLAG_QUERY_SELECT_HELP)
 	// NOTE: TODO: There appears to be a bug in Cobra where the type of the `from`` flag is `--from` (i.e., not string)

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -46,7 +46,7 @@ func innerQuery(t *testing.T, filename string, queryRequest *QueryRequest, autof
 	}
 
 	// Copy the test filename to the command line flags were the code looks for it
-	utils.GlobalFlags.InputFile = filename
+	utils.GlobalFlags.PersistentFlags.InputFile = filename
 
 	// allocate response/result object and invoke query
 	var response = new(QueryResponse)

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -112,7 +112,7 @@ func NewCommandResource() *cobra.Command {
 	command.Use = CMD_USAGE_RESOURCE_LIST
 	command.Short = "Report on resources found in BOM input file"
 	command.Long = "Report on resources found in BOM input file"
-	command.Flags().StringVarP(&utils.GlobalFlags.OutputFormat, FLAG_FILE_OUTPUT_FORMAT, "", FORMAT_TEXT,
+	command.Flags().StringVarP(&utils.GlobalFlags.PersistentFlags.OutputFormat, FLAG_FILE_OUTPUT_FORMAT, "", FORMAT_TEXT,
 		FLAG_RESOURCE_OUTPUT_FORMAT_HELP+RESOURCE_LIST_OUTPUT_SUPPORTED_FORMATS)
 	command.Flags().StringP(FLAG_RESOURCE_TYPE, "", RESOURCE_TYPE_DEFAULT, FLAG_RESOURCE_TYPE_HELP)
 	command.Flags().StringP(FLAG_REPORT_WHERE, "", "", FLAG_REPORT_WHERE_HELP)
@@ -168,15 +168,16 @@ func resourceCmdImpl(cmd *cobra.Command, args []string) (err error) {
 	defer getLogger().Exit()
 
 	// Create output writer
-	outputFile, writer, err := createOutputFile(utils.GlobalFlags.OutputFile)
-	getLogger().Tracef("outputFile: `%v`; writer: `%v`", outputFile, writer)
+	outputFilename := utils.GlobalFlags.PersistentFlags.OutputFile
+	outputFile, writer, err := createOutputFile(outputFilename)
+	getLogger().Tracef("outputFile: `%v`; writer: `%v`", outputFilename, writer)
 
 	// use function closure to assure consistent error output based upon error type
 	defer func() {
 		// always close the output file
 		if outputFile != nil {
 			outputFile.Close()
-			getLogger().Infof("Closed output file: `%s`", utils.GlobalFlags.OutputFile)
+			getLogger().Infof("Closed output file: `%s`", outputFilename)
 		}
 	}()
 
@@ -187,7 +188,7 @@ func resourceCmdImpl(cmd *cobra.Command, args []string) (err error) {
 	var resourceType string
 	resourceType, err = retrieveResourceType(cmd)
 
-	ListResources(writer, utils.GlobalFlags.OutputFormat, resourceType, whereFilters)
+	ListResources(writer, utils.GlobalFlags.PersistentFlags.OutputFormat, resourceType, whereFilters)
 
 	return
 }

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -188,7 +188,9 @@ func resourceCmdImpl(cmd *cobra.Command, args []string) (err error) {
 	var resourceType string
 	resourceType, err = retrieveResourceType(cmd)
 
-	ListResources(writer, utils.GlobalFlags.PersistentFlags.OutputFormat, resourceType, whereFilters)
+	if err == nil {
+		err = ListResources(writer, utils.GlobalFlags.PersistentFlags.OutputFormat, resourceType, whereFilters)
+	}
 
 	return
 }

--- a/cmd/resource_test.go
+++ b/cmd/resource_test.go
@@ -88,7 +88,7 @@ func innerTestResourceList(t *testing.T, testInfo *ResourceTestInfo) (outputBuff
 	}
 
 	// The command looks for the input filename in global flags struct
-	utils.GlobalFlags.InputFile = testInfo.InputFile
+	utils.GlobalFlags.PersistentFlags.InputFile = testInfo.InputFile
 
 	// invoke resource list command with a byte buffer
 	outputBuffer, err = innerBufferedTestResourceList(t, testInfo, whereFilters)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,7 +85,7 @@ const (
 	MSG_FLAG_DEBUG          = "enable debug logging"
 	MSG_FLAG_INPUT          = "input filename (e.g., \"path/sbom.json\")"
 	MSG_FLAG_OUTPUT         = "output filename"
-	MSG_FLAG_LOG_QUIET      = "enable quiet logging mode (removes all information messages from console output); overrides other logging commands"
+	MSG_FLAG_LOG_QUIET      = "enable quiet logging mode (removes all informational messages from console output); overrides other logging commands"
 	MSG_FLAG_LOG_INDENT     = "enable log indentation of functional callstack"
 	MSG_FLAG_CONFIG_SCHEMA  = "provide custom application schema configuration file (i.e., overrides default `config.json`)"
 	MSG_FLAG_CONFIG_LICENSE = "provide custom application license policy configuration file (i.e., overrides default `license.json`)"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,7 +55,7 @@ const (
 	CMD_USAGE_QUERY              = CMD_QUERY + " --input-file <input_file> [--select * | field1[,fieldN]] [--from [key1[.keyN]] [--where key=regex[,...]]"
 	CMD_USAGE_RESOURCE_LIST      = CMD_RESOURCE + " --input-file <input_file> [--type component|service] [--where key=regex[,...]] [--format txt|csv|md]"
 	CMD_USAGE_SCHEMA_LIST        = CMD_SCHEMA + " [--where key=regex[,...]] [--format txt|csv|md]"
-	CMD_USAGE_VALIDATE           = CMD_VALIDATE + " --input-file <input_file> [--variant <variant_name>] [--error-limit <integer>] [--colorize=true|false] [--force schema_file]"
+	CMD_USAGE_VALIDATE           = CMD_VALIDATE + " --input-file <input_file> [--variant <variant_name>] [--format txt|json] [--force schema_file]"
 	CMD_USAGE_VULNERABILITY_LIST = CMD_VULNERABILITY + " " + SUBCOMMAND_VULNERABILITY_LIST + " --input-file <input_file> [--summary] [--where key=regex[,...]] [--format json|txt|csv|md]"
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -155,15 +155,15 @@ func init() {
 	//rootCmd.PersistentFlags().StringVarP(&utils.GlobalFlags.ConfigCustomValidationFile, FLAG_CONFIG_CUSTOM_VALIDATION, "", DEFAULT_CUSTOM_VALIDATION_CONFIG, "TODO")
 
 	// Declare top-level, persistent flags and where to place the post-parse values
-	rootCmd.PersistentFlags().BoolVarP(&utils.GlobalFlags.Trace, FLAG_TRACE, FLAG_TRACE_SHORT, false, MSG_FLAG_TRACE)
-	rootCmd.PersistentFlags().BoolVarP(&utils.GlobalFlags.Debug, FLAG_DEBUG, FLAG_DEBUG_SHORT, false, MSG_FLAG_DEBUG)
-	rootCmd.PersistentFlags().StringVarP(&utils.GlobalFlags.InputFile, FLAG_FILENAME_INPUT, FLAG_FILENAME_INPUT_SHORT, "", MSG_FLAG_INPUT)
-	rootCmd.PersistentFlags().StringVarP(&utils.GlobalFlags.OutputFile, FLAG_FILENAME_OUTPUT, FLAG_FILENAME_OUTPUT_SHORT, "", MSG_FLAG_OUTPUT)
+	rootCmd.PersistentFlags().BoolVarP(&utils.GlobalFlags.PersistentFlags.Trace, FLAG_TRACE, FLAG_TRACE_SHORT, false, MSG_FLAG_TRACE)
+	rootCmd.PersistentFlags().BoolVarP(&utils.GlobalFlags.PersistentFlags.Debug, FLAG_DEBUG, FLAG_DEBUG_SHORT, false, MSG_FLAG_DEBUG)
+	rootCmd.PersistentFlags().StringVarP(&utils.GlobalFlags.PersistentFlags.InputFile, FLAG_FILENAME_INPUT, FLAG_FILENAME_INPUT_SHORT, "", MSG_FLAG_INPUT)
+	rootCmd.PersistentFlags().StringVarP(&utils.GlobalFlags.PersistentFlags.OutputFile, FLAG_FILENAME_OUTPUT, FLAG_FILENAME_OUTPUT_SHORT, "", MSG_FLAG_OUTPUT)
 
 	// NOTE: Although we check for the quiet mode flag in main; we track the flag
 	// using Cobra framework in order to enable more comprehensive help
 	// and take advantage of other features.
-	rootCmd.PersistentFlags().BoolVarP(&utils.GlobalFlags.Quiet, FLAG_QUIET_MODE, FLAG_QUIET_MODE_SHORT, false, MSG_FLAG_LOG_QUIET)
+	rootCmd.PersistentFlags().BoolVarP(&utils.GlobalFlags.PersistentFlags.Quiet, FLAG_QUIET_MODE, FLAG_QUIET_MODE_SHORT, false, MSG_FLAG_LOG_QUIET)
 
 	// Optionally, allow log callstack trace to be indented
 	rootCmd.PersistentFlags().BoolVarP(&utils.GlobalFlags.LogOutputIndentCallstack, FLAG_LOG_OUTPUT_INDENT, "", false, MSG_FLAG_LOG_INDENT)
@@ -260,11 +260,11 @@ func preRunTestForInputFile(cmd *cobra.Command, args []string) error {
 	getLogger().Tracef("args: %v", args)
 
 	// Make sure the input filename is present and exists
-	file := utils.GlobalFlags.InputFile
-	if file == "" {
+	inputFilename := utils.GlobalFlags.PersistentFlags.InputFile
+	if inputFilename == "" {
 		return getLogger().Errorf("Missing required argument(s): %s", FLAG_FILENAME_INPUT)
-	} else if _, err := os.Stat(file); err != nil {
-		return getLogger().Errorf("File not found: `%s`", file)
+	} else if _, err := os.Stat(inputFilename); err != nil {
+		return getLogger().Errorf("File not found: `%s`", inputFilename)
 	}
 	return nil
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -119,9 +119,9 @@ func TestMain(m *testing.M) {
 		flag.Parse()
 	}
 	getLogger().Tracef("Setting Debug=`%t`, Trace=`%t`, Quiet=`%t`,", *TestLogLevelDebug, *TestLogLevelTrace, *TestLogQuiet)
-	utils.GlobalFlags.Trace = *TestLogLevelTrace
-	utils.GlobalFlags.Debug = *TestLogLevelDebug
-	utils.GlobalFlags.Quiet = *TestLogQuiet
+	utils.GlobalFlags.PersistentFlags.Trace = *TestLogLevelTrace
+	utils.GlobalFlags.PersistentFlags.Debug = *TestLogLevelDebug
+	utils.GlobalFlags.PersistentFlags.Quiet = *TestLogQuiet
 
 	// Load configs, create logger, etc.
 	// NOTE: Be sure ALL "go test" flags are parsed/processed BEFORE initializing

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -471,7 +471,7 @@ func FormatSchemaErrorsJson(errs []gojsonschema.ResultError) string {
 			sb.WriteString(schemaErrorText)
 
 			if i < (lenErrs-1) && i < (errLimit-1) {
-				sb.WriteString(",")
+				sb.WriteString(",\n")
 			}
 		}
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -165,7 +165,7 @@ func normalizeValidationErrorTypes(document *schema.Sbom, valid bool, err error)
 			// Note: InvalidSBOMError type errors include schema errors which have already
 			// been added to the error type and will shown with the Error() interface
 			if valid {
-				getLogger().Errorf("invalid state: error (%T) returned, but SBOM valid!", t)
+				_ = getLogger().Errorf("invalid state: error (%T) returned, but SBOM valid!", t)
 			}
 			getLogger().Error(err)
 		default:

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -309,6 +309,7 @@ func Validate(output io.Writer, persistentFlags utils.PersistentCommandFlags, va
 		case FORMAT_JSON:
 			// Note: JSON data files MUST ends in a newline s as this is a POSIX standard
 			formattedErrors = FormatSchemaErrors(schemaErrors, validateFlags, FORMAT_JSON)
+			// getLogger().Debugf("%s", formattedErrors)
 			fmt.Fprintf(output, "%s", formattedErrors)
 		case FORMAT_TEXT:
 			fallthrough

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -27,7 +27,6 @@ import (
 	"github.com/CycloneDX/sbom-utility/resources"
 	"github.com/CycloneDX/sbom-utility/schema"
 	"github.com/CycloneDX/sbom-utility/utils"
-	"github.com/iancoleman/orderedmap"
 	"github.com/spf13/cobra"
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -43,6 +42,8 @@ const (
 	FLAG_VALIDATE_SCHEMA_VARIANT   = "variant"
 	FLAG_VALIDATE_CUSTOM           = "custom" // TODO: document when no longer experimental
 	FLAG_VALIDATE_ERR_LIMIT        = "error-limit"
+	FLAG_VALIDATE_ERR_DETAILS      = "error-details"
+	FLAG_VALIDATE_ERR_VALUES       = "error-values"
 	MSG_VALIDATE_SCHEMA_FORCE      = "force specified schema file for validation; overrides inferred schema"
 	MSG_VALIDATE_SCHEMA_VARIANT    = "select named schema variant (e.g., \"strict\"); variant must be declared in configuration file (i.e., \"config.json\")"
 	MSG_VALIDATE_FLAG_CUSTOM       = "perform custom validation using custom configuration settings (i.e., \"custom.json\")"
@@ -64,23 +65,6 @@ const (
 const (
 	PROTOCOL_PREFIX_FILE = "file://"
 )
-
-func NewValidationErrResult(resultError gojsonschema.ResultError) (validationErrResult *ValidationResultFormat) {
-	// Prepare values that are optionally output as JSON
-	validationErrResult = &ValidationResultFormat{
-		ResultError: resultError,
-	}
-	// Prepare for JSON output by adding all required fields to our ordered map
-	validationErrResult.resultMap = orderedmap.New()
-	validationErrResult.resultMap.Set("type", resultError.Type())
-	validationErrResult.resultMap.Set("field", resultError.Field())
-	if context := resultError.Context(); context != nil {
-		validationErrResult.resultMap.Set("context", resultError.Context().String())
-	}
-	validationErrResult.resultMap.Set("description", resultError.Description())
-
-	return
-}
 
 func NewCommandValidate() *cobra.Command {
 	// NOTE: `RunE` function takes precedent over `Run` (anonymous) function if both provided

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -337,6 +337,15 @@ func Validate() (valid bool, document *schema.Sbom, schemaErrors []gojsonschema.
 }
 
 func formatSchemaErrorTypes(resultError gojsonschema.ResultError, colorize bool) (formattedResult string) {
+
+	var jsonErrorMap = make(map[string]interface{})
+	jsonErrorMap["type"] = resultError.Type()
+	jsonErrorMap["context"] = resultError.Context()
+	jsonErrorMap["value"] = resultError.Value()
+	jsonErrorMap["details"] = resultError.Details()
+	jsonErrorMap["description"] = resultError.Description()
+	jsonErrorMap["descriptionFormat"] = resultError.DescriptionFormat()
+
 	switch resultError.(type) {
 	case *gojsonschema.FalseError:
 	case *gojsonschema.RequiredError:
@@ -354,7 +363,7 @@ func formatSchemaErrorTypes(resultError gojsonschema.ResultError, colorize bool)
 	case *gojsonschema.ArrayMaxItemsError:
 	case *gojsonschema.ItemsMustBeUniqueError:
 		getLogger().Infof("ItemsMustBeUniqueError:")
-		formattedResult, _ = log.FormatInterfaceAsJson(resultError)
+		formattedResult, _ = log.FormatInterfaceAsJson(jsonErrorMap)
 	case *gojsonschema.ArrayContainsError:
 	case *gojsonschema.ArrayMinPropertiesError:
 	case *gojsonschema.ArrayMaxPropertiesError:
@@ -374,16 +383,12 @@ func formatSchemaErrorTypes(resultError gojsonschema.ResultError, colorize bool)
 	case *gojsonschema.ConditionElseError:
 	default:
 		if colorize {
-			formattedResult, _ = log.FormatInterfaceAsColorizedJson(resultError)
+			formattedResult, _ = log.FormatInterfaceAsColorizedJson(jsonErrorMap)
 		} else {
-			formattedResult, _ = log.FormatInterfaceAsJson(resultError)
+			formattedResult, _ = log.FormatInterfaceAsJson(jsonErrorMap)
 		}
 	}
 
-	// err.SetType(t)
-	// err.SetContext(context)
-	// err.SetValue(value)
-	// err.SetDetails(details)
 	// err.SetDescriptionFormat(d)
 	// details["field"] = err.Field()
 	// if _, exists := details["context"]; !exists && context != nil {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -114,8 +114,8 @@ func initCommandValidate(command *cobra.Command) {
 	// Force a schema file to use for validation (override inferred schema)
 	command.Flags().StringVarP(&utils.GlobalFlags.ValidateFlags.ForcedJsonSchemaFile, FLAG_VALIDATE_SCHEMA_FORCE, "", "", MSG_VALIDATE_SCHEMA_FORCE)
 	// Optional schema "variant" of inferred schema (e.g, "strict")
-	command.Flags().StringVarP(&utils.GlobalFlags.Variant, FLAG_VALIDATE_SCHEMA_VARIANT, "", "", MSG_VALIDATE_SCHEMA_VARIANT)
-	command.Flags().BoolVarP(&utils.GlobalFlags.CustomValidation, FLAG_VALIDATE_CUSTOM, "", false, MSG_VALIDATE_FLAG_CUSTOM)
+	command.Flags().StringVarP(&utils.GlobalFlags.ValidateFlags.SchemaVariant, FLAG_VALIDATE_SCHEMA_VARIANT, "", "", MSG_VALIDATE_SCHEMA_VARIANT)
+	command.Flags().BoolVarP(&utils.GlobalFlags.ValidateFlags.CustomValidation, FLAG_VALIDATE_CUSTOM, "", false, MSG_VALIDATE_FLAG_CUSTOM)
 	// Colorize default: true (for historical reasons)
 	command.Flags().BoolVarP(&utils.GlobalFlags.ValidateFlags.ColorizeErrorOutput, FLAG_COLORIZE_OUTPUT, "", true, MSG_VALIDATE_FLAG_ERR_COLORIZE)
 	command.Flags().IntVarP(&utils.GlobalFlags.ValidateFlags.MaxNumErrors, FLAG_VALIDATE_ERR_LIMIT, "", DEFAULT_MAX_ERROR_LIMIT, MSG_VALIDATE_FLAG_ERR_LIMIT)
@@ -199,7 +199,7 @@ func Validate() (valid bool, document *schema.Sbom, schemaErrors []gojsonschema.
 	}
 
 	// if "custom" flag exists, then assure we support the format
-	if utils.GlobalFlags.CustomValidation && !document.FormatInfo.IsCycloneDx() {
+	if utils.GlobalFlags.ValidateFlags.CustomValidation && !document.FormatInfo.IsCycloneDx() {
 		err = schema.NewUnsupportedFormatError(
 			schema.MSG_FORMAT_UNSUPPORTED_COMMAND,
 			document.GetFilename(),
@@ -315,7 +315,7 @@ func Validate() (valid bool, document *schema.Sbom, schemaErrors []gojsonschema.
 
 	// Perform additional validation in document composition/structure
 	// and "custom" required data within specified fields
-	if utils.GlobalFlags.CustomValidation {
+	if utils.GlobalFlags.ValidateFlags.CustomValidation {
 		// Perform all custom validation
 		err := validateCustomCDXDocument(document)
 		if err != nil {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -89,13 +89,13 @@ func NewCommandValidate() *cobra.Command {
 	command.Short = "Validate input file against its declared BOM schema"
 	command.Long = "Validate input file against its declared BOM schema, if detectable and supported."
 	command.RunE = validateCmdImpl
-	command.Flags().StringVarP(&utils.GlobalFlags.OutputFormat, FLAG_FILE_OUTPUT_FORMAT, "", "",
+	command.Flags().StringVarP(&utils.GlobalFlags.PersistentFlags.OutputFormat, FLAG_FILE_OUTPUT_FORMAT, "", "",
 		MSG_VALIDATE_FLAG_ERR_FORMAT+VALIDATE_SUPPORTED_ERROR_FORMATS)
 
 	command.PreRunE = func(cmd *cobra.Command, args []string) error {
 
 		// This command can be called with this persistent flag, but does not make sense...
-		inputFile := utils.GlobalFlags.InputFile
+		inputFile := utils.GlobalFlags.PersistentFlags.InputFile
 		if inputFile != "" {
 			getLogger().Warningf("Invalid flag for command: `%s` (`%s`). Ignoring...", FLAG_FILENAME_OUTPUT, FLAG_FILENAME_OUTPUT_SHORT)
 		}
@@ -210,7 +210,8 @@ func Validate() (valid bool, document *schema.Sbom, schemaErrors []gojsonschema.
 	}
 
 	// Create a loader for the SBOM (JSON) document
-	documentLoader := gojsonschema.NewReferenceLoader(PROTOCOL_PREFIX_FILE + utils.GlobalFlags.InputFile)
+	inputFile := utils.GlobalFlags.PersistentFlags.InputFile
+	documentLoader := gojsonschema.NewReferenceLoader(PROTOCOL_PREFIX_FILE + inputFile)
 
 	schemaName := document.SchemaInfo.File
 	var schemaLoader gojsonschema.JSONLoader
@@ -298,7 +299,7 @@ func Validate() (valid bool, document *schema.Sbom, schemaErrors []gojsonschema.
 			schemaErrors)
 
 		// Format error results and append to InvalidSBOMError error "details"
-		format := utils.GlobalFlags.OutputFormat
+		format := utils.GlobalFlags.PersistentFlags.OutputFormat
 		errInvalid.Details = FormatSchemaErrors(schemaErrors, utils.GlobalFlags.ValidateFlags, format)
 
 		return INVALID, document, schemaErrors, errInvalid

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -297,23 +297,9 @@ func Validate() (valid bool, document *schema.Sbom, schemaErrors []gojsonschema.
 			nil,
 			schemaErrors)
 
-		// Format error results
+		// Format error results and append to InvalidSBOMError error "details"
 		format := utils.GlobalFlags.OutputFormat
-		var formattedSchemaErrors string
-		getLogger().Infof("Outputting error results (`%s` format)...\n", format)
-		switch format {
-		case FORMAT_JSON:
-			formattedSchemaErrors = FormatSchemaErrorsJson(schemaErrors, utils.GlobalFlags.ValidateFlags)
-		case FORMAT_TEXT:
-			formattedSchemaErrors = FormatSchemaErrorsText(schemaErrors, utils.GlobalFlags.ValidateFlags)
-		default:
-			getLogger().Warningf("error results not supported for `%s` format; defaulting to `%s` format...",
-				format, FORMAT_TEXT)
-			formattedSchemaErrors = FormatSchemaErrorsText(schemaErrors, utils.GlobalFlags.ValidateFlags)
-		}
-
-		// Append formatted schema errors "details" to the InvalidSBOMError type
-		errInvalid.Details = formattedSchemaErrors
+		errInvalid.Details = FormatSchemaErrors(schemaErrors, utils.GlobalFlags.ValidateFlags, format)
 
 		return INVALID, document, schemaErrors, errInvalid
 	}

--- a/cmd/validate_cdx_examples_test.go
+++ b/cmd/validate_cdx_examples_test.go
@@ -63,86 +63,86 @@ const (
 )
 
 func TestValidateExampleCdx14UseCaseAssembly(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_ASSEMBLY, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_ASSEMBLY, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCaseAuthenticityJsf(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_AUTHENTICITY_JSF, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_AUTHENTICITY_JSF, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCaseComponentKnownVulnerabilities(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_COMP_KNOWN_VULN, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_COMP_KNOWN_VULN, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCaseCompositionAndCompleteness(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_COMPOSITION_COMPLETENESS, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_COMPOSITION_COMPLETENESS, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCaseDependencyGraph(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_DEP_GRAPH, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_DEP_GRAPH, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCaseExternalReferences(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_EXT_REFS, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_EXT_REFS, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCaseIntegrityVerification(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_INTEGRITY_VERIFICATION, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_INTEGRITY_VERIFICATION, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCaseInventory(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_INVENTORY, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_INVENTORY, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCaseLicenseCompliance(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_LICENSE_COMPLIANCE, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_LICENSE_COMPLIANCE, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCaseOpenChainConformance(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_OPENCHAIN_CONFORMANCE, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_OPENCHAIN_CONFORMANCE, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCasePackageEvaluation(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_PKG_EVALUATION, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_PKG_EVALUATION, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCasePackagingDistribution(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_PKG_DIST, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_PKG_DIST, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCasePedigree(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_PEDIGREE, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_PEDIGREE, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCaseProvenance(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_PROVENANCE, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_PROVENANCE, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCaseSecurityAdvisories(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_SEC_ADVISORIES, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_SEC_ADVISORIES, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCaseServiceDefinition(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_SVC_DEFN, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_SVC_DEFN, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCaseVulnerabilityExploitation(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_VULN_EXPLOITATION, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_VULN_EXPLOITATION, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleCdx14UseCaseVulnerabilityRemediation(t *testing.T) {
-	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_VULN_REMEDIATION, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_EXAMPLE_CDX_1_4_USE_CASE_VULN_REMEDIATION, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 // CycloneDX - Examples
 func TestValidateExampleBomCdx12NpmJuiceShop(t *testing.T) {
-	innerValidateError(t, TEST_CDX_1_2_EXAMPLE_BOM_NPM_JUICE_SHOP, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_CDX_1_2_EXAMPLE_BOM_NPM_JUICE_SHOP, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleBomCdx13Laravel(t *testing.T) {
-	innerValidateError(t, TEST_CDX_1_3_EXAMPLE_BOM_LARAVEL, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_CDX_1_3_EXAMPLE_BOM_LARAVEL, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateExampleSaaSBomCdx14ApiGatewayDatastores(t *testing.T) {
-	innerValidateError(t, TEST_CDX_1_4_EXAMPLE_SAASBOM_APIGW_MS_DATASTORES, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_CDX_1_4_EXAMPLE_SAASBOM_APIGW_MS_DATASTORES, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }

--- a/cmd/validate_cdx_test.go
+++ b/cmd/validate_cdx_test.go
@@ -37,11 +37,11 @@ const (
 // -----------------------------------------------------------
 
 func TestValidateCdx13MinRequiredBasic(t *testing.T) {
-	innerValidateError(t, TEST_CDX_1_3_MIN_REQUIRED, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_CDX_1_3_MIN_REQUIRED, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateCdx14MinRequiredBasic(t *testing.T) {
-	innerValidateError(t, TEST_CDX_1_4_MIN_REQUIRED, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_CDX_1_4_MIN_REQUIRED, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 // -----------------------------------------------------------

--- a/cmd/validate_config_test.go
+++ b/cmd/validate_config_test.go
@@ -42,6 +42,7 @@ func TestValidateConfigInvalidFormatKey(t *testing.T) {
 	innerValidateError(t,
 		TEST_INVALID_FORMAT_KEY_FOO,
 		SCHEMA_VARIANT_NONE,
+		FORMAT_TEXT,
 		&schema.UnsupportedFormatError{})
 }
 
@@ -49,6 +50,7 @@ func TestValidateConfigInvalidVersion(t *testing.T) {
 	innerValidateError(t,
 		TEST_CDX_SPEC_VERSION_INVALID,
 		SCHEMA_VARIANT_NONE,
+		FORMAT_TEXT,
 		&schema.UnsupportedSchemaError{})
 }
 
@@ -56,6 +58,7 @@ func TestValidateConfigInvalidVariant(t *testing.T) {
 	innerValidateError(t,
 		TEST_CDX_1_4_MIN_REQUIRED,
 		"foo",
+		FORMAT_TEXT,
 		&schema.UnsupportedSchemaError{})
 }
 
@@ -63,6 +66,7 @@ func TestValidateConfigCDXBomFormatInvalid(t *testing.T) {
 	innerValidateError(t,
 		TEST_CDX_BOM_FORMAT_INVALID,
 		SCHEMA_VARIANT_NONE,
+		FORMAT_TEXT,
 		&schema.UnsupportedFormatError{})
 }
 
@@ -70,6 +74,7 @@ func TestValidateConfigCDXBomFormatMissing(t *testing.T) {
 	innerValidateError(t,
 		TEST_CDX_BOM_FORMAT_MISSING,
 		SCHEMA_VARIANT_NONE,
+		FORMAT_TEXT,
 		&schema.UnsupportedFormatError{})
 }
 
@@ -77,6 +82,7 @@ func TestValidateConfigCDXSpecVersionMissing(t *testing.T) {
 	innerValidateError(t,
 		TEST_CDX_SPEC_VERSION_MISSING,
 		SCHEMA_VARIANT_NONE,
+		FORMAT_TEXT,
 		&schema.UnsupportedSchemaError{})
 }
 
@@ -84,6 +90,7 @@ func TestValidateConfigSPDXSpdxIdInvalid(t *testing.T) {
 	innerValidateError(t,
 		TEST_SPDX_SPDX_ID_INVALID,
 		SCHEMA_VARIANT_NONE,
+		FORMAT_TEXT,
 		&schema.UnsupportedFormatError{})
 }
 
@@ -91,5 +98,6 @@ func TestValidateConfigSPDXSpdxVersionInvalid(t *testing.T) {
 	innerValidateError(t,
 		TEST_SPDX_SPDX_VERSION_MISSING,
 		SCHEMA_VARIANT_NONE,
+		FORMAT_TEXT,
 		&schema.UnsupportedSchemaError{})
 }

--- a/cmd/validate_custom_test.go
+++ b/cmd/validate_custom_test.go
@@ -58,7 +58,7 @@ const (
 
 func innerCustomValidateError(t *testing.T, filename string, variant string, innerError error) (document *schema.Sbom, schemaErrors []gojsonschema.ResultError, actualError error) {
 	utils.GlobalFlags.CustomValidation = true
-	document, schemaErrors, actualError = innerValidateError(t, filename, variant, innerError)
+	document, schemaErrors, actualError = innerValidateError(t, filename, variant, FORMAT_TEXT, innerError)
 	utils.GlobalFlags.CustomValidation = false
 	return
 }
@@ -103,6 +103,7 @@ func TestValidateCustomCdx14MetadataPropsMissingDisclaimer(t *testing.T) {
 	document, results, _ := innerValidateError(t,
 		TEST_CUSTOM_CDX_1_4_METADATA_PROPS_DISCLAIMER_MISSING,
 		SCHEMA_VARIANT_CUSTOM,
+		FORMAT_TEXT,
 		&InvalidSBOMError{})
 	getLogger().Debugf("filename: `%s`, results:\n%v", document.GetFilename(), results)
 }
@@ -111,6 +112,7 @@ func TestValidateCustomCdx14MetadataPropsMissingClassification(t *testing.T) {
 	document, results, _ := innerValidateError(t,
 		TEST_CUSTOM_CDX_1_4_METADATA_PROPS_CLASSIFICATION_MISSING,
 		SCHEMA_VARIANT_CUSTOM,
+		FORMAT_TEXT,
 		&InvalidSBOMError{})
 	getLogger().Debugf("filename: `%s`, results:\n%v", document.GetFilename(), results)
 }

--- a/cmd/validate_custom_test.go
+++ b/cmd/validate_custom_test.go
@@ -57,16 +57,16 @@ const (
 // -------------------------------------------
 
 func innerCustomValidateError(t *testing.T, filename string, variant string, innerError error) (document *schema.Sbom, schemaErrors []gojsonschema.ResultError, actualError error) {
-	utils.GlobalFlags.CustomValidation = true
+	utils.GlobalFlags.ValidateFlags.CustomValidation = true
 	document, schemaErrors, actualError = innerValidateError(t, filename, variant, FORMAT_TEXT, innerError)
-	utils.GlobalFlags.CustomValidation = false
+	utils.GlobalFlags.ValidateFlags.CustomValidation = false
 	return
 }
 
 func innerCustomValidateInvalidSBOMInnerError(t *testing.T, filename string, variant string, innerError error) (document *schema.Sbom, schemaErrors []gojsonschema.ResultError, actualError error) {
-	utils.GlobalFlags.CustomValidation = true
+	utils.GlobalFlags.ValidateFlags.CustomValidation = true
 	document, schemaErrors, actualError = innerValidateInvalidSBOMInnerError(t, filename, variant, innerError)
-	utils.GlobalFlags.CustomValidation = false
+	utils.GlobalFlags.ValidateFlags.CustomValidation = false
 	return
 }
 

--- a/cmd/validate_format.go
+++ b/cmd/validate_format.go
@@ -293,7 +293,7 @@ func FormatSchemaErrorsText(errs []gojsonschema.ResultError, flags utils.Validat
 			}
 
 			// append the numbered schema error
-			schemaErrorText := fmt.Sprintf("\n\t%d. \"%s\": \"%s\", \"%s\": [%s], \"%s\": [%s], \"%s\": [%s]",
+			schemaErrorText := fmt.Sprintf("\n\t%d. \"%s\": \"%s\",\n\t\t\"%s\": [%s],\n\t\t\"%s\": [%s],\n\t\t\"%s\": [%s]",
 				i+1,
 				ERROR_DETAIL_KEY_DATA_TYPE, resultError.Type(),
 				ERROR_DETAIL_KEY_FIELD, resultError.Field(),

--- a/cmd/validate_format.go
+++ b/cmd/validate_format.go
@@ -29,6 +29,7 @@ import (
 )
 
 const (
+	ERROR_DETAIL_KEY_VALUE            = "value"
 	ERROR_DETAIL_KEY_DATA_TYPE        = "type"
 	ERROR_DETAIL_KEY_VALUE_TYPE_ARRAY = "array"
 	ERROR_DETAIL_ARRAY_ITEM_INDEX_I   = "i"
@@ -36,7 +37,7 @@ const (
 )
 
 const (
-	ERROR_DETAIL_JSON_DEFAULT_PREFIX = "...."
+	ERROR_DETAIL_JSON_DEFAULT_PREFIX = "    "
 	ERROR_DETAIL_JSON_DEFAULT_INDENT = "    "
 )
 
@@ -67,7 +68,7 @@ func (result *ValidationResultFormat) Format(showValue bool, flags utils.Validat
 
 	// Conditionally, add optional values as requested
 	if showValue {
-		result.resultMap.Set("value", result.ResultError.Value())
+		result.resultMap.Set(ERROR_DETAIL_KEY_VALUE, result.ResultError.Value())
 	}
 
 	// TODO: add a general JSON formatting flag
@@ -140,7 +141,7 @@ func formatSchemaErrorTypes(resultError gojsonschema.ResultError, flags utils.Va
 
 	validationErrorResult := NewValidationErrResult(resultError)
 
-	switch resultError.(type) {
+	switch errorType := resultError.(type) {
 	// case *gojsonschema.AdditionalPropertyNotAllowedError:
 	// case *gojsonschema.ArrayContainsError:
 	// case *gojsonschema.ArrayMaxItemsError:
@@ -175,6 +176,7 @@ func formatSchemaErrorTypes(resultError gojsonschema.ResultError, flags utils.Va
 	// case *gojsonschema.StringLengthGTEError:
 	// case *gojsonschema.StringLengthLTEError:
 	default:
+		getLogger().Debugf("default formatting: ResultError Type: [%v]", errorType)
 		formattedResult = validationErrorResult.Format(true, flags)
 	}
 

--- a/cmd/validate_format.go
+++ b/cmd/validate_format.go
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+// "github.com/iancoleman/orderedmap"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/CycloneDX/sbom-utility/log"
+	"github.com/CycloneDX/sbom-utility/utils"
+	"github.com/iancoleman/orderedmap"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+type ValidationResultFormatter struct {
+	Results []ValidationResultFormat
+}
+
+// JsonContext is a linked-list of JSON key strings
+type ValidationResultFormat struct {
+	resultMap         *orderedmap.OrderedMap
+	ResultError       gojsonschema.ResultError
+	Context           *gojsonschema.JsonContext `json:"context"`           // jsonErrorMap["context"] = resultError.Context()
+	Type              string                    `json:"type"`              // jsonErrorMap["type"] = resultError.Type()
+	Field             string                    `json:"field"`             // details["field"] = err.Field()
+	Description       string                    `json:"description"`       // jsonErrorMap["description"] = resultError.Description()
+	DescriptionFormat string                    `json:"descriptionFormat"` // jsonErrorMap["descriptionFormat"] = resultError.DescriptionFormat()
+	Value             interface{}               `json:"value"`             // jsonErrorMap["value"] = resultError.Value()
+	Details           map[string]interface{}    `json:"details"`           // jsonErrorMap["details"] = resultError.Details()
+}
+
+func (validationErrResult *ValidationResultFormat) MarshalJSON() (marshalled []byte, err error) {
+	return validationErrResult.resultMap.MarshalJSON()
+}
+
+func (result *ValidationResultFormat) Format(showValue bool, flags utils.ValidateCommandFlags) string {
+
+	var sb strings.Builder
+
+	// Conditionally, add optional values as requested
+	if showValue {
+		result.resultMap.Set("value", result.ResultError.Value())
+	}
+
+	formattedResult, err := log.FormatInterfaceAsJson(result.resultMap)
+	if err != nil {
+		return fmt.Sprintf("formatting error: %s", err.Error())
+	}
+	sb.WriteString(formattedResult)
+
+	return sb.String()
+}
+
+func (result *ValidationResultFormat) FormatItemsMustBeUniqueError(showValue bool, flags utils.ValidateCommandFlags) string {
+
+	var sb strings.Builder
+
+	// Conditionally, add optional values as requested
+	if showValue {
+		result.resultMap.Set("value", result.ResultError.Value())
+	}
+
+	formattedResult, err := log.FormatInterfaceAsJson(result.resultMap)
+	if err != nil {
+		return fmt.Sprintf("formatting error: %s", err.Error())
+	}
+	sb.WriteString(formattedResult)
+
+	return sb.String()
+}
+
+func formatSchemaErrorTypes(resultError gojsonschema.ResultError, flags utils.ValidateCommandFlags) (formattedResult string) {
+
+	validationErrorResult := NewValidationErrResult(resultError)
+
+	switch resultError.(type) {
+	// case *gojsonschema.AdditionalPropertyNotAllowedError:
+	// case *gojsonschema.ArrayContainsError:
+	// case *gojsonschema.ArrayMaxItemsError:
+	// case *gojsonschema.ArrayMaxPropertiesError:
+	// case *gojsonschema.ArrayMinItemsError:
+	// case *gojsonschema.ArrayMinPropertiesError:
+	// case *gojsonschema.ArrayNoAdditionalItemsError:
+	// case *gojsonschema.ConditionElseError:
+	// case *gojsonschema.ConditionThenError:
+	// case *gojsonschema.ConstError:
+	// case *gojsonschema.DoesNotMatchFormatError:
+	// case *gojsonschema.DoesNotMatchPatternError:
+	// case *gojsonschema.EnumError:
+	// case *gojsonschema.FalseError:
+	// case *gojsonschema.InternalError:
+	// case *gojsonschema.InvalidPropertyNameError:
+	// case *gojsonschema.InvalidPropertyPatternError:
+	// case *gojsonschema.InvalidTypeError:
+	case *gojsonschema.ItemsMustBeUniqueError:
+		formattedResult = validationErrorResult.FormatItemsMustBeUniqueError(true, flags)
+	// case *gojsonschema.MissingDependencyError:
+	// case *gojsonschema.MultipleOfError:
+	// case *gojsonschema.NumberAllOfError:
+	// case *gojsonschema.NumberAnyOfError:
+	// case *gojsonschema.NumberGTEError:
+	// case *gojsonschema.NumberGTError:
+	// case *gojsonschema.NumberLTEError:
+	// case *gojsonschema.NumberLTError:
+	// case *gojsonschema.NumberNotError:
+	// case *gojsonschema.NumberOneOfError:
+	// case *gojsonschema.RequiredError:
+	// case *gojsonschema.StringLengthGTEError:
+	// case *gojsonschema.StringLengthLTEError:
+	default:
+		formattedResult = validationErrorResult.Format(true, flags)
+	}
+
+	return
+}
+
+func FormatSchemaErrorsJson(errs []gojsonschema.ResultError, flags utils.ValidateCommandFlags) string {
+	var sb strings.Builder
+
+	lenErrs := len(errs)
+	if lenErrs > 0 {
+		sb.WriteString(fmt.Sprintf("\n(%d) Schema errors detected (use `--debug` for more details):\n", lenErrs))
+		errLimit := flags.MaxNumErrors
+
+		// If we have more errors than the (default or user set) limit; notify user
+		if lenErrs > errLimit {
+			// notify users more errors exist
+			msg := fmt.Sprintf("Too many errors. Showing (%v/%v) errors.", errLimit, len(errs))
+			getLogger().Infof("%s", msg)
+		}
+
+		if lenErrs > 1 {
+			sb.WriteString("[\n")
+		}
+
+		for i, resultError := range errs {
+			// short-circuit if too many errors (i.e., using the error limit flag value)
+			if i > errLimit {
+				break
+			}
+
+			// add to the result errors
+			schemaErrorText := formatSchemaErrorTypes(resultError, flags)
+			sb.WriteString(schemaErrorText)
+
+			if i < (lenErrs-1) && i < (errLimit-1) {
+				sb.WriteString(",\n")
+			}
+		}
+
+		if lenErrs > 1 {
+			sb.WriteString("\n]")
+		}
+	}
+
+	return sb.String()
+}
+
+func FormatSchemaErrorsText(errs []gojsonschema.ResultError, flags utils.ValidateCommandFlags) string {
+	var sb strings.Builder
+
+	lenErrs := len(errs)
+	if lenErrs > 0 {
+		errLimit := utils.GlobalFlags.ValidateFlags.MaxNumErrors
+		colorize := utils.GlobalFlags.ValidateFlags.ColorizeErrorOutput
+		var formattedValue string
+		var description string
+		var failingObject string
+
+		sb.WriteString(fmt.Sprintf("\n(%d) Schema errors detected (use `--debug` for more details):", lenErrs))
+		for i, resultError := range errs {
+
+			// short-circuit if we have too many errors
+			if i == errLimit {
+				// notify users more errors exist
+				msg := fmt.Sprintf("Too many errors. Showing (%v/%v) errors.", i, len(errs))
+				getLogger().Infof("%s", msg)
+				// always include limit message in discrete output (i.e., not turned off by --quiet flag)
+				sb.WriteString("\n" + msg)
+				break
+			}
+
+			// Some descriptions include very long enums; in those cases,
+			// truncate to a reasonable length using an intelligent separator
+			description = resultError.Description()
+			// truncate output unless debug flag is used
+			if !utils.GlobalFlags.Debug &&
+				len(description) > DEFAULT_MAX_ERR_DESCRIPTION_LEN {
+				description, _, _ = strings.Cut(description, ":")
+				description = description + " ... (truncated)"
+			}
+
+			// TODO: provide flag to allow users to "turn on", by default we do NOT want this
+			// as this slows down processing on SBOMs with large numbers of errors
+			if colorize {
+				formattedValue, _ = log.FormatInterfaceAsColorizedJson(resultError.Value())
+			}
+			// Indent error detail output in logs
+			formattedValue = log.AddTabs(formattedValue)
+			// NOTE: if we do not colorize or indent we could simply do this:
+			failingObject = fmt.Sprintf("\n\tFailing object: [%v]", formattedValue)
+
+			// truncate output unless debug flag is used
+			if !utils.GlobalFlags.Debug &&
+				len(failingObject) > DEFAULT_MAX_ERR_DESCRIPTION_LEN {
+				failingObject = failingObject[:DEFAULT_MAX_ERR_DESCRIPTION_LEN]
+				failingObject = failingObject + " ... (truncated)"
+			}
+
+			// append the numbered schema error
+			schemaErrorText := fmt.Sprintf("\n\t%d. Type: [%s], Field: [%s], Description: [%s] %s",
+				i+1,
+				resultError.Type(),
+				resultError.Field(),
+				description,
+				failingObject)
+
+			sb.WriteString(schemaErrorText)
+		}
+	}
+	return sb.String()
+}

--- a/cmd/validate_format.go
+++ b/cmd/validate_format.go
@@ -293,7 +293,7 @@ func FormatSchemaErrorsText(errs []gojsonschema.ResultError, flags utils.Validat
 			}
 
 			// append the numbered schema error
-			schemaErrorText := fmt.Sprintf("\n\t%d. \"%s\": [%s], \"%s\": [%s], \"%s\": [%s], \"%s\": [%s]",
+			schemaErrorText := fmt.Sprintf("\n\t%d. \"%s\": \"%s\", \"%s\": [%s], \"%s\": [%s], \"%s\": [%s]",
 				i+1,
 				ERROR_DETAIL_KEY_DATA_TYPE, resultError.Type(),
 				ERROR_DETAIL_KEY_FIELD, resultError.Field(),

--- a/cmd/validate_format.go
+++ b/cmd/validate_format.go
@@ -50,12 +50,6 @@ type ValidationResultFormat struct {
 	resultMap   *orderedmap.OrderedMap
 	ResultError gojsonschema.ResultError
 	Context     *gojsonschema.JsonContext `json:"context"` // jsonErrorMap["context"] = resultError.Context()
-	//Type              string                    `json:"type"`              // jsonErrorMap["type"] = resultError.Type()
-	//Field             string                    `json:"field"`             // details["field"] = err.Field()
-	//Description       string                    `json:"description"`       // jsonErrorMap["description"] = resultError.Description()
-	//DescriptionFormat string                    `json:"descriptionFormat"` // jsonErrorMap["descriptionFormat"] = resultError.DescriptionFormat()
-	//Value             interface{}               `json:"value"`             // jsonErrorMap["value"] = resultError.Value()
-	//Details           map[string]interface{}    `json:"details"`           // jsonErrorMap["details"] = resultError.Details()
 }
 
 func (validationErrResult *ValidationResultFormat) MarshalJSON() (marshalled []byte, err error) {
@@ -256,7 +250,7 @@ func FormatSchemaErrorsText(errs []gojsonschema.ResultError, flags utils.Validat
 			// truncate to a reasonable length using an intelligent separator
 			description = resultError.Description()
 			// truncate output unless debug flag is used
-			if !utils.GlobalFlags.Debug &&
+			if !utils.GlobalFlags.PersistentFlags.Debug &&
 				len(description) > DEFAULT_MAX_ERR_DESCRIPTION_LEN {
 				description, _, _ = strings.Cut(description, ":")
 				description = description + " ... (truncated)"
@@ -273,7 +267,7 @@ func FormatSchemaErrorsText(errs []gojsonschema.ResultError, flags utils.Validat
 			failingObject = fmt.Sprintf("\n\tFailing object: [%v]", formattedValue)
 
 			// truncate output unless debug flag is used
-			if !utils.GlobalFlags.Debug &&
+			if !utils.GlobalFlags.PersistentFlags.Debug &&
 				len(failingObject) > DEFAULT_MAX_ERR_DESCRIPTION_LEN {
 				failingObject = failingObject[:DEFAULT_MAX_ERR_DESCRIPTION_LEN]
 				failingObject = failingObject + " ... (truncated)"

--- a/cmd/validate_format.go
+++ b/cmd/validate_format.go
@@ -215,7 +215,7 @@ func FormatSchemaErrorsJson(errs []gojsonschema.ResultError, flags utils.Validat
 			sb.WriteString(ERROR_DETAIL_JSON_DEFAULT_PREFIX)
 			sb.WriteString(schemaErrorText)
 
-			if i < (lenErrs-1) && i < (errLimit-1) {
+			if i < (lenErrs-1) && i < (errLimit) {
 				sb.WriteString(",\n")
 			}
 		}

--- a/cmd/validate_format.go
+++ b/cmd/validate_format.go
@@ -72,15 +72,22 @@ func (result *ValidationResultFormat) FormatItemsMustBeUniqueError(showValue boo
 	var sb strings.Builder
 
 	// Conditionally, add optional values as requested
+	// For this error type, we want to reduce the information show to the end user.
+	// Originally, the entire array with duplicate items was show for EVERY occurrence;
+	// attempt to only show the failing item itself once (and only once)
+	// TODO: deduplication (planned) will also help shrink large error output
 	if showValue {
 		details := result.ResultError.Details()
 		valueType, typeFound := details["type"]
+		// verify the claimed type is an array
 		if typeFound && valueType == "array" {
 			index, indexFound := details["i"]
+			// if a claimed duplicate index is provided (we use the first "i" index not the 2nd "j" one)
 			if indexFound {
 				value := result.ResultError.Value()
 				array, arrayValid := value.([]interface{})
 				i, indexValid := index.(int)
+				// verify the claimed item index is within range
 				if arrayValid && indexValid && i < len(array) {
 					result.resultMap.Set("value", array[i])
 				}

--- a/cmd/validate_spdx_examples_test.go
+++ b/cmd/validate_spdx_examples_test.go
@@ -32,29 +32,29 @@ const (
 
 // SPDX - Examples
 func TestValidateSpdx22Example1(t *testing.T) {
-	innerValidateError(t, TEST_SPDX_2_2_EXAMPLE_1, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_SPDX_2_2_EXAMPLE_1, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateSPDX22Example2Bin(t *testing.T) {
-	innerValidateError(t, TEST_SPDX_2_2_EXAMPLE_2_BIN, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_SPDX_2_2_EXAMPLE_2_BIN, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateSPDX22Example2Src(t *testing.T) {
-	innerValidateError(t, TEST_SPDX_2_2_EXAMPLE_2_SRC, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_SPDX_2_2_EXAMPLE_2_SRC, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateSPDX22Example5Bin(t *testing.T) {
-	innerValidateError(t, TEST_SPDX_2_2_EXAMPLE_5_BIN, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_SPDX_2_2_EXAMPLE_5_BIN, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateSPDX22Example5Src(t *testing.T) {
-	innerValidateError(t, TEST_SPDX_2_2_EXAMPLE_5_SRC, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_SPDX_2_2_EXAMPLE_5_SRC, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateSPDX22Example6Lib(t *testing.T) {
-	innerValidateError(t, TEST_SPDX_2_2_EXAMPLE_6_LIB, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_SPDX_2_2_EXAMPLE_6_LIB, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 func TestValidateSPDX22Example6Src(t *testing.T) {
-	innerValidateError(t, TEST_SPDX_2_2_EXAMPLE_6_SRC, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_SPDX_2_2_EXAMPLE_6_SRC, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }

--- a/cmd/validate_spdx_test.go
+++ b/cmd/validate_spdx_test.go
@@ -41,7 +41,7 @@ const (
 // TODO: Need an SPDX 2.2.1 variant
 // TODO: Need an SPDX 2.2 "custom" variant
 func TestValidateSpdx22MinRequiredBasic(t *testing.T) {
-	innerValidateError(t, TEST_SPDX_2_2_MIN_REQUIRED, SCHEMA_VARIANT_NONE, nil)
+	innerValidateError(t, TEST_SPDX_2_2_MIN_REQUIRED, SCHEMA_VARIANT_NONE, FORMAT_TEXT, nil)
 }
 
 // -----------------------------------------------------------

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -56,7 +56,7 @@ func innerValidateError(t *testing.T, filename string, variant string, format st
 	// Copy the test filename to the command line flags where the code looks for it
 	utils.GlobalFlags.InputFile = filename
 	// Set the schema variant where the command line flag would
-	utils.GlobalFlags.Variant = variant
+	utils.GlobalFlags.ValidateFlags.SchemaVariant = variant
 	// Set the err result format
 	utils.GlobalFlags.OutputFormat = format
 

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -45,7 +45,8 @@ const (
 )
 
 const (
-	TEST_CDX_1_4_VALIDATE_ERR_COMPONENTS_UNIQUE = "test/validation/cdx-1-4-validate-err-components-unique-items-1.json"
+	TEST_CDX_1_4_VALIDATE_ERR_COMPONENTS_UNIQUE    = "test/validation/cdx-1-4-validate-err-components-unique-items-1.json"
+	TEST_CDX_1_4_VALIDATE_ERR_FORMAT_IRI_REFERENCE = "test/validation/cdx-1-4-validate-err-components-format-iri-reference.json"
 )
 
 // Tests basic validation and expected errors
@@ -273,10 +274,19 @@ func TestValidateForceCustomSchemaCdxSchemaOlder(t *testing.T) {
 // 		nil)
 // }
 
-func TestValidateCdx14ComponentsUniqueJsonResults(t *testing.T) {
+func TestValidateCdx14ErrorResultsUniqueComponentsJson(t *testing.T) {
 	//utils.GlobalFlags.ValidateFlags.ForcedJsonSchemaFile = TEST_SCHEMA_CDX_1_3_CUSTOM
 	innerValidateError(t,
 		TEST_CDX_1_4_VALIDATE_ERR_COMPONENTS_UNIQUE,
+		SCHEMA_VARIANT_NONE,
+		FORMAT_JSON,
+		&InvalidSBOMError{})
+}
+
+func TestValidateCdx14ErrorResultsFormatIriReferencesJson(t *testing.T) {
+	//utils.GlobalFlags.ValidateFlags.ForcedJsonSchemaFile = TEST_SCHEMA_CDX_1_3_CUSTOM
+	innerValidateError(t,
+		TEST_CDX_1_4_VALIDATE_ERR_FORMAT_IRI_REFERENCE,
 		SCHEMA_VARIANT_NONE,
 		FORMAT_JSON,
 		&InvalidSBOMError{})

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -44,8 +44,12 @@ const (
 	TEST_CDX_1_4_MATURITY_EXAMPLE_1_BASE = "test/cyclonedx/cdx-1-4-mature-example-1.json"
 )
 
+const (
+	TEST_CDX_1_4_VALIDATE_ERR_COMPONENTS_UNIQUE = "test/validation/cdx-1-4-validate-err-components-unique-items-1.json"
+)
+
 // Tests basic validation and expected errors
-func innerValidateError(t *testing.T, filename string, variant string, expectedError error) (document *schema.Sbom, schemaErrors []gojsonschema.ResultError, actualError error) {
+func innerValidateError(t *testing.T, filename string, variant string, format string, expectedError error) (document *schema.Sbom, schemaErrors []gojsonschema.ResultError, actualError error) {
 	getLogger().Enter()
 	defer getLogger().Exit()
 
@@ -53,6 +57,8 @@ func innerValidateError(t *testing.T, filename string, variant string, expectedE
 	utils.GlobalFlags.InputFile = filename
 	// Set the schema variant where the command line flag would
 	utils.GlobalFlags.Variant = variant
+	// Set the err result format
+	utils.GlobalFlags.OutputFormat = format
 
 	// Invoke the actual validate function
 	var isValid bool
@@ -93,7 +99,7 @@ func innerValidateInvalidSBOMInnerError(t *testing.T, filename string, variant s
 	getLogger().Enter()
 	defer getLogger().Exit()
 
-	document, schemaErrors, actualError = innerValidateError(t, filename, variant, &InvalidSBOMError{})
+	document, schemaErrors, actualError = innerValidateError(t, filename, variant, FORMAT_TEXT, &InvalidSBOMError{})
 
 	invalidSBOMError, ok := actualError.(*InvalidSBOMError)
 
@@ -109,7 +115,7 @@ func innerValidateInvalidSBOMInnerError(t *testing.T, filename string, variant s
 // It also tests that the syntax error occurred at the expected line number and character offset
 func innerValidateSyntaxError(t *testing.T, filename string, variant string, expectedLineNum int, expectedCharNum int) (document *schema.Sbom, actualError error) {
 
-	document, _, actualError = innerValidateError(t, filename, variant, &json.SyntaxError{})
+	document, _, actualError = innerValidateError(t, filename, variant, FORMAT_TEXT, &json.SyntaxError{})
 	syntaxError, ok := actualError.(*json.SyntaxError)
 
 	if !ok {
@@ -136,6 +142,7 @@ func innerTestSchemaErrorAndErrorResults(t *testing.T,
 	document, results, _ := innerValidateError(t,
 		filename,
 		variant,
+		FORMAT_TEXT,
 		&InvalidSBOMError{})
 	getLogger().Debugf("filename: `%s`, results:\n%v", document.GetFilename(), results)
 
@@ -160,6 +167,7 @@ func TestValidateInvalidInputFileLoad(t *testing.T) {
 	innerValidateError(t,
 		TEST_INPUT_FILE_NON_EXISTENT,
 		SCHEMA_VARIANT_NONE,
+		FORMAT_TEXT,
 		&fs.PathError{})
 }
 
@@ -197,6 +205,7 @@ func TestValidateForceCustomSchemaCdx13(t *testing.T) {
 	innerValidateError(t,
 		TEST_CDX_1_3_MATURITY_EXAMPLE_1_BASE,
 		SCHEMA_VARIANT_NONE,
+		FORMAT_TEXT,
 		nil)
 }
 
@@ -206,6 +215,7 @@ func TestValidateForceCustomSchemaCdx14(t *testing.T) {
 	innerValidateError(t,
 		TEST_CDX_1_4_MATURITY_EXAMPLE_1_BASE,
 		SCHEMA_VARIANT_NONE,
+		FORMAT_TEXT,
 		nil)
 }
 
@@ -215,6 +225,7 @@ func TestValidateForceCustomSchemaCdxSchemaOlder(t *testing.T) {
 	innerValidateError(t,
 		TEST_CDX_1_4_MATURITY_EXAMPLE_1_BASE,
 		SCHEMA_VARIANT_NONE,
+		FORMAT_TEXT,
 		nil)
 }
 
@@ -224,3 +235,12 @@ func TestValidateForceCustomSchemaCdxSchemaOlder(t *testing.T) {
 // 		SCHEMA_VARIANT_NONE,
 // 		nil)
 // }
+
+func TestValidateCdx14ComponentsUniqueJsonResults(t *testing.T) {
+	//utils.GlobalFlags.ValidateFlags.ForcedJsonSchemaFile = TEST_SCHEMA_CDX_1_3_CUSTOM
+	innerValidateError(t,
+		TEST_CDX_1_4_VALIDATE_ERR_COMPONENTS_UNIQUE,
+		SCHEMA_VARIANT_NONE,
+		FORMAT_JSON,
+		nil)
+}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -288,6 +288,25 @@ func TestValidateForceCustomSchemaCdxSchemaOlder(t *testing.T) {
 		nil)
 }
 
+// TODO: add additional checks on the buffered output
+func TestValidateCdx14ErrorResultsUniqueComponentsText(t *testing.T) {
+	innerValidateError(t,
+		TEST_CDX_1_4_VALIDATE_ERR_COMPONENTS_UNIQUE,
+		SCHEMA_VARIANT_NONE,
+		FORMAT_TEXT,
+		&InvalidSBOMError{})
+}
+
+// TODO: add additional checks on the buffered output
+func TestValidateCdx14ErrorResultsFormatIriReferencesText(t *testing.T) {
+	innerValidateError(t,
+		TEST_CDX_1_4_VALIDATE_ERR_FORMAT_IRI_REFERENCE,
+		SCHEMA_VARIANT_NONE,
+		FORMAT_TEXT,
+		&InvalidSBOMError{})
+}
+
+// TODO: add additional checks on the buffered output
 func TestValidateCdx14ErrorResultsUniqueComponentsJson(t *testing.T) {
 	innerValidateError(t,
 		TEST_CDX_1_4_VALIDATE_ERR_COMPONENTS_UNIQUE,
@@ -296,6 +315,7 @@ func TestValidateCdx14ErrorResultsUniqueComponentsJson(t *testing.T) {
 		&InvalidSBOMError{})
 }
 
+// TODO: add additional checks on the buffered output
 func TestValidateCdx14ErrorResultsFormatIriReferencesJson(t *testing.T) {
 	innerValidateError(t,
 		TEST_CDX_1_4_VALIDATE_ERR_FORMAT_IRI_REFERENCE,

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -55,11 +55,11 @@ func innerValidateError(t *testing.T, filename string, variant string, format st
 	defer getLogger().Exit()
 
 	// Copy the test filename to the command line flags where the code looks for it
-	utils.GlobalFlags.InputFile = filename
+	utils.GlobalFlags.PersistentFlags.InputFile = filename
+	// Set the err result format
+	utils.GlobalFlags.PersistentFlags.OutputFormat = format
 	// Set the schema variant where the command line flag would
 	utils.GlobalFlags.ValidateFlags.SchemaVariant = variant
-	// Set the err result format
-	utils.GlobalFlags.OutputFormat = format
 
 	// Invoke the actual validate function
 	var isValid bool

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -279,5 +279,5 @@ func TestValidateCdx14ComponentsUniqueJsonResults(t *testing.T) {
 		TEST_CDX_1_4_VALIDATE_ERR_COMPONENTS_UNIQUE,
 		SCHEMA_VARIANT_NONE,
 		FORMAT_JSON,
-		nil)
+		&InvalidSBOMError{})
 }

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -63,7 +63,8 @@ func innerValidateError(t *testing.T, filename string, variant string, format st
 
 	// Invoke the actual validate function
 	var isValid bool
-	isValid, document, schemaErrors, actualError = Validate()
+	//isValid, document, schemaErrors, actualError = Validate()
+	isValid, document, schemaErrors, actualError = Validate(utils.GlobalFlags.PersistentFlags, utils.GlobalFlags.ValidateFlags)
 
 	getLogger().Tracef("document: `%s`, isValid=`%t`, actualError=`%T`", document.GetFilename(), isValid, actualError)
 

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -308,18 +308,38 @@ func TestValidateCdx14ErrorResultsFormatIriReferencesText(t *testing.T) {
 
 // TODO: add additional checks on the buffered output
 func TestValidateCdx14ErrorResultsUniqueComponentsJson(t *testing.T) {
-	innerValidateError(t,
+	var EXPECTED_ERROR_NUM = 2
+	var EXPECTED_ERROR_CONTEXT = "(root).components"
+	_, schemaErrors, _ := innerValidateError(t,
 		TEST_CDX_1_4_VALIDATE_ERR_COMPONENTS_UNIQUE,
 		SCHEMA_VARIANT_NONE,
 		FORMAT_JSON,
 		&InvalidSBOMError{})
+
+	if len(schemaErrors) != EXPECTED_ERROR_NUM {
+		t.Errorf("invalid error count: expected `%v` schema errors; actual errors: `%v`)", EXPECTED_ERROR_NUM, len(schemaErrors))
+	}
+
+	if schemaErrors[0].Context().String() != EXPECTED_ERROR_CONTEXT {
+		t.Errorf("invalid schema error context: expected `%v`; actual: `%v`)", EXPECTED_ERROR_CONTEXT, schemaErrors[0].Context().String())
+	}
 }
 
 // TODO: add additional checks on the buffered output
 func TestValidateCdx14ErrorResultsFormatIriReferencesJson(t *testing.T) {
-	innerValidateError(t,
+	var EXPECTED_ERROR_NUM = 1
+	var EXPECTED_ERROR_CONTEXT = "(root).components.2.externalReferences.0.url"
+	_, schemaErrors, _ := innerValidateError(t,
 		TEST_CDX_1_4_VALIDATE_ERR_FORMAT_IRI_REFERENCE,
 		SCHEMA_VARIANT_NONE,
 		FORMAT_JSON,
 		&InvalidSBOMError{})
+
+	if len(schemaErrors) != EXPECTED_ERROR_NUM {
+		t.Errorf("invalid schema error count: expected `%v`; actual: `%v`)", EXPECTED_ERROR_NUM, len(schemaErrors))
+	}
+
+	if schemaErrors[0].Context().String() != EXPECTED_ERROR_CONTEXT {
+		t.Errorf("invalid schema error context: expected `%v`; actual: `%v`)", EXPECTED_ERROR_CONTEXT, schemaErrors[0].Context().String())
+	}
 }

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -157,6 +157,43 @@ func innerTestSchemaErrorAndErrorResults(t *testing.T,
 	}
 }
 
+func schemaErrorExists(schemaErrors []gojsonschema.ResultError,
+	expectedType string, expectedField string, expectedValue interface{}) bool {
+
+	for i, resultError := range schemaErrors {
+		// Some descriptions include very long enums; in those cases,
+		// truncate to a reasonable length using an intelligent separator
+		getLogger().Tracef(">> %d. Type: [%s], Field: [%s], Value: [%v]",
+			i+1,
+			resultError.Type(),
+			resultError.Field(),
+			resultError.Value())
+
+		actualType := resultError.Type()
+		actualField := resultError.Field()
+		actualValue := resultError.Value()
+
+		if actualType == expectedType {
+			// we have matched on the type (key) field, continue to match other fields
+			if expectedField != "" &&
+				actualField != expectedField {
+				getLogger().Tracef("expected Field: `%s`; actual Field: `%s`", expectedField, actualField)
+				return false
+			}
+
+			if expectedValue != "" &&
+				actualValue != expectedValue {
+				getLogger().Tracef("expected Value: `%s`; actual Value: `%s`", actualValue, expectedValue)
+				return false
+			}
+			return true
+		} else {
+			getLogger().Debugf("Skipping result[%d]: expected Type: `%s`; actual Type: `%s`", i, expectedType, actualType)
+		}
+	}
+	return false
+}
+
 // -----------------------------------------------------------
 // Command tests
 // -----------------------------------------------------------

--- a/cmd/vulnerability.go
+++ b/cmd/vulnerability.go
@@ -136,7 +136,7 @@ func NewCommandVulnerability() *cobra.Command {
 	command.Use = CMD_USAGE_VULNERABILITY_LIST
 	command.Short = "Report on vulnerabilities found in the BOM input file"
 	command.Long = "Report on vulnerabilities found in the BOM input file"
-	command.Flags().StringVarP(&utils.GlobalFlags.OutputFormat, FLAG_FILE_OUTPUT_FORMAT, "", FORMAT_TEXT,
+	command.Flags().StringVarP(&utils.GlobalFlags.PersistentFlags.OutputFormat, FLAG_FILE_OUTPUT_FORMAT, "", FORMAT_TEXT,
 		FLAG_VULNERABILITY_OUTPUT_FORMAT_HELP+VULNERABILITY_LIST_SUPPORTED_FORMATS)
 	command.Flags().StringP(FLAG_REPORT_WHERE, "", "", FLAG_REPORT_WHERE_HELP)
 	command.Flags().BoolVarP(
@@ -176,7 +176,8 @@ func vulnerabilityCmdImpl(cmd *cobra.Command, args []string) (err error) {
 	defer getLogger().Exit()
 
 	// Create output writer
-	outputFile, writer, err := createOutputFile(utils.GlobalFlags.OutputFile)
+	outputFilename := utils.GlobalFlags.PersistentFlags.OutputFile
+	outputFile, writer, err := createOutputFile(outputFilename)
 	getLogger().Tracef("outputFile: `%v`; writer: `%v`", outputFile, writer)
 
 	// use function closure to assure consistent error output based upon error type
@@ -184,7 +185,7 @@ func vulnerabilityCmdImpl(cmd *cobra.Command, args []string) (err error) {
 		// always close the output file
 		if outputFile != nil {
 			err = outputFile.Close()
-			getLogger().Infof("Closed output file: `%s`", utils.GlobalFlags.OutputFile)
+			getLogger().Infof("Closed output file: `%s`", outputFilename)
 		}
 	}()
 
@@ -195,7 +196,7 @@ func vulnerabilityCmdImpl(cmd *cobra.Command, args []string) (err error) {
 		return
 	}
 
-	err = ListVulnerabilities(writer, utils.GlobalFlags.OutputFormat, whereFilters, utils.GlobalFlags.VulnerabilityFlags)
+	err = ListVulnerabilities(writer, utils.GlobalFlags.PersistentFlags.OutputFormat, whereFilters, utils.GlobalFlags.VulnerabilityFlags)
 
 	return
 }

--- a/cmd/vulnerability_test.go
+++ b/cmd/vulnerability_test.go
@@ -88,7 +88,7 @@ func innerTestVulnList(t *testing.T, testInfo *VulnTestInfo, flags utils.Vulnera
 	}
 
 	// The command looks for the input filename in global flags struct
-	utils.GlobalFlags.InputFile = testInfo.InputFile
+	utils.GlobalFlags.PersistentFlags.InputFile = testInfo.InputFile
 
 	// invoke list command with a byte buffer
 	outputBuffer, err = innerBufferedTestVulnList(t, testInfo, whereFilters, flags)

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/fatih/color v1.15.0
 	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f
+	github.com/iancoleman/orderedmap v0.2.0
 	github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6
 	github.com/mrutkows/go-jsondiff v0.2.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfkj3CTRcShK0KOL/w6iTiKyqqBA9a41Wnggw8=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
+github.com/iancoleman/orderedmap v0.2.0 h1:sq1N/TFpYH++aViPcaKjys3bDClUEU7s5B+z6jq8pNA=
+github.com/iancoleman/orderedmap v0.2.0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jwangsadinata/go-multimap v0.0.0-20190620162914-c29f3d7f33b6 h1:OzCtZaD1uI5Fc1C+4oNAp7kZ4ibh5OIgxI29moH/IbE=

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mrutkows/go-jsondiff v0.2.0 h1:T+05e1QSe7qB6vhkVtv3NImD3ni+Jdxpj69iMsptAqY=
 github.com/mrutkows/go-jsondiff v0.2.0/go.mod h1:TuasE0Ldrf4r1Gp0uIatS9SnPZPYybjmTGjB7WXKWl4=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/log/format.go
+++ b/log/format.go
@@ -172,7 +172,6 @@ func FormatIndentedInterfaceAsColorizedJson(data interface{}, indent int, newlin
 	return string(bytes), nil
 }
 
-// TODO: make indent length configurable
 func FormatIndentedInterfaceAsJson(data interface{}, prefix string, indent string) (string, error) {
 	bytes, err := json.MarshalIndent(data, prefix, indent)
 	if err != nil {
@@ -181,6 +180,8 @@ func FormatIndentedInterfaceAsJson(data interface{}, prefix string, indent strin
 	return string(bytes), nil
 }
 
+// NOTE: hardcodes indent length
+// TODO: make configurable as a formatter field/value
 func FormatInterfaceAsJson(data interface{}) (string, error) {
 	bytes, err := json.MarshalIndent(data, "", "    ")
 	if err != nil {

--- a/log/format.go
+++ b/log/format.go
@@ -161,9 +161,10 @@ func FormatInterfaceAsColorizedJson(data interface{}) (string, error) {
 	return string(bytes), nil
 }
 
-func FormatIndentedInterfaceAsColorizedJson(data interface{}, indent int) (string, error) {
+func FormatIndentedInterfaceAsColorizedJson(data interface{}, indent int, newline string) (string, error) {
 	formatter := prettyjson.NewFormatter()
 	formatter.Indent = indent
+	formatter.Newline = newline
 	bytes, err := formatter.Marshal(data)
 	if err != nil {
 		return "", err

--- a/log/format.go
+++ b/log/format.go
@@ -162,6 +162,14 @@ func FormatInterfaceAsColorizedJson(data interface{}) (string, error) {
 }
 
 // TODO: make indent length configurable
+func FormatIndentedInterfaceAsJson(data interface{}, prefix string, indent string) (string, error) {
+	bytes, err := json.MarshalIndent(data, prefix, indent)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
 func FormatInterfaceAsJson(data interface{}) (string, error) {
 	bytes, err := json.MarshalIndent(data, "", "    ")
 	if err != nil {

--- a/log/format.go
+++ b/log/format.go
@@ -161,6 +161,16 @@ func FormatInterfaceAsColorizedJson(data interface{}) (string, error) {
 	return string(bytes), nil
 }
 
+func FormatIndentedInterfaceAsColorizedJson(data interface{}, indent int) (string, error) {
+	formatter := prettyjson.NewFormatter()
+	formatter.Indent = indent
+	bytes, err := formatter.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
 // TODO: make indent length configurable
 func FormatIndentedInterfaceAsJson(data interface{}, prefix string, indent string) (string, error) {
 	bytes, err := json.MarshalIndent(data, prefix, indent)

--- a/schema/schema_formats.go
+++ b/schema/schema_formats.go
@@ -416,7 +416,7 @@ func (sbom *Sbom) FindFormatAndSchema() (err error) {
 
 			// Copy format info into Sbom context
 			sbom.FormatInfo = format
-			err = sbom.findSchemaVersionWithVariant(format, version, utils.GlobalFlags.Variant)
+			err = sbom.findSchemaVersionWithVariant(format, version, utils.GlobalFlags.ValidateFlags.SchemaVariant)
 			return
 		}
 	}
@@ -444,9 +444,9 @@ func (sbom *Sbom) findSchemaVersionWithVariant(format FormatSchema, version stri
 
 			// If a variant is also requested, see if we can find one for that criteria
 			// Note: the default value for "variant" is an empty string
-			if utils.GlobalFlags.Variant == schema.Variant {
+			if utils.GlobalFlags.ValidateFlags.SchemaVariant == schema.Variant {
 				getLogger().Tracef("Match found for requested schema variant: `%s`",
-					FormatSchemaVariant(utils.GlobalFlags.Variant))
+					FormatSchemaVariant(utils.GlobalFlags.ValidateFlags.SchemaVariant))
 				sbom.SchemaInfo = schema
 				return
 			}

--- a/schema/schema_formats.go
+++ b/schema/schema_formats.go
@@ -401,7 +401,7 @@ func (sbom *Sbom) UnmarshalCDXSbom() (err error) {
 	return
 }
 
-func (sbom *Sbom) FindFormatAndSchema() (err error) {
+func (sbom *Sbom) FindFormatAndSchema(sbomFilename string) (err error) {
 	getLogger().Enter()
 	defer getLogger().Exit()
 
@@ -422,7 +422,7 @@ func (sbom *Sbom) FindFormatAndSchema() (err error) {
 	}
 
 	// if we reach here, we did not find the format in our configuration (list)
-	err = NewUnknownFormatError(utils.GlobalFlags.InputFile)
+	err = NewUnknownFormatError(sbomFilename)
 	return
 }
 

--- a/test/validation/cdx-1-4-validate-err-components-format-iri-reference.json
+++ b/test/validation/cdx-1-4-validate-err-components-format-iri-reference.json
@@ -102,27 +102,40 @@
   },
   "components": [
     {
-      "type": "library",
-      "bom-ref": "pkg:npm/sample@2.0.0",
-      "purl": "pkg:npm/sample@2.0.0",
-      "name": "sample",
-      "version": "2.0.0",
-      "description": "Node.js Sampler package",
-      "licenses": [
+      "type": "operating-system",
+      "name": "debian",
+      "version": "10",
+      "description": "Debian GNU/Linux 10 (buster)",
+      "externalReferences": [
         {
-          "license": {
-            "id": "MIT"
-          }
+          "url": "https://www.debian.org/",
+          "type": "website"
+        },
+        {
+          "url": "https://www.debian.org/support",
+          "type": "other",
+          "comment": "support"
         }
       ]
     },
     {
       "type": "library",
-      "bom-ref": "pkg:npm/body-parser@1.19.0",
-      "purl": "pkg:npm/body-parser@1.19.0",
-      "name": "body-parser",
-      "version": "1.19.0",
-      "description": "Node.js body parsing middleware",
+      "bom-ref": "pkg:empty",
+      "name": "Empty",
+      "externalReferences": [
+        {
+          "url": "",
+          "type": "build-meta"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/asn1.js@5.4.1?package-id=e24b6ffc41aa39e5",
+      "author": "Fedor Indutny",
+      "name": "asn1.js",
+      "version": "5.4.1",
+      "description": "ASN.1 encoder and decoder",
       "licenses": [
         {
           "license": {
@@ -130,57 +143,15 @@
           }
         }
       ],
-      "hashes": [
+      "purl": "pkg:npm/asn1.js@5.4.1",
+      "externalReferences": [
         {
-          "alg": "SHA-1",
-          "content": "96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:npm/body-parser@1.19.0",
-      "purl": "pkg:npm/body-parser@1.19.0",
-      "name": "body-parser",
-      "version": "1.19.0",
-      "description": "Node.js body parsing middleware",
-      "licenses": [
+          "url": "git@github.com:indutny/asn1.js",
+          "type": "distribution"
+        },
         {
-          "license": {
-            "id": "MIT"
-          }
-        }
-      ],
-      "hashes": [
-        {
-          "alg": "SHA-1",
-          "content": "96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "body-parser",
-      "version": "1.20.0"
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:npm/body-parser@1.19.0",
-      "purl": "pkg:npm/body-parser@1.19.0",
-      "name": "body-parser",
-      "version": "1.19.0",
-      "description": "Node.js body parsing middleware",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT"
-          }
-        }
-      ],
-      "hashes": [
-        {
-          "alg": "SHA-1",
-          "content": "96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
+          "url": "https://github.com/indutny/asn1.js",
+          "type": "website"
         }
       ]
     }

--- a/test/validation/cdx-1-4-validate-err-components-unique-items-1.json
+++ b/test/validation/cdx-1-4-validate-err-components-unique-items-1.json
@@ -1,0 +1,228 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1,
+  "serialNumber": "urn:uuid:1a2b3c4d-1234-abcd-9876-a3b4c5d6e7f9",
+  "externalReferences": [
+    {
+      "url": "support@example.com",
+      "comment": "Support for questions about SBOM contents",
+      "type": "support"
+    }
+  ],
+  "metadata": {
+    "timestamp": "2022-10-12T19:07:00Z",
+    "properties": [
+      {
+        "name": "urn:example.com:classification",
+        "value": "This SBOM is Confidential Information. Do not distribute."
+      },
+      {
+        "name": "urn:example.com:disclaimer",
+        "value": "This SBOM is current as of the date it was generated and is subject to change."
+      }
+    ],
+    "manufacture": {
+      "name": "Example Co.",
+      "url": [
+        "https://example.com"
+      ],
+      "contact": [
+        {
+          "email": "contact@example.com"
+        }
+      ]
+    },
+    "supplier": {
+      "name": "Example Co. Distribution Dept.",
+      "url": [
+        "https://example.com/software/"
+      ],
+      "contact": [
+        {
+          "email": "distribution@example.com"
+        }
+      ]
+    },
+    "component": {
+      "type": "application",
+      "bom-ref": "pkg:oci/example.com/product/application@10.0.4.0",
+      "purl": "pkg:oci/example.com/product/application@10.0.4.0",
+      "name": "Example Application v10.0.4",
+      "description": "Example's Do-It-All application",
+      "version": "10.0.4.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "externalReferences": [
+        {
+          "type": "website",
+          "url": "https://example.com/application"
+        }
+      ],
+      "properties": [
+        {
+          "name": "urn:example.com:identifier:product",
+          "value": "71C22290D7DB11EBAA175CFD3E629A2A"
+        },
+        {
+          "name": "urn:example.com:identifier:distribution",
+          "value": "5737-I23"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "1111aaaa2222cccc3333dddd4444eeee5555ffff"
+        }
+      ],
+      "supplier": {
+        "name": "Example Co. Distribution Dept.",
+        "url": [
+          "https://example.com"
+        ],
+        "contact": [
+          {
+            "email": "distribution@example.com"
+          }
+        ]
+      },
+      "publisher": "Example Inc. EMEA"
+    },
+    "licenses": [
+      {
+        "license": {
+          "id": "Apache-1.0"
+        }
+      },
+      {
+        "license": {
+          "id": "Apache-2.0"
+        }
+      },
+      {
+        "license": {
+          "id": "GPL-3.0-only"
+        }
+      },
+      {
+        "license": {
+          "id": "MIT"
+        }
+      }
+    ],
+    "tools": [
+      {
+        "vendor": "SecurityTools.com",
+        "name": "Security Scanner v1.0",
+        "version": "1.0.0-beta.1+0099",
+        "hashes": [
+          {
+            "alg": "SHA-1",
+            "content": "96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
+          }
+        ]
+      },
+      {
+        "vendor": "SBOM.com",
+        "name": "SBOM Generator v2.1",
+        "version": "2.1.12",
+        "hashes": [
+          {
+            "alg": "SHA-1",
+            "content": "96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
+          }
+        ]
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/sample@2.0.0",
+      "purl": "pkg:npm/sample@2.0.0",
+      "name": "sample",
+      "version": "2.0.0",
+      "description": "Node.js Sampler package",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/body-parser@1.19.0",
+      "purl": "pkg:npm/body-parser@1.19.0",
+      "name": "body-parser",
+      "version": "1.19.0",
+      "description": "Node.js body parsing middleware",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/body-parser@1.19.0",
+      "purl": "pkg:npm/body-parser@1.19.0",
+      "name": "body-parser",
+      "version": "1.19.0",
+      "description": "Node.js body parsing middleware",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "body-parser",
+      "version": "1.20.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "pkg:npm/body-parser@1.19.0",
+      "purl": "pkg:npm/body-parser@1.19.0",
+      "name": "body-parser",
+      "version": "1.19.0",
+      "description": "Node.js body parsing middleware",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-1",
+          "content": "96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
+        }
+      ]
+    }
+  ]
+}

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -57,10 +57,8 @@ type CommandFlags struct {
 	VulnerabilityFlags VulnerabilityCommandFlags
 
 	// Validate (local) flags
-	Variant                 string
 	ValidateProperties      bool
 	ValidateFlags           ValidateCommandFlags
-	CustomValidation        bool
 	CustomValidationOptions CustomValidationFlags
 
 	// Summary formats (i.e., only valid for summary)
@@ -83,7 +81,11 @@ type LicenseCommandFlags struct {
 }
 
 type ValidateCommandFlags struct {
-	ForcedJsonSchemaFile      string
+	SchemaVariant        string
+	ForcedJsonSchemaFile string
+	// Uses custom validation flags if "true"; defaults to config. "custom.json"
+	CustomValidation bool
+	// error result processing
 	MaxNumErrors              int
 	MaxErrorDescriptionLength int
 	ColorizeErrorOutput       bool

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -86,7 +86,9 @@ type ValidateCommandFlags struct {
 	ForcedJsonSchemaFile      string
 	MaxNumErrors              int
 	MaxErrorDescriptionLength int
-	ColorizeJsonErrors        bool
+	ColorizeErrorOutput       bool
+	ShowErrorValue            bool
+	ShowErrorDetail           bool
 }
 
 type VulnerabilityCommandFlags struct {

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -61,15 +61,12 @@ type CommandFlags struct {
 
 // NOTE: These flags are shared by both the list and policy subcommands
 type PersistentCommandFlags struct {
-	Quiet            bool // suppresses all non-essential (informational) output from a command. Overrides any other log-level commands.
-	Trace            bool // trace logging
-	Debug            bool // debug logging
-	InputFile        string
-	OutputFile       string // Note: not used by `validate` command, which emits a warning if supplied
-	OutputSbomFormat string
-	// Summary formats (i.e., only valid for summary)
-	// NOTE: "query" and "list" (raw) commands always returns JSON by default
-	OutputFormat string // e.g., TXT (default), CSV, markdown (normalized to lowercase)
+	Quiet        bool // suppresses all non-essential (informational) output from a command. Overrides any other log-level commands.
+	Trace        bool // trace logging
+	Debug        bool // debug logging
+	InputFile    string
+	OutputFile   string // TODO: TODO: Note: not used by `validate` command, which emits a warning if supplied
+	OutputFormat string // e.g., "txt", "csv"", "md" (markdown) (normalized to lowercase)
 }
 
 type DiffCommandFlags struct {
@@ -92,7 +89,6 @@ type ValidateCommandFlags struct {
 	MaxErrorDescriptionLength int
 	ColorizeErrorOutput       bool
 	ShowErrorValue            bool
-	ShowErrorDetail           bool
 }
 
 type VulnerabilityCommandFlags struct {

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -40,12 +40,7 @@ type CommandFlags struct {
 	ConfigLicensePolicyFile    string
 
 	// persistent flags (common to all commands)
-	Quiet            bool // suppresses all non-essential (informational) output from a command. Overrides any other log-level commands.
-	Trace            bool // trace logging
-	Debug            bool // debug logging
-	InputFile        string
-	OutputFile       string // Note: not used by `validate` command, which emits a warning if supplied
-	OutputSbomFormat string
+	PersistentFlags PersistentCommandFlags
 
 	// Diff flags
 	DiffFlags DiffCommandFlags
@@ -57,19 +52,26 @@ type CommandFlags struct {
 	VulnerabilityFlags VulnerabilityCommandFlags
 
 	// Validate (local) flags
-	ValidateProperties      bool
 	ValidateFlags           ValidateCommandFlags
 	CustomValidationOptions CustomValidationFlags
-
-	// Summary formats (i.e., only valid for summary)
-	// NOTE: "query" and "list" (raw) commands always returns JSON by default
-	OutputFormat string // e.g., TXT (default), CSV, markdown (normalized to lowercase)
 
 	// Log indent
 	LogOutputIndentCallstack bool
 }
 
 // NOTE: These flags are shared by both the list and policy subcommands
+type PersistentCommandFlags struct {
+	Quiet            bool // suppresses all non-essential (informational) output from a command. Overrides any other log-level commands.
+	Trace            bool // trace logging
+	Debug            bool // debug logging
+	InputFile        string
+	OutputFile       string // Note: not used by `validate` command, which emits a warning if supplied
+	OutputSbomFormat string
+	// Summary formats (i.e., only valid for summary)
+	// NOTE: "query" and "list" (raw) commands always returns JSON by default
+	OutputFormat string // e.g., TXT (default), CSV, markdown (normalized to lowercase)
+}
+
 type DiffCommandFlags struct {
 	Colorize    bool
 	RevisedFile string


### PR DESCRIPTION
Provides requested JSON format for issue/fixes: https://github.com/CycloneDX/sbom-utility/issues/36
and goes beyond that preparing for customized error handlers to better format verbose errors (and lay the foundation for de-duplication) which is part of this issue: https://github.com/CycloneDX/sbom-utility/issues/37