### PR TITLE
Add test to assure we can unmarshal empty definitions and declarations objects for v1.6

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,6 +29,7 @@
             "databind",
             "Debugf",
             "defn",
+            "Defns",
             "deserializers",
             "DHTML",
             "dropwizard",

--- a/cmd/component_test.go
+++ b/cmd/component_test.go
@@ -40,6 +40,9 @@ const (
 	TEST_COMPONENT_LIST_CDX_1_6_CBOM = TEST_CDX_1_6_CRYPTO_BOM
 	// test/cyclonedx/1.6/cdx-1-6-valid-mlbom-environmental-considerations.json
 	TEST_COMPONENT_LIST_CDX_1_6_MLBOM = TEST_CDX_1_6_MACHINE_LEARNING_BOM
+	// test/cyclonedx/1.6/specification/valid-empty-defns-decls.json
+	// Test general BOM with empty top-level bom objects, but valid components
+	TEST_COMPONENT_LIST_CDX_1_6_SBOM = "test/cyclonedx/1.6/specification/valid-empty-defns-decls.json"
 )
 
 var COMPONENT_TEST_DEFAULT_FLAGS utils.ComponentCommandFlags
@@ -223,5 +226,10 @@ func TestComponentListCdx16ValidComponentSwid(t *testing.T) {
 
 func TestComponentListCdx16ValidComponentTypes(t *testing.T) {
 	ti := NewComponentTestInfoBasic(TEST_CDX_SPEC_1_6_VALID_COMPONENT_TYPES, FORMAT_CSV, nil)
+	innerTestComponentList(t, ti, COMPONENT_TEST_DEFAULT_FLAGS)
+}
+
+func TestComponentListCdx16EmptyDefnsDecls(t *testing.T) {
+	ti := NewComponentTestInfoBasic(TEST_COMPONENT_LIST_CDX_1_6_SBOM, FORMAT_CSV, nil)
 	innerTestComponentList(t, ti, COMPONENT_TEST_DEFAULT_FLAGS)
 }

--- a/test/cyclonedx/1.6/specification/valid-empty-defns-decls.json
+++ b/test/cyclonedx/1.6/specification/valid-empty-defns-decls.json
@@ -1,0 +1,16 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "components": [
+    {
+      "type": "library",
+      "name": "somelib"
+    }
+  ],
+  "definitions": {
+    "standards": []
+  },
+  "declaration": {
+    "attestations": []
+  }
+}


### PR DESCRIPTION
This is a test case that will assure PR https://github.com/CycloneDX/sbom-utility/pull/118 unmarshal code is tested from from now on.