### PR TITLE
Log to stderr

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -104,7 +104,7 @@ func NewDefaultLogger() *MiniLogger {
 		tagEnter:        DEFAULT_ENTER_TAG,
 		tagExit:         DEFAULT_EXIT_TAG,
 		tagColor:        color.New(color.FgMagenta),
-		outputFile:      os.Stdout,
+		outputFile:      os.Stderr,
 		maxStrLength:    64,
 	}
 
@@ -361,7 +361,7 @@ func (log MiniLogger) dumpInterface(lvl Level, tag string, value interface{}, sk
 			}
 
 			// TODO: use a general output writer (set to stdout, stderr, or file stream)
-			fmt.Println(sb.String())
+			fmt.Fprintln(log.outputFile, sb.String())
 		} else {
 			os.Stderr.WriteString("Error: Unable to retrieve call stack. Exiting...")
 			os.Exit(-2)
@@ -370,7 +370,7 @@ func (log MiniLogger) dumpInterface(lvl Level, tag string, value interface{}, sk
 }
 
 func (log MiniLogger) DumpString(value string) {
-	fmt.Print(value)
+	fmt.Fprint(log.outputFile, value)
 }
 
 func (log MiniLogger) DumpStruct(structName string, field interface{}) error {
@@ -389,7 +389,7 @@ func (log MiniLogger) DumpStruct(structName string, field interface{}) error {
 	}
 
 	// TODO: print to output stream
-	fmt.Println(sb.String())
+	fmt.Fprintln(log.outputFile, sb.String())
 
 	return nil
 }
@@ -398,8 +398,8 @@ func (log MiniLogger) DumpArgs() {
 	args := os.Args
 	for i, a := range args {
 		// TODO: print to output stream
-		fmt.Print(log.indentRunes)
-		fmt.Printf("os.Arg[%d]: '%v'\n", i, a)
+		fmt.Fprint(log.outputFile, log.indentRunes)
+		fmt.Fprintf(log.outputFile, "os.Arg[%d]: '%v'\n", i, a)
 	}
 }
 
@@ -409,7 +409,7 @@ func (log MiniLogger) DumpSeparator(sep byte, repeat int) (string, error) {
 		for i := 0; i < repeat; i++ {
 			sb.WriteByte(sep)
 		}
-		fmt.Println(sb.String())
+		fmt.Fprintln(log.outputFile, sb.String())
 		return sb.String(), nil
 	} else {
 		return "", errors.New("invalid repeat length (>80)")
@@ -417,5 +417,5 @@ func (log MiniLogger) DumpSeparator(sep byte, repeat int) (string, error) {
 }
 
 func (log *MiniLogger) DumpStackTrace() {
-	fmt.Println(string(debug.Stack()))
+	fmt.Fprintln(log.outputFile, string(debug.Stack()))
 }


### PR DESCRIPTION
Make minilogger methods output to `outputFile` rather than stdout, and set `outputFile` to stderr.

Resolves #120 