### PR TITLE
Update go-release-action to latest version and dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           - goos: windows
             goarch: s390x
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # Set build/link environment variables
     - name: Set APP_NAME env
@@ -53,7 +53,7 @@ jobs:
       run: cyclonedx-gomod mod -json=true -output ${{env.SBOM_NAME}}
 
     # Release binaries in all GOOS/GOARCH combinations (with all config. files)
-    - uses: wangyoucao577/go-release-action@v1.39
+    - uses: wangyoucao577/go-release-action@v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}


### PR DESCRIPTION
The build matrix is failing... attempting to correct by updating to latest go-release-action.  More may be needed in terms of go-setup action.