### PR TITLE
Add PURL to license info report

### DIFF
--- a/cmd/license_list.go
+++ b/cmd/license_list.go
@@ -59,6 +59,7 @@ const (
 	LICENSE_FILTER_KEY_RESOURCE_NAME = "resource-name"
 	LICENSE_FILTER_KEY_BOM_REF       = "bom-ref"
 	LICENSE_FILTER_KEY_BOM_LOCATION  = "bom-location"
+	LICENSE_FILTER_KEY_PURL          = "purl"
 )
 
 // var LICENSE_LIST_TITLES_LICENSE_CHOICE = []string{"License.Id", "License.Name", "License.Url", "Expression", "License.Text.ContentType", "License.Text.Encoding", "License.Text.Content"}
@@ -86,6 +87,7 @@ var LICENSE_LIST_ROW_DATA = []ColumnFormatData{
 	*NewColumnFormatData(LICENSE_FILTER_KEY_LICENSE_TEXT_ENCODING, -1, false, false),
 	*NewColumnFormatData(LICENSE_FILTER_KEY_LICENSE_TEXT_CONTENT_TYPE, -1, false, false),
 	*NewColumnFormatData(LICENSE_FILTER_KEY_LICENSE_TEXT_CONTENT, 8, false, false),
+	*NewColumnFormatData(LICENSE_FILTER_KEY_PURL, REPORT_DO_NOT_TRUNCATE, false, false),
 }
 
 // Command help formatting

--- a/cmd/license_test.go
+++ b/cmd/license_test.go
@@ -35,6 +35,7 @@ const (
 	TEST_LICENSE_LIST_CDX_1_3_NONE_FOUND              = "test/cyclonedx/cdx-1-3-license-list-none-found.json"
 	TEST_LICENSE_LIST_CDX_1_4_NONE_FOUND              = "test/cyclonedx/cdx-1-4-license-list-none-found.json"
 	TEST_LICENSE_LIST_CDX_1_5_LICENSE_CHOICE_VARIANTS = "test/cyclonedx/cdx-1-5-license-choice-variants.json"
+	TEST_LICENSE_LIST_CDX_1_5_MATURE_EXAMPLE_1        = "test/cyclonedx/cdx-1-5-mature-example-1.json"
 
 	TEST_LICENSE_LIST_TEXT_CDX_1_4_INVALID_LICENSE_ID    = "test/cyclonedx/cdx-1-4-license-policy-invalid-spdx-id.json"
 	TEST_LICENSE_LIST_TEXT_CDX_1_4_INVALID_LICENSE_NAME  = "test/cyclonedx/cdx-1-4-license-policy-invalid-license-name.json"
@@ -335,6 +336,25 @@ func TestLicenseListSummaryTextCdx14LicenseExpInName(t *testing.T) {
 	lti.ResultLineContainsValuesAtLineNum = 3
 	lti.ResultExpectedLineCount = 5 // title and data rows
 	innerTestLicenseList(t, lti)
+}
+
+func TestLicenseListTextCdx15WherePURLTypeIsNPM(t *testing.T) {
+	lti1 := NewLicenseTestInfo(
+		TEST_LICENSE_LIST_CDX_1_5_MATURE_EXAMPLE_1,
+		FORMAT_TEXT, false)
+	lti1.ResultLineContainsValues = []string{"Apache-1.0"}
+	lti1.ResultLineContainsValuesAtLineNum = 2
+	lti1.ResultExpectedLineCount = 10 // title and data rows
+	innerTestLicenseList(t, lti1)
+
+	lti2 := NewLicenseTestInfo(
+		TEST_LICENSE_LIST_CDX_1_5_MATURE_EXAMPLE_1,
+		FORMAT_TEXT, false)
+	lti2.WhereClause = "purl=pkg.npm.*"
+	lti2.ResultLineContainsValues = []string{"MIT"}
+	lti2.ResultLineContainsValuesAtLineNum = 2
+	lti2.ResultExpectedLineCount = 5 // title and data rows
+	innerTestLicenseList(t, lti2)
 }
 
 // Test custom marshal of CDXLicense (empty CDXAttachment)

--- a/schema/cyclonedx_abstractions.go
+++ b/schema/cyclonedx_abstractions.go
@@ -324,6 +324,7 @@ type LicenseInfo struct {
 	BOMRef                 CDXRefType       `json:"bom-ref"`
 	BOMLocationValue       int              `json:"bom-location-value"`
 	BOMLocation            string           `json:"bom-location"`
+	PURL                   string           `json:"purl"` 
 	LicenseChoice          CDXLicenseChoice // Do not marshal
 	Policy                 LicensePolicy    // Do not marshal
 	Component              CDXComponent     // Do not marshal
@@ -356,6 +357,7 @@ func (licenseInfo *LicenseInfo) MapCDXLicenseFromComponent(cdxComponent CDXCompo
 	if cdxComponent.BOMRef != nil {
 		licenseInfo.BOMRef = *cdxComponent.BOMRef
 	}
+	licenseInfo.PURL = cdxComponent.Purl
 }
 
 func NewLicenseInfoFromService(cdxService CDXService, licenseChoice CDXLicenseChoice, location int) (licenseInfo *LicenseInfo) {

--- a/test/cyclonedx/cdx-1-5-mature-example-1.json
+++ b/test/cyclonedx/cdx-1-5-mature-example-1.json
@@ -46,7 +46,7 @@
     },
     "component": {
       "type": "application",
-      "bom-ref": "pkg:oci/example.com/product/application@10.0.4.0",
+      "bom-ref": "bom-ref_pkg:oci/example.com/product/application@10.0.4.0",
       "purl": "pkg:oci/example.com/product/application@10.0.4.0",
       "name": "Example Application v10.0.4",
       "description": "Example's Do-It-All application",
@@ -143,7 +143,7 @@
   "components": [
     {
       "type": "library",
-      "bom-ref": "pkg:npm/sample@2.0.0",
+      "bom-ref": "bom-ref_pkg:npm/sample@2.0.0",
       "purl": "pkg:npm/sample@2.0.0",
       "name": "sample",
       "version": "2.0.0",
@@ -158,7 +158,7 @@
     },
     {
       "type": "library",
-      "bom-ref": "pkg:npm/body-parser@1.19.0",
+      "bom-ref": "bom-ref_pkg:npm/body-parser@1.19.0",
       "purl": "pkg:npm/body-parser@1.19.0",
       "name": "body-parser",
       "version": "1.19.0",


### PR DESCRIPTION
As dicussed in person, this PR solves #123. With having the PURL in the result list of the `license list` command, we can use the `--where`  parameter to get only the PURL types we are interested in. 