### PR TITLE
Fix parsing CycloneDX 1.6 declarations/definitions elements

### DIFF
--- a/schema/cyclonedx.go
+++ b/schema/cyclonedx.go
@@ -53,8 +53,8 @@ type CDXBom struct {
 	Annotations        *[]CDXAnnotation        `json:"annotations,omitempty" cdx:"added:1.5"`
 	Formulation        *[]CDXFormula           `json:"formulation,omitempty" cdx:"added:1.5"`
 	Properties         *[]CDXProperty          `json:"properties,omitempty" cdx:"added:1.5"`
-	Declarations       *[]CDXDeclaration       `json:"declarations,omitempty" cdx:"added:1.6"`
-	Definitions        *[]CDXDefinition        `json:"definitions,omitempty" cdx:"added:1.6"`
+	Declarations       *CDXDeclaration         `json:"declarations,omitempty" cdx:"added:1.6"`
+	Definitions        *CDXDefinition          `json:"definitions,omitempty" cdx:"added:1.6"`
 }
 
 // v1.2: existed


### PR DESCRIPTION
For example, this SBOM

```
{
  "bomFormat": "CycloneDX",
  "specVersion": "1.6",
  "components": [
    {
      "type": "library",
      "name": "somelib"
    }
  ],
  "definitions": {
    "standards": []
  }
}

```

passes `sbom-utility validate`, but if e.g. `sbom-utility component` fails with error `Error: json: cannot unmarshal object into Go struct field CDXBom.definitions of type []schema.CDXDefinition`.
