### PR TITLE
Minor update to SPDX 2.3.1-dvelopment JSON scheam which added a `$schema` meta-tag

### DIFF
--- a/resources/schema/spdx/2.3.1/spdx-schema.json
+++ b/resources/schema/spdx/2.3.1/spdx-schema.json
@@ -4,6 +4,10 @@
   "title" : "SPDX 2.3",
   "type" : "object",
   "properties" : {
+    "$schema": {
+      "type": "string",
+      "description": "Reference the SPDX 2.3 JSON schema."
+    },
     "SPDXID" : {
       "type" : "string",
       "description" : "Uniquely identify any element in an SPDX document which may be referenced by other elements."

--- a/resources/schema/spdx/README.md
+++ b/resources/schema/spdx/README.md
@@ -26,6 +26,8 @@ Supported schemas by release (tag):
 | release tag | branch | schema file (git format) |
 | :-- | :-- | :-- |
 | [v2.2.1](https://github.com/spdx/spdx-spec/releases/tag/v2.2.1) | https://github.com/spdx/spdx-spec/tree/v2.2.1 | https://github.com/spdx/spdx-spec/blob/v2.2.1/schemas/spdx-schema.json |
+| [v2.3](https://github.com/spdx/spdx-spec/releases/tag/v2.3) | https://github.com/spdx/spdx-spec/tree/development/v2.3 | https://github.com/spdx/spdx-spec/blob/development/v2.3/schemas/spdx-schema.json |
+| v2.3.1 | https://github.com/spdx/spdx-spec/tree/development/v2.3.1 | https://github.com/spdx/spdx-spec/blob/development/v2.3.1/schemas/spdx-schema.json |
 
 Development branches:
 | branch | schema file (git format) |

--- a/resources/schema/spdx/README.md
+++ b/resources/schema/spdx/README.md
@@ -27,9 +27,10 @@ Supported schemas by release (tag):
 | :-- | :-- | :-- |
 | [v2.2.1](https://github.com/spdx/spdx-spec/releases/tag/v2.2.1) | https://github.com/spdx/spdx-spec/tree/v2.2.1 | https://github.com/spdx/spdx-spec/blob/v2.2.1/schemas/spdx-schema.json |
 | [v2.3](https://github.com/spdx/spdx-spec/releases/tag/v2.3) | https://github.com/spdx/spdx-spec/tree/development/v2.3 | https://github.com/spdx/spdx-spec/blob/development/v2.3/schemas/spdx-schema.json |
-| v2.3.1 | https://github.com/spdx/spdx-spec/tree/development/v2.3.1 | https://github.com/spdx/spdx-spec/blob/development/v2.3.1/schemas/spdx-schema.json |
+
 
 Development branches:
 | branch | schema file (git format) |
 | :-- | :-- |
 | [development/v2.2.2](https://github.com/spdx/spdx-spec/tree/development/v2.2.2) (default) | https://github.com/spdx/spdx-spec/blob/development/v2.2.2/schemas/spdx-schema.json |
+| v2.3.1 | https://github.com/spdx/spdx-spec/tree/development/v2.3.1 | https://github.com/spdx/spdx-spec/blob/development/v2.3.1/schemas/spdx-schema.json |

--- a/resources/schema/spdx/README.md
+++ b/resources/schema/spdx/README.md
@@ -32,5 +32,5 @@ Supported schemas by release (tag):
 Development branches:
 | branch | schema file (git format) |
 | :-- | :-- |
-| [development/v2.2.2](https://github.com/spdx/spdx-spec/tree/development/v2.2.2) (default) | https://github.com/spdx/spdx-spec/blob/development/v2.2.2/schemas/spdx-schema.json |
-| v2.3.1 | https://github.com/spdx/spdx-spec/tree/development/v2.3.1 | https://github.com/spdx/spdx-spec/blob/development/v2.3.1/schemas/spdx-schema.json |
+| [development/v2.2.2](https://github.com/spdx/spdx-spec/tree/development/v2.2.2) | https://github.com/spdx/spdx-spec/blob/development/v2.2.2/schemas/spdx-schema.json |
+| [development/v2.3.1](https://github.com/spdx/spdx-spec/tree/development/v2.3.1) | https://github.com/spdx/spdx-spec/blob/development/v2.3.1/schemas/spdx-schema.json |


### PR DESCRIPTION
Source: https://github.com/spdx/spdx-spec/blob/development/v2.3.1/schemas/spdx-schema.json

See the `$schema` object added:

```json
"title" : "SPDX 2.3",
"type" : "object",
"properties" : {
+    "$schema": {
+      "type": "string",
+      "description": "Reference the SPDX 2.3 JSON schema."
+    },
"SPDXID" : {
    "type" : "string",
```