### PR TITLE
fix: avoid nil pointer panic when vulnerability analysis omits response (#148)

### DIFF
--- a/schema/bom_hash.go
+++ b/schema/bom_hash.go
@@ -389,7 +389,9 @@ func (bom *BOM) HashmapVulnerability(cdxVulnerability CDXVulnerability, whereFil
 			vulnInfo.AnalysisJustification = VULN_ANALYSIS_STATE_EMPTY
 		}
 
-		vulnInfo.AnalysisResponse = *cdxVulnerability.Analysis.Response
+		if cdxVulnerability.Analysis.Response != nil {
+			vulnInfo.AnalysisResponse = *cdxVulnerability.Analysis.Response
+		}
 		if len(vulnInfo.AnalysisResponse) == 0 {
 			vulnInfo.AnalysisResponse = []string{VULN_ANALYSIS_STATE_EMPTY}
 		}

--- a/schema/bom_hash_test.go
+++ b/schema/bom_hash_test.go
@@ -423,6 +423,27 @@ func TestHashZeroCDXVulnerabilityStruct(t *testing.T) {
 	}
 }
 
+// Regression test for https://github.com/CycloneDX/sbom-utility/issues/148 :
+// a vulnerability with an `analysis` object that omits the optional `response`
+// array must not cause a nil pointer dereference panic.
+func TestHashCDXVulnerabilityAnalysisWithoutResponse(t *testing.T) {
+	cdxVulnerability := CDXVulnerability{
+		Id: "CVE-2026-0000",
+		Analysis: &CDXAnalysis{
+			State: "exploitable",
+		},
+	}
+	document := NewBOM("")
+	hashed, err := document.HashmapVulnerability(cdxVulnerability, nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if !hashed {
+		t.Error(getLogger().Errorf("expected non-empty vulnerability to be hashed."))
+	}
+}
+
 // ----------------------
 // License Hashing
 // ----------------------


### PR DESCRIPTION
## Summary

The CycloneDX `analysis.response` array is optional. When a vulnerability has an `analysis` object but no `response`, `HashmapVulnerability` dereferenced the nil `*[]string` pointer and panicked with `invalid memory address or nil pointer dereference` at `schema/bom_hash.go:392` (reported in #148, also reproduced locally).

This guards the dereference and keeps the existing `UNDEFINED` placeholder fallback.

## Test

Added `TestHashCDXVulnerabilityAnalysisWithoutResponse` in `schema/bom_hash_test.go`, which panics on `main` and passes with the fix. `go test ./schema/` and `go vet ./schema/` pass.