### PR TITLE
Catch "diff" command panics within external library deps. and exit gracefully

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,16 +6,8 @@
     "configurations": [
 
         {
-            "name": "DebugServer",
-            "type": "go",
-            "request": "launch",
-            "mode": "debug",
-            "program": "${workspaceFolder}",
-            "dlvFlags": ["--check-go-version=false"]
-        },
-        {
             "showGlobalVariables": true,
-            "name": "Query: SELECT * FROM metadata.component",
+            "name": "Debug: query: SELECT * FROM metadata.component",
             "type": "go",
             "request": "launch",
             "mode": "debug",
@@ -25,12 +17,22 @@
         },
         {
             "showGlobalVariables": true,
-            "name": "Debug: license list --format csv",
+            "name": "Debug: license list",
             "type": "go",
             "request": "launch",
             "mode": "debug",
             "program": "main.go", // "program": "${file}",
-            "args": ["license", "list", "-i", "/Users/Matt_1/Downloads/acdx.json", "--format", "csv"],
+            "args": ["license", "list", "-i", "<filename>", "--format", "json"],
+            "dlvFlags": ["--check-go-version=false"]
+        },
+        {
+            "showGlobalVariables": true,
+            "name": "Debug: diff",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "main.go", // "program": "${file}",
+            "args": ["diff", "-i", "test/cyclonedx/cdx-1-4-mature-example-1.json", "--input-revision", "test/diff/cdx-1-4-mature-example-1-delta.json"],
             "dlvFlags": ["--check-go-version=false"]
         },
     ]


### PR DESCRIPTION
Attempted to provide some partial relief to the issue: https://github.com/CycloneDX/sbom-utility/issues/74
... despite not being able to submit a fix to the upstream library where the panic occurs.

Diff panics now exit with something that llke:

````
Welcome to the sbom-utility! Version `latest` (sbom-utility) (darwin/arm64)
===========================================================================
[INFO] Loading (embedded) default schema config file: `config.json`...
[INFO] Loading (embedded) default license policy file: `license.json`...
[INFO] Reading file (--input-file): `nats-box-49.sbom.json` ...
[INFO] Reading file (--input-revision): `nats-box-50.sbom.json` ...
[INFO] Comparing files: `nats-box-49.sbom.json` (base) to `nats-box-50.sbom.json` (revised) ...
panic occurred: runtime error: slice bounds out of range [2004:1743]
[ERROR] panic occurred: runtime error: slice bounds out of range [2004:1743]
[ERROR] diff failed: differences between files perhaps too large.
```