### PR TITLE
WIP: Add support for CycloneDX v2.0 (development) bundled JSON schema

### DIFF
--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev-threatmodeling/cyclonedx-blueprint-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev-threatmodeling/cyclonedx-blueprint-2.0.schema.json
@@ -1,0 +1,2138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-blueprint-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Blueprint Model",
+  "$comment": "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "blueprints": {
+      "type": "array",
+      "title": "Blueprints",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/blueprint"
+      },
+      "description": "A collection of blueprints, each supporting a wide range of analytical activities, from use case documentation and behavioural analysis to comprehensive system-level threat and risk modelling."
+    },
+    "blueprint": {
+      "type": "object",
+      "title": "Blueprint",
+      "description": "A versatile, machine-readable model designed to support a wide range of analytical activities, from use case documentation and behavioural analysis to comprehensive system-level threat and risk modelling.",
+      "required": [
+        "name",
+        "modelTypes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the blueprint, used to identify this model within the BOM and distinguish it from other blueprints.",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A detailed explanation of the blueprint, including its scope, the system or subsystem it represents, and any relevant context about the modelling objectives or intended audience."
+        },
+        "metadata": {
+          "$ref": "#/$defs/metadata"
+        },
+        "modelTypes": {
+          "type": "array",
+          "title": "Model Types",
+          "minItems": 1,
+          "uniqueItems": true,
+          "description": "The types of models being represented.",
+          "items": {
+            "$ref": "#/$defs/modelType"
+          }
+        },
+        "scope": {
+          "$ref": "#/$defs/scope"
+        },
+        "assets": {
+          "type": "array",
+          "title": "Assets",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/asset"
+          },
+          "description": "The assets (components, services, data, actors) included in the model."
+        },
+        "behaviors": {
+          "$ref": "cyclonedx-behavior-2.0.schema.json#/$defs/behaviors"
+        },
+        "dataStores": {
+          "type": "array",
+          "title": "Data Stores",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/dataStore"
+          },
+          "description": "Structured description of data stores used in the model."
+        },
+        "dataSets": {
+          "type": "array",
+          "title": "Data Sets",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/dataSet"
+          },
+          "description": "Datasets handled by the system, including placements and sensitivity."
+        },
+        "zones": {
+          "type": "array",
+          "title": "Zones",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/zone"
+          },
+          "description": "Logical, physical, or trust zones that group assets with similar characteristics."
+        },
+        "boundaries": {
+          "type": "array",
+          "title": "Boundaries",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/boundary"
+          },
+          "description": "Boundaries between zones."
+        },
+        "flows": {
+          "type": "array",
+          "title": "Flows",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/flow"
+          },
+          "description": "Data, control, or process flows between assets."
+        },
+        "relationships": {
+          "type": "array",
+          "title": "Relationships",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/relationship"
+          },
+          "description": "Static, structural relationships between elements of the model, complementing the runtime exchanges captured by flows."
+        },
+        "actors": {
+          "type": "array",
+          "title": "Actors",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/actor"
+          },
+          "description": "Human or system actors involved in the model, distinct from assets."
+        },
+        "assumptions": {
+          "type": "array",
+          "title": "Assumptions",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/assumption"
+          },
+          "description": "Assumptions made during the modeling process."
+        },
+        "visualizations": {
+          "type": "array",
+          "title": "Visualizations",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/visualization"
+          },
+          "description": "Visual representations of the model."
+        },
+        "useCases": {
+          "type": "array",
+          "title": "Use Cases",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "properties": {
+              "ref": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+                "title": "Use Case Reference",
+                "description": "A reference to a use case object defined in definitions."
+              },
+              "assets": {
+                "type": "array",
+                "title": "Assets",
+                "uniqueItems": true,
+                "items": {
+                  "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+                },
+                "description": "References using bom-link or bom-ref to the blueprint assets that are involved in or exercised by this use case."
+              },
+              "flows": {
+                "type": "array",
+                "title": "Flows",
+                "uniqueItems": true,
+                "items": {
+                  "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+                },
+                "description": "References using bom-link or bom-ref to the blueprint flows that are triggered or traversed during the execution of this use case."
+              },
+              "requirements": {
+                "type": "array",
+                "title": "Requirements",
+                "uniqueItems": true,
+                "items": {
+                  "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+                },
+                "description": "References using bom-link or bom-ref to the requirements that are implemented, validated, or addressed by this use case."
+              }
+            }
+          },
+          "description": "Use cases analyzed as part of the model, linking actors, goals, and steps to the blueprint's assets, flows, and requirements."
+        },
+        "requirements": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the requirements, declared in definitions, that are derived from or related to this model."
+        },
+        "externalReferences": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReferences"
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "modelType": {
+      "title": "Model Type",
+      "description": "The type of model being represented, either a predefined value from the enumeration or a custom name and description for types not covered by the enumeration. Threat, risk, and privacy analyses are represented in their own models, which reference the blueprint, rather than as blueprint model types.",
+      "oneOf": [
+        {
+          "type": "string",
+          "title": "Predefined Model Type",
+          "description": "A predefined model type from the enumeration.",
+          "enum": [
+            "architecture",
+            "behavioral",
+            "conceptual",
+            "data-flow",
+            "deployment",
+            "logical",
+            "network",
+            "operational",
+            "physical",
+            "process"
+          ],
+          "meta:enum": {
+            "architecture": "An architecture model of the system or software, capturing its major components, their responsibilities, and the interfaces and relationships between them. Broader than a single view, it frames the overall design.",
+            "behavioral": "A behavioural model, capturing how the system acts over time through its processes, state changes, interactions, and control flow, as opposed to its static structure.",
+            "conceptual": "A conceptual model at the highest level of abstraction, capturing the key entities, concepts, and relationships in technology-neutral terms without implementation detail. The first level of the conceptual, logical, and physical progression.",
+            "data-flow": "A data flow model showing how data moves between processes, data stores, and external entities. This is the substrate most commonly used for STRIDE per-element threat analysis.",
+            "deployment": "A deployment model showing how software is allocated to runtime and infrastructure, including nodes, containers, environments, and the artifacts placed on them.",
+            "logical": "A logical model detailing the structure and behaviour of the system independent of any specific implementation technology. The middle level of the conceptual, logical, and physical progression.",
+            "network": "A network model showing topology and connectivity, including segments, links, and the paths over which components communicate.",
+            "operational": "An operational model describing how the system is run and supported in production, including procedures, responsibilities, and operational dependencies.",
+            "physical": "A physical model at the implementation level, capturing the tangible realization of the system such as hardware, devices, infrastructure, topology, and physical locations. The most concrete level of the conceptual, logical, and physical progression.",
+            "process": "A process model describing a business or system process as an ordered set of activities and decisions and the actors that carry them out."
+          }
+        },
+        {
+          "type": "object",
+          "title": "Custom Model Type",
+          "description": "A custom model type not covered by the predefined enumeration, allowing organisations to define domain-specific model categories.",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "minLength": 1,
+              "description": "The name of the custom model type."
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "A description of the custom model type."
+            }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "title": "Blueprint Metadata",
+      "description": "Metadata about the creation, review, and approval of the blueprint.",
+      "additionalProperties": false,
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "title": "Timestamp",
+          "format": "date-time",
+          "description": "When the blueprint was created or last updated."
+        },
+        "authors": {
+          "type": "array",
+          "title": "Authors",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-party-2.0.schema.json#/$defs/partyChoice"
+          },
+          "description": "The parties that created the blueprint. Each entry is either an inline party object or a reference to a previously declared party. The party's `roles` should include `author`."
+        },
+        "reviewer": {
+          "$ref": "cyclonedx-party-2.0.schema.json#/$defs/partyChoice",
+          "description": "The party that reviewed the blueprint. The party's `roles` should include `reviewer`."
+        },
+        "reviewDate": {
+          "type": "string",
+          "title": "Review Date",
+          "format": "date-time",
+          "description": "When the blueprint was reviewed."
+        },
+        "approver": {
+          "$ref": "cyclonedx-party-2.0.schema.json#/$defs/partyChoice",
+          "description": "The party that approved the blueprint. The party's `roles` should include `signatory` or a custom role identifying the approving authority."
+        },
+        "approvalDate": {
+          "type": "string",
+          "title": "Approval Date",
+          "format": "date-time",
+          "description": "When the blueprint was approved."
+        },
+        "ordinalVersion": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/ordinalVersion"
+        },
+        "lifecycles": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/lifecycles"
+        },
+        "validityPeriod": {
+          "$ref": "#/$defs/validityPeriod"
+        }
+      }
+    },
+    "validityPeriod": {
+      "type": "object",
+      "title": "Validity Period",
+      "description": "The period during which the blueprint is considered valid.",
+      "additionalProperties": false,
+      "properties": {
+        "start": {
+          "type": "string",
+          "title": "Start",
+          "format": "date-time",
+          "description": "When the blueprint becomes valid."
+        },
+        "end": {
+          "type": "string",
+          "title": "End",
+          "format": "date-time",
+          "description": "When the blueprint expires."
+        },
+        "reviewFrequency": {
+          "type": "string",
+          "title": "Review Frequency",
+          "pattern": "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?$",
+          "description": "ISO 8601 duration for review frequency (e.g., P3M for quarterly)."
+        }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "title": "Scope",
+      "description": "Specifies what is included and excluded from the blueprint model, establishing the boundaries within which the modelling and analysis is performed.",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "minLength": 1,
+          "description": "Name of the scope."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Description of what is included and excluded from the model."
+        },
+        "boundaries": {
+          "type": "array",
+          "title": "Boundaries",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Explicit boundaries of the model."
+        },
+        "includedComponents": {
+          "type": "array",
+          "title": "Included Components",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to components explicitly included."
+        },
+        "excludedComponents": {
+          "type": "array",
+          "title": "Excluded Components",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to components explicitly excluded."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "asset": {
+      "type": "object",
+      "title": "Asset",
+      "description": "A component, service, data store, actor, or other element included in the blueprint model. An actor asset references a party, since a party such as a person, persona, system, or organization may itself be an asset, including a person in the intelligence sense of a human source.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "description": "Unique identifier for the asset."
+        },
+        "componentRef": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the component this asset represents."
+        },
+        "serviceRef": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the service this asset represents."
+        },
+        "partyRef": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the party this asset represents, such as a person, persona, system, or organization. Used when the asset is an actor."
+        },
+        "type": {
+          "title": "Asset Type",
+          "description": "The kind of asset. Use the custom option for kinds not covered by the enumeration.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Predefined Asset Type",
+              "enum": [
+                "actor",
+                "agent",
+                "api",
+                "broker",
+                "cache",
+                "component",
+                "container",
+                "data",
+                "data-store",
+                "device",
+                "endpoint",
+                "function",
+                "gateway",
+                "infrastructure",
+                "interface",
+                "model",
+                "module",
+                "network",
+                "process",
+                "queue",
+                "resource",
+                "service",
+                "stream",
+                "subsystem",
+                "system",
+                "tool"
+              ],
+              "meta:enum": {
+                "actor": "An actor that is an asset in its own right, referencing a party via partyRef. A party such as a system or organization is commonly an asset, and a person may be an asset in the intelligence sense of a human source.",
+                "agent": "Autonomous AI or software agent.",
+                "api": "API endpoint or interface.",
+                "broker": "Message broker or event bus infrastructure.",
+                "cache": "Caching layer or in-memory data store.",
+                "component": "Software component or application.",
+                "container": "Container or orchestration unit.",
+                "data": "Dataset.",
+                "data-store": "Database, file system, or data repository.",
+                "device": "Physical or IoT device.",
+                "endpoint": "Service endpoint or URL.",
+                "function": "Serverless function or lambda.",
+                "gateway": "API gateway, load balancer, or proxy.",
+                "infrastructure": "Infrastructure component.",
+                "interface": "System interface or contract.",
+                "model": "AI or machine learning model.",
+                "module": "Software module or package.",
+                "network": "Network segment or resource.",
+                "process": "Business or system process.",
+                "queue": "Message queue or task queue.",
+                "resource": "Generic resource or artifact.",
+                "service": "Service or microservice.",
+                "stream": "Data stream or event stream.",
+                "subsystem": "Part of a larger system.",
+                "system": "Complete system or application.",
+                "tool": "A tool or capability invoked by an agent, such as a function, API, or service exposed to an AI agent."
+              }
+            },
+            {
+              "type": "object",
+              "title": "Custom Asset Type",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name",
+                  "description": "The name of the custom asset type."
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom asset type."
+                }
+              }
+            }
+          ]
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "minLength": 1,
+          "description": "Name of the asset."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Description of the asset's role and purpose."
+        },
+        "zone": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the zone containing this asset."
+        },
+        "classification": {
+          "$ref": "#/$defs/assetClassification"
+        },
+        "tags": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/tags"
+        },
+        "responsibilities": {
+          "type": "array",
+          "title": "Responsibilities",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Responsibilities or functions of this asset."
+        },
+        "interfaces": {
+          "type": "array",
+          "title": "Interfaces",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/interface"
+          },
+          "description": "Interfaces exposed by this asset."
+        },
+        "useCases": {
+          "type": "array",
+          "title": "Use Cases",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to use case objects that describe how actors interact with this asset, including the specific goals, sequences of steps, alternative and exception flows, and any requirements that govern its usage."
+        },
+        "authentication": {
+          "type": "array",
+          "title": "Authentication",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/authenticationType"
+          },
+          "description": "Authentication methods supported/required."
+        },
+        "authorization": {
+          "type": "array",
+          "title": "Authorization",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/authorizationType"
+          },
+          "description": "Authorization models supported/required."
+        },
+        "ownership": {
+          "$ref": "#/$defs/ownership"
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        },
+        "externalReferences": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReferences"
+        }
+      },
+      "oneOf": [
+        {
+          "title": "Component Reference Asset",
+          "description": "An asset defined by reference to a component declared elsewhere in the BOM.",
+          "required": [
+            "bom-ref",
+            "componentRef"
+          ]
+        },
+        {
+          "title": "Service Reference Asset",
+          "description": "An asset defined by reference to a service declared elsewhere in the BOM.",
+          "required": [
+            "bom-ref",
+            "serviceRef"
+          ]
+        },
+        {
+          "title": "Party Reference Asset",
+          "description": "An asset defined by reference to a party declared elsewhere in the BOM, such as a person, persona, system, or organization that is itself an asset.",
+          "required": [
+            "bom-ref",
+            "partyRef"
+          ]
+        },
+        {
+          "title": "Inline Asset",
+          "description": "An asset defined inline within the blueprint with an explicit type and name.",
+          "required": [
+            "bom-ref",
+            "type",
+            "name"
+          ]
+        }
+      ]
+    },
+    "dataStore": {
+      "type": "object",
+      "title": "Data Store",
+      "description": "A persistent storage system used within the modelled system to hold, retrieve, or manage data.",
+      "required": [
+        "bom-ref",
+        "name",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "minLength": 1,
+          "description": "Name of the data store."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Purpose and contents of the store."
+        },
+        "type": {
+          "title": "Type",
+          "description": "The type of data store. Use the custom option for technologies not covered by the enumeration.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Predefined Data Store Type",
+              "enum": [
+                "block",
+                "blockchain",
+                "cache",
+                "column-family",
+                "data-lake",
+                "data-warehouse",
+                "document",
+                "event-log",
+                "file",
+                "graph",
+                "hierarchical",
+                "in-memory",
+                "key-value",
+                "ledger",
+                "message-queue",
+                "multi-model",
+                "object",
+                "registry",
+                "relational",
+                "search",
+                "spatial",
+                "time-series",
+                "vector"
+              ],
+              "meta:enum": {
+                "block": "Block storage exposing raw volumes.",
+                "blockchain": "Distributed ledger or blockchain storage.",
+                "cache": "Caching tier.",
+                "column-family": "Wide-column or column-family store.",
+                "data-lake": "Data lake or lakehouse for raw and semi-structured data.",
+                "data-warehouse": "Analytical data warehouse optimised for OLAP workloads.",
+                "document": "Document database.",
+                "event-log": "Event log or append-only streaming store.",
+                "file": "File system or network-attached storage.",
+                "graph": "Graph database.",
+                "hierarchical": "Hierarchical or tree-structured database, such as a directory store.",
+                "in-memory": "In-memory data store used as a primary store.",
+                "key-value": "Key-value store.",
+                "ledger": "Immutable, append-only ledger database.",
+                "message-queue": "Message queue or broker with persistent storage.",
+                "multi-model": "A store supporting multiple data models.",
+                "object": "Object storage.",
+                "registry": "Configuration or service registry.",
+                "relational": "Relational database.",
+                "search": "Search index or full-text search engine.",
+                "spatial": "Spatial or geospatial database.",
+                "time-series": "Time-series database.",
+                "vector": "Vector database for embeddings and similarity search."
+              }
+            },
+            {
+              "type": "object",
+              "title": "Custom Data Store Type",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name",
+                  "description": "The name of the custom data store type."
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom data store type."
+                }
+              }
+            }
+          ]
+        },
+        "vendor": {
+          "type": "string",
+          "title": "Vendor",
+          "description": "The vendor or publisher of the data store product."
+        },
+        "product": {
+          "type": "string",
+          "title": "Product",
+          "description": "The name of the data store product."
+        },
+        "version": {
+          "type": "string",
+          "title": "Version",
+          "description": "The version of the data store product."
+        },
+        "environment": {
+          "type": "string",
+          "title": "Environment",
+          "description": "Deployment environment (prod, test, etc.)."
+        },
+        "zone": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the zone where the asset resides."
+        },
+        "location": {
+          "type": "string",
+          "title": "Location",
+          "description": "Physical or logical hosting location."
+        },
+        "technologies": {
+          "type": "array",
+          "title": "Technologies",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "Supporting technologies or services."
+        },
+        "dataSets": {
+          "type": "array",
+          "title": "Data Sets",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to data sets stored here."
+        },
+        "authorization": {
+          "type": "array",
+          "title": "Authorization",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/authorizationType"
+          },
+          "description": "Authorization models supported/required."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "dataSet": {
+      "type": "object",
+      "title": "Data Set",
+      "description": "A logical collection of related data managed within the modelled system, including its classification, ownership, and storage placements.",
+      "required": [
+        "bom-ref",
+        "name",
+        "description"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "minLength": 1,
+          "description": "Name of the dataset."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "minLength": 1,
+          "description": "What information is contained and why it exists."
+        },
+        "dataProfiles": {
+          "type": "array",
+          "title": "Data Profiles",
+          "description": "Data profiles that govern the dataset. Each entry is either an inline profile object or a reference using bom-link or bom-ref to a previously declared profile, typically declared in the root profiles catalogue.",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-data-2.0.schema.json#/$defs/dataProfileChoice"
+          }
+        },
+        "dataObjects": {
+          "type": "array",
+          "title": "Data Objects",
+          "description": "The specific data objects stored in the dataset. Each object names a payload and may reference one of the dataset's data profiles for its governing policy.",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-data-2.0.schema.json#/$defs/dataObject"
+          }
+        },
+        "recordCount": {
+          "type": "integer",
+          "title": "Record Count",
+          "description": "Approximate number of records."
+        },
+        "owners": {
+          "type": "array",
+          "title": "Owners",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-party-2.0.schema.json#/$defs/partyChoice"
+          },
+          "description": "Parties that own the dataset. Each entry is either an inline party object or a reference to a previously declared party. The party's `roles` should include `owner`."
+        },
+        "authorization": {
+          "type": "array",
+          "title": "Authorization",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/authorizationType"
+          },
+          "description": "Authorization models supported/required."
+        },
+        "placements": {
+          "type": "array",
+          "title": "Placements",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "title": "Placement",
+            "description": "Describes where a dataset physically or logically resides and the storage characteristics at that location.",
+            "required": [
+              "dataStore"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "dataStore": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+                "description": "Reference using bom-link or bom-ref to the store holding this dataset."
+              },
+              "encrypted": {
+                "type": "boolean",
+                "title": "Encrypted",
+                "description": "Whether the dataset is encrypted at this location."
+              },
+              "retention": {
+                "type": "string",
+                "title": "Retention",
+                "description": "Retention policy for this placement."
+              },
+              "replicated": {
+                "type": "boolean",
+                "title": "Replicated",
+                "description": "Indicates if this placement is a replica."
+              }
+            }
+          },
+          "description": "Where the dataset resides."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "interface": {
+      "type": "object",
+      "required": [
+        "name",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the interface."
+        },
+        "type": {
+          "title": "Type",
+          "description": "The type of interface. Use the custom option for types not covered by the enumeration.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Predefined Interface Type",
+              "enum": [
+                "rest",
+                "graphql",
+                "grpc",
+                "soap",
+                "messaging",
+                "file",
+                "database",
+                "cli",
+                "gui",
+                "api",
+                "event",
+                "stream"
+              ]
+            },
+            {
+              "type": "object",
+              "title": "Custom Interface Type",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name",
+                  "description": "The name of the custom interface type."
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom interface type."
+                }
+              }
+            }
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the interface."
+        },
+        "specification": {
+          "type": "string",
+          "description": "Link or reference to interface specification."
+        },
+        "protocol": {
+          "type": "string",
+          "description": "Communication protocol used."
+        },
+        "dataFormat": {
+          "type": "string",
+          "description": "Data format (e.g., JSON, XML, Protocol Buffers)."
+        },
+        "authentication": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/authenticationType"
+          }
+        },
+        "operations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Operations or methods exposed."
+        }
+      }
+    },
+    "zone": {
+      "type": "object",
+      "title": "Zone",
+      "description": "A grouping of assets that share a common characteristic, security posture, or administrative control, so they can be reasoned about as a unit. A zone may be logical, physical, network, trust, or another kind, may nest within a parent zone, and is connected to or separated from other zones by boundaries.",
+      "required": [
+        "bom-ref",
+        "name",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "minLength": 1,
+          "description": "Name of the zone."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Description of the zone's characteristics."
+        },
+        "type": {
+          "title": "Type",
+          "description": "The type of zone. Use the custom option for types not covered by the enumeration.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Predefined Zone Type",
+              "enum": [
+                "availability",
+                "compliance",
+                "data",
+                "deployment",
+                "functional",
+                "geographic",
+                "logical",
+                "network",
+                "organizational",
+                "physical",
+                "process",
+                "tenant",
+                "trust"
+              ],
+              "meta:enum": {
+                "availability": "An availability or fault-isolation zone, such as a cloud availability zone, used to bound the blast radius of failures and reason about redundancy and resilience.",
+                "compliance": "A compliance scope zone whose assets fall under a specific regulatory regime, such as PCI DSS, HIPAA, or FedRAMP, delineating what is in scope and the controls applied.",
+                "data": "A data classification zone grouping assets by the sensitivity of the data they hold or process, such as public, internal, confidential, or restricted.",
+                "deployment": "A deployment environment grouping assets by lifecycle stage, such as development, staging, or production.",
+                "functional": "A functional grouping of assets that serve a common purpose or capability, independent of where or how they are deployed.",
+                "geographic": "A geographic or data-residency zone bounding assets to a region, country, or jurisdiction, used to reason about sovereignty and cross-border data flows.",
+                "logical": "A logical grouping of assets defined by architecture or design rather than physical placement.",
+                "network": "A network segmentation zone, such as a subnet, VLAN, or security group, within which assets share network-level reachability and controls.",
+                "organizational": "An organizational or administrative zone grouping assets under a common owner, team, or authority.",
+                "physical": "A physical zone bounding assets to a tangible location, such as a data centre, building, or device enclosure.",
+                "process": "A process or execution isolation zone, such as a sandbox, container runtime, or trusted execution environment, within which code runs with a defined level of isolation.",
+                "tenant": "A tenancy isolation zone separating the assets and data of one tenant from another in a multi-tenant system.",
+                "trust": "A security trust zone whose assets share a common level of trust, so that movement between trust zones is where authentication, authorization, and validation are enforced."
+              }
+            },
+            {
+              "type": "object",
+              "title": "Custom Zone Type",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name",
+                  "description": "The name of the custom zone type."
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom zone type."
+                }
+              }
+            }
+          ]
+        },
+        "parent": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the parent zone if this is a sub-zone."
+        },
+        "characteristics": {
+          "type": "array",
+          "title": "Characteristics",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "Key characteristics of this zone."
+        },
+        "constraints": {
+          "type": "array",
+          "title": "Constraints",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "Constraints or limitations of this zone."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "boundary": {
+      "type": "object",
+      "title": "Boundary",
+      "description": "An edge that separates or connects two or more zones, marking a point where security controls, policies, or trust levels change. The controls expected when data or actors cross it are captured in crossingRequirements, and the threat model's trust boundary extends a boundary with trust semantics.",
+      "required": [
+        "bom-ref",
+        "zones"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "minLength": 1,
+          "description": "Name of the boundary."
+        },
+        "type": {
+          "title": "Type",
+          "description": "The type of boundary. Use the custom option for types not covered by the enumeration.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Predefined Boundary Type",
+              "enum": [
+                "data",
+                "functional",
+                "network",
+                "organizational",
+                "physical",
+                "process",
+                "trust"
+              ],
+              "meta:enum": {
+                "data": "A data classification boundary, crossed when data moves between zones of differing sensitivity, where reclassification, masking, or validation may apply.",
+                "functional": "A functional boundary between areas of differing responsibility or capability.",
+                "network": "A network boundary, such as a firewall, gateway, or security group, controlling reachability between network zones.",
+                "organizational": "An organizational or administrative boundary between assets under different ownership or authority.",
+                "physical": "A physical security boundary, such as a facility perimeter or device enclosure, between physical zones.",
+                "process": "A process or execution boundary between isolation contexts, such as between a sandbox and its host.",
+                "trust": "A trust boundary between zones of differing trust, the primary point at which authentication, authorization, and input validation are enforced and a key trigger for threat analysis."
+              }
+            },
+            {
+              "type": "object",
+              "title": "Custom Boundary Type",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name",
+                  "description": "The name of the custom boundary type."
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom boundary type."
+                }
+              }
+            }
+          ]
+        },
+        "zones": {
+          "type": "array",
+          "title": "Zones",
+          "uniqueItems": true,
+          "minItems": 2,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the zones this boundary connects or separates."
+        },
+        "crossingRequirements": {
+          "$ref": "#/$defs/crossingRequirements"
+        },
+        "sessionManagement": {
+          "$ref": "#/$defs/sessionManagement"
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "crossingRequirements": {
+      "type": "object",
+      "title": "Crossing Requirements",
+      "description": "The security controls, policies, and constraints applied when data or actors cross a boundary between zones, such as the authentication and authorization enforced, the protocols permitted, and the validation, logging, and monitoring performed at the crossing.",
+      "additionalProperties": false,
+      "properties": {
+        "authentication": {
+          "type": "array",
+          "title": "Authentication",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/authenticationType"
+          },
+          "description": "Authentication required to cross this boundary."
+        },
+        "authorization": {
+          "type": "array",
+          "title": "Authorization",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/authorizationType"
+          },
+          "description": "Authorization models enforced at this boundary."
+        },
+        "dataValidation": {
+          "type": "boolean",
+          "title": "Data Validation",
+          "description": "Whether data is validated when crossing this boundary."
+        },
+        "dataTransformation": {
+          "type": "boolean",
+          "title": "Data Transformation",
+          "description": "Whether data is transformed when crossing this boundary."
+        },
+        "logging": {
+          "type": "boolean",
+          "title": "Logging",
+          "description": "Whether crossings are logged."
+        },
+        "monitoring": {
+          "type": "boolean",
+          "title": "Monitoring",
+          "description": "Whether crossings are monitored."
+        },
+        "rateLimit": {
+          "type": "string",
+          "title": "Rate Limit",
+          "description": "Rate limiting policy."
+        },
+        "protocols": {
+          "type": "array",
+          "title": "Protocols",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "Allowed protocols for crossing."
+        }
+      }
+    },
+    "sessionManagement": {
+      "type": "object",
+      "title": "Session Management",
+      "description": "The lifecycle of the authenticated session established at this boundary, covering session timeouts, access and refresh token validity, and logout behaviour. These properties characterize the session that results from authenticating, independently of the authentication method used.",
+      "additionalProperties": false,
+      "properties": {
+        "accessTokenExpires": {
+          "type": "boolean",
+          "title": "Access Token Expires",
+          "description": "Whether access tokens issued for this boundary expire."
+        },
+        "accessTokenTtl": {
+          "type": "integer",
+          "title": "Access Token Time To Live",
+          "minimum": 0,
+          "description": "Validity period of an access token, in seconds."
+        },
+        "refreshToken": {
+          "type": "boolean",
+          "title": "Refresh Token",
+          "description": "Whether refresh tokens are issued for this boundary."
+        },
+        "refreshTokenExpires": {
+          "type": "boolean",
+          "title": "Refresh Token Expires",
+          "description": "Whether refresh tokens expire."
+        },
+        "refreshTokenTtl": {
+          "type": "integer",
+          "title": "Refresh Token Time To Live",
+          "minimum": 0,
+          "description": "Validity period of a refresh token, in seconds."
+        },
+        "idleTimeout": {
+          "type": "integer",
+          "title": "Idle Timeout",
+          "minimum": 0,
+          "description": "Period of inactivity after which the session ends, in seconds."
+        },
+        "absoluteTimeout": {
+          "type": "integer",
+          "title": "Absolute Timeout",
+          "minimum": 0,
+          "description": "Period after session creation after which the session ends regardless of activity, in seconds."
+        },
+        "userLogout": {
+          "type": "boolean",
+          "title": "User Logout",
+          "description": "Whether a user can explicitly end the session."
+        },
+        "systemLogout": {
+          "type": "boolean",
+          "title": "System Logout",
+          "description": "Whether the system can end the session without user action."
+        }
+      }
+    },
+    "relationship": {
+      "type": "object",
+      "title": "Relationship",
+      "description": "A typed structural relationship from one element to one or more others, complementing the runtime exchanges captured by flows. The subject is `ref`, and the kind of relationship is expressed as a single typed property whose value lists the targets, mirroring the dependency graph for readability.",
+      "additionalProperties": false,
+      "required": [
+        "ref"
+      ],
+      "oneOf": [
+        {
+          "required": [
+            "aggregates"
+          ]
+        },
+        {
+          "required": [
+            "associates"
+          ]
+        },
+        {
+          "required": [
+            "composes"
+          ]
+        },
+        {
+          "required": [
+            "contains"
+          ]
+        },
+        {
+          "required": [
+            "dependsOn"
+          ]
+        },
+        {
+          "required": [
+            "generalizes"
+          ]
+        },
+        {
+          "required": [
+            "realizes"
+          ]
+        },
+        {
+          "required": [
+            "serves"
+          ]
+        },
+        {
+          "required": [
+            "custom"
+          ]
+        }
+      ],
+      "properties": {
+        "ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "title": "Reference",
+          "description": "Reference using bom-link or bom-ref to the subject element of the relationship."
+        },
+        "aggregates": {
+          "$ref": "#/$defs/relationshipTargets",
+          "title": "Aggregates",
+          "description": "The subject is the whole in a whole-part relationship in which each target part may exist independently of the whole."
+        },
+        "associates": {
+          "$ref": "#/$defs/relationshipTargets",
+          "title": "Associates",
+          "description": "The subject has a general association with each target."
+        },
+        "composes": {
+          "$ref": "#/$defs/relationshipTargets",
+          "title": "Composes",
+          "description": "The subject is the whole in a whole-part relationship in which each target part cannot exist without the whole."
+        },
+        "contains": {
+          "$ref": "#/$defs/relationshipTargets",
+          "title": "Contains",
+          "description": "The subject contains or nests each target."
+        },
+        "dependsOn": {
+          "$ref": "#/$defs/relationshipTargets",
+          "title": "Depends On",
+          "description": "The subject depends on each target."
+        },
+        "generalizes": {
+          "$ref": "#/$defs/relationshipTargets",
+          "title": "Generalizes",
+          "description": "The subject is a generalisation of each target, as in inheritance."
+        },
+        "realizes": {
+          "$ref": "#/$defs/relationshipTargets",
+          "title": "Realizes",
+          "description": "The subject realises or implements each target."
+        },
+        "serves": {
+          "$ref": "#/$defs/relationshipTargets",
+          "title": "Serves",
+          "description": "The subject provides a service to each target."
+        },
+        "custom": {
+          "type": "array",
+          "title": "Custom Relationships",
+          "description": "Relationships whose kind is not covered by the predefined properties. Each entry names the kind and lists its targets.",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "title": "Custom Relationship",
+            "additionalProperties": false,
+            "required": [
+              "type",
+              "targets"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "title": "Type",
+                "minLength": 1,
+                "description": "The name of the custom relationship kind."
+              },
+              "targets": {
+                "$ref": "#/$defs/relationshipTargets",
+                "title": "Targets",
+                "description": "The targets of the custom relationship."
+              },
+              "description": {
+                "type": "string",
+                "title": "Description",
+                "description": "A description of the custom relationship kind."
+              }
+            }
+          }
+        }
+      }
+    },
+    "relationshipTargets": {
+      "type": "array",
+      "title": "Relationship Targets",
+      "description": "References using bom-link or bom-ref to the target elements of a relationship.",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+      }
+    },
+    "flow": {
+      "type": "object",
+      "title": "Flow",
+      "description": "Represents a data, control, or process flow between two assets, capturing the direction, type, protocols, and security controls that govern the exchange.",
+      "required": [
+        "bom-ref",
+        "name",
+        "source",
+        "destination",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "minLength": 1,
+          "description": "Name or description of the flow."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Detailed description of what flows and why."
+        },
+        "type": {
+          "title": "Type",
+          "description": "The type of flow. Use the custom option for types not covered by the enumeration.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Predefined Flow Type",
+              "enum": [
+                "control",
+                "data",
+                "energy",
+                "event",
+                "financial",
+                "message",
+                "physical",
+                "process",
+                "signal"
+              ],
+              "meta:enum": {
+                "control": "Control or command flow.",
+                "data": "Data or information flow.",
+                "energy": "Power or energy flow.",
+                "event": "Event or notification flow.",
+                "financial": "Financial, value, or payment flow.",
+                "message": "Message or communication flow.",
+                "physical": "Physical movement of goods or materials.",
+                "process": "Business process flow.",
+                "signal": "Hardware or system signal."
+              }
+            },
+            {
+              "type": "object",
+              "title": "Custom Flow Type",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name",
+                  "description": "The name of the custom flow type."
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom flow type."
+                }
+              }
+            }
+          ]
+        },
+        "source": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the source of the flow. The source may be either an asset (such as a component, service, data store, or other element in the blueprint) or an actor that originates the exchange."
+        },
+        "destination": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the destination of the flow. The destination may be either an asset (such as a component, service, data store, or other element in the blueprint) or an actor that receives the exchange."
+        },
+        "bidirectional": {
+          "type": "boolean",
+          "title": "Bidirectional",
+          "default": false,
+          "description": "Whether flow occurs in both directions."
+        },
+        "synchronous": {
+          "type": "boolean",
+          "title": "Synchronous",
+          "description": "Whether the flow is synchronous or asynchronous."
+        },
+        "encrypted": {
+          "type": "boolean",
+          "title": "Encrypted",
+          "description": "Whether the data carried by this flow is encrypted in transit."
+        },
+        "volume": {
+          "type": "string",
+          "title": "Volume",
+          "description": "Expected volume or frequency of flow."
+        },
+        "timing": {
+          "type": "string",
+          "title": "Timing",
+          "description": "Timing characteristics (real-time, batch, scheduled)."
+        },
+        "protocols": {
+          "type": "array",
+          "title": "Protocols",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "Communication protocols used by this flow."
+        },
+        "dataProfiles": {
+          "type": "array",
+          "title": "Data Profiles",
+          "description": "Data profiles that govern the data carried by this flow. A flow may carry data governed by multiple profiles, for example a payment submission carrying both payment card data and customer personally identifiable information. Each entry is either an inline profile object or a reference using bom-link or bom-ref to a previously declared profile.",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-data-2.0.schema.json#/$defs/dataProfileChoice"
+          }
+        },
+        "dataObjects": {
+          "type": "array",
+          "title": "Data Objects",
+          "description": "The specific data objects carried by this flow. Each object names a payload and may reference one of the flow's data profiles for its governing policy.",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-data-2.0.schema.json#/$defs/dataObject"
+          }
+        },
+        "authentication": {
+          "type": "array",
+          "title": "Authentication",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/authenticationType"
+          },
+          "description": "Authentication required for this flow."
+        },
+        "authorization": {
+          "type": "array",
+          "title": "Authorization",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/authorizationType"
+          },
+          "description": "Authorization models enforced on this flow."
+        },
+        "sequence": {
+          "type": "integer",
+          "title": "Sequence",
+          "minimum": 0,
+          "description": "Ordering hint so flows can be assembled into sequence diagrams."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "actor": {
+      "type": "object",
+      "title": "Actor",
+      "description": "An actor is a contextual binding between a party and the modelled system. The party identifies who or what is acting (an organisation, person, system, or persona). The actor layer adds properties that are meaningful only within the blueprint, such as the permissions the actor holds in this system and the trust zone in which the actor operates. Identity, roles, archetype, and inter-party relations such as delegation are carried by the wrapped party and shall not be duplicated on the actor.",
+      "required": [
+        "bom-ref",
+        "party"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "description": "Unique identifier for this actor binding. References to actors from other parts of the blueprint, such as use cases or flows, use this identifier."
+        },
+        "party": {
+          "$ref": "cyclonedx-party-2.0.schema.json#/$defs/partyChoice",
+          "title": "Party",
+          "description": "The party that this actor binds to the modelled system. May be an inline party object declaring identity and roles in place, or a bom-link or bom-ref to a party declared elsewhere in the document."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A narrative describing this actor's role within the modelled system, distinct from the party's identity-level description. Use to record context-specific framing such as why this actor is in scope or how it interacts with the assets in this blueprint."
+        },
+        "permissions": {
+          "type": "array",
+          "title": "Permissions",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "The permissions, capabilities, or duties this actor holds within the modelled system. Distinct from any innate party-level capabilities; these are scoped to the blueprint."
+        },
+        "zone": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "title": "Zone",
+          "description": "Reference using bom-link or bom-ref to the trust zone in which the actor operates."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "assumption": {
+      "type": "object",
+      "title": "Assumption",
+      "description": "A stated belief or condition accepted as true for the purposes of the model, which may impact the validity of the analysis if proven false.",
+      "required": [
+        "description"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "minLength": 1,
+          "description": "A clear statement of the assumption being made, including the believed condition, the reasoning or evidence behind it, and any constraints or scope under which it applies."
+        },
+        "topic": {
+          "title": "Topic",
+          "description": "The topic of the assumption. Use the custom option for topics not covered by the enumeration.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Predefined Assumption Topic",
+              "enum": [
+                "availability",
+                "business",
+                "compliance",
+                "operational",
+                "performance",
+                "security",
+                "technical"
+              ],
+              "meta:enum": {
+                "availability": "Assumption about system uptime, redundancy, or failover capabilities.",
+                "business": "Assumption about business requirements, constraints, or organizational context.",
+                "compliance": "Assumption about regulatory, legal, or policy compliance obligations.",
+                "operational": "Assumption about operational procedures, staffing, or maintenance practices.",
+                "performance": "Assumption about throughput, latency, capacity, or scalability characteristics.",
+                "security": "Assumption about threat landscape, trust boundaries, or security controls.",
+                "technical": "Assumption about technology choices, capabilities, or technical constraints."
+              }
+            },
+            {
+              "type": "object",
+              "title": "Custom Assumption Topic",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name",
+                  "description": "The name of the custom assumption topic."
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom assumption topic."
+                }
+              }
+            }
+          ]
+        },
+        "relatedAssets": {
+          "type": "array",
+          "title": "Related Assets",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the assets that are directly affected by or dependent on this assumption, enabling impact analysis when the assumption's validity changes."
+        },
+        "validity": {
+          "type": "string",
+          "title": "Validity",
+          "enum": [
+            "invalid",
+            "unknown",
+            "unverified",
+            "verified"
+          ],
+          "meta:enum": {
+            "invalid": "The assumption has been disproven or is no longer applicable.",
+            "unknown": "The validity of the assumption has not yet been assessed.",
+            "unverified": "The assumption has been identified but not yet validated.",
+            "verified": "The assumption has been confirmed as true through validation."
+          },
+          "default": "unknown",
+          "description": "The current validation state of the assumption, tracked over time to ensure that modelling decisions built on this assumption remain sound."
+        },
+        "impact": {
+          "type": "string",
+          "title": "Impact",
+          "description": "A narrative describing the consequences to the model, its assets, or the broader system if this assumption proves false, including the severity and scope of affected components."
+        },
+        "owner": {
+          "$ref": "cyclonedx-party-2.0.schema.json#/$defs/partyChoice",
+          "description": "The party responsible for tracking, validating, and maintaining this assumption over the lifecycle of the model. May be an inline party object or a reference to a previously declared party. The party's `roles` should include `owner`."
+        },
+        "validationMethod": {
+          "type": "string",
+          "title": "Validation Method",
+          "description": "The approach, test, or evidence that can be used to confirm or disprove this assumption, such as a review, audit, penetration test, or empirical measurement."
+        },
+        "validationDate": {
+          "type": "string",
+          "title": "Validation Date",
+          "format": "date-time",
+          "description": "The date and time when the assumption was last validated or reviewed, used to track staleness and trigger re-evaluation."
+        }
+      }
+    },
+    "visualization": {
+      "type": "object",
+      "title": "Visualization",
+      "description": "A visual representation of the model or a subset of its elements, capturing the diagram type, its content, and the elements depicted.",
+      "required": [
+        "name",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "minLength": 1,
+          "description": "Name or title of the visualization."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Description of what the visualization shows."
+        },
+        "type": {
+          "$ref": "#/$defs/visualizationType"
+        },
+        "attachment": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/attachment"
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "format": "iri-reference",
+          "description": "URL to the diagram if stored externally."
+        },
+        "level": {
+          "type": "string",
+          "title": "Level",
+          "enum": [
+            "detailed",
+            "high",
+            "medium",
+            "overview"
+          ],
+          "meta:enum": {
+            "detailed": "Fine-grained view showing implementation-level specifics.",
+            "high": "High-level view showing major components and relationships.",
+            "medium": "Intermediate view balancing breadth and depth.",
+            "overview": "Top-level summary providing a broad perspective of the system."
+          },
+          "description": "Level of detail in the visualization."
+        },
+        "elements": {
+          "type": "array",
+          "title": "Elements",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to elements shown in this visualization."
+        },
+        "interactive": {
+          "type": "boolean",
+          "title": "Interactive",
+          "description": "Whether the visualization is interactive."
+        },
+        "layers": {
+          "type": "array",
+          "title": "Layers",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "Layers or views available in the visualization."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "visualizationType": {
+      "type": "object",
+      "title": "Visualization Type",
+      "description": "The type of diagram or visual representation.",
+      "oneOf": [
+        {
+          "title": "Predefined Visualization Type",
+          "description": "A visualization type selected from a predefined set of well-known diagram types.",
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "enum": [
+                "activity",
+                "architecture",
+                "attack-tree",
+                "block",
+                "class",
+                "code",
+                "communication",
+                "component",
+                "container",
+                "context",
+                "data-flow",
+                "deployment",
+                "entity",
+                "flowchart",
+                "matrix",
+                "mind-map",
+                "network",
+                "process",
+                "sequence",
+                "state",
+                "timing",
+                "use-case"
+              ],
+              "meta:enum": {
+                "activity": "Activity or workflow diagram.",
+                "architecture": "System architecture diagram.",
+                "attack-tree": "Attack tree diagram showing alternative paths to a goal.",
+                "block": "Block diagram, including SysML block definition and internal block diagrams.",
+                "class": "Class or object diagram.",
+                "code": "Code structure diagram.",
+                "communication": "Communication diagram, formerly known as the collaboration diagram.",
+                "component": "Component diagram.",
+                "container": "Container diagram, as in C4.",
+                "context": "Context diagram.",
+                "data-flow": "Data flow diagram, or DFD.",
+                "deployment": "Deployment or infrastructure diagram.",
+                "entity": "Entity relationship diagram.",
+                "flowchart": "Flowchart depicting steps or decision logic.",
+                "matrix": "Matrix diagram, such as a dependency structure or traceability matrix.",
+                "mind-map": "Mind map diagram for decomposition or brainstorming.",
+                "network": "Network topology diagram.",
+                "process": "Business process diagram.",
+                "sequence": "Sequence or interaction diagram.",
+                "state": "State machine diagram.",
+                "timing": "Timing diagram showing state changes over time.",
+                "use-case": "Use case diagram."
+              }
+            }
+          }
+        },
+        {
+          "title": "Custom Visualization Type",
+          "description": "A custom visualization type not covered by the predefined enumeration.",
+          "required": [
+            "name"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "minLength": 1,
+              "description": "The name of the custom visualization type."
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "A description of the custom visualization type."
+            }
+          }
+        }
+      ]
+    },
+    "assetClassification": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "criticality": {
+          "$ref": "cyclonedx-risk-2.0.schema.json#/$defs/criticality"
+        },
+        "classification": {
+          "$ref": "cyclonedx-data-2.0.schema.json#/$defs/dataClassification"
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Business or technical categories."
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Tags for classification and search."
+        }
+      }
+    },
+    "ownership": {
+      "type": "array",
+      "title": "Ownership",
+      "description": "Parties responsible for the asset. Each entry is either an inline party object or a reference to a previously declared party. The party's `roles` carry the relationship (`owner`, `steward`, `custodian`, `end-user`, or a custom role). Multiple parties may share the same role; preference among them is expressed via `role.order`.",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "cyclonedx-party-2.0.schema.json#/$defs/partyChoice"
+      }
+    },
+    "authenticationType": {
+      "title": "Authentication Type",
+      "description": "The authentication method or protocol used to verify identity, either a predefined value from the enumeration or a custom object describing a method not covered by the enumeration.",
+      "oneOf": [
+        {
+          "type": "string",
+          "title": "Predefined Authentication Type",
+          "description": "A predefined authentication method from the enumeration.",
+          "enum": [
+            "api-key",
+            "basic",
+            "bearer",
+            "biometric",
+            "certificate",
+            "digest",
+            "eap",
+            "fido2",
+            "form",
+            "hmac",
+            "jwt",
+            "kerberos",
+            "ldap",
+            "magic-link",
+            "mtls",
+            "none",
+            "ntlm",
+            "oauth1",
+            "oauth2",
+            "oidc",
+            "pin",
+            "psk",
+            "push",
+            "radius",
+            "saml",
+            "scram",
+            "session-cookie",
+            "ssh",
+            "totp"
+          ],
+          "meta:enum": {
+            "api-key": "API key authentication.",
+            "basic": "HTTP Basic authentication (RFC 7617), where the browser presents a native credential dialog and the username and password are sent on each request.",
+            "bearer": "Bearer token authentication.",
+            "biometric": "Biometric authentication, such as fingerprint or face recognition.",
+            "certificate": "Certificate-based authentication.",
+            "digest": "Digest authentication.",
+            "eap": "Extensible Authentication Protocol, commonly used with IEEE 802.1X.",
+            "fido2": "FIDO2 or WebAuthn passwordless authentication.",
+            "form": "Form-based authentication, where credentials such as a username and password are submitted through an application login form rather than the browser-native HTTP Basic dialog.",
+            "hmac": "HMAC request signing using a shared secret key.",
+            "jwt": "JSON Web Token authentication.",
+            "kerberos": "Kerberos authentication.",
+            "ldap": "LDAP directory authentication.",
+            "magic-link": "Passwordless authentication using a single-use link.",
+            "mtls": "Mutual TLS authentication.",
+            "none": "No authentication required.",
+            "ntlm": "NTLM authentication.",
+            "oauth1": "OAuth 1.0 authentication.",
+            "oauth2": "OAuth 2.0 authentication.",
+            "oidc": "OpenID Connect authentication.",
+            "pin": "Personal identification number, a short secret used as a knowledge factor, such as a device or application unlock PIN.",
+            "psk": "Pre-shared key authentication.",
+            "push": "Out-of-band push approval, where a prompt is sent to a registered device or application for the user to approve or deny, optionally confirmed by matching a displayed number.",
+            "radius": "RADIUS authentication.",
+            "saml": "SAML authentication.",
+            "scram": "Salted Challenge Response Authentication Mechanism.",
+            "session-cookie": "Session authentication using a server-side session identified by a cookie.",
+            "ssh": "SSH key authentication.",
+            "totp": "Time-based one-time password authentication."
+          }
+        },
+        {
+          "type": "object",
+          "title": "Custom Authentication Type",
+          "description": "A custom authentication method not covered by the predefined enumeration, allowing organisations to describe proprietary, emerging, or composite authentication approaches.",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "minLength": 1,
+              "description": "The name of the custom authentication method."
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "A description of the custom authentication method, including how identity is verified and any relevant constraints."
+            }
+          }
+        }
+      ]
+    },
+    "authorizationType": {
+      "title": "Authorization Type",
+      "description": "The authorization model used to determine and enforce access permissions, either a predefined value from the enumeration or a custom object describing a model not covered by the enumeration.",
+      "oneOf": [
+        {
+          "type": "string",
+          "title": "Predefined Authorization Type",
+          "description": "A predefined authorization model from the enumeration.",
+          "enum": [
+            "abac",
+            "acl",
+            "capability",
+            "dac",
+            "mac",
+            "none",
+            "pbac",
+            "radac",
+            "rbac",
+            "rebac"
+          ],
+          "meta:enum": {
+            "abac": "Attribute-Based Access Control.",
+            "acl": "Access Control Lists.",
+            "capability": "Capability-Based Access Control.",
+            "dac": "Discretionary Access Control.",
+            "mac": "Mandatory Access Control.",
+            "none": "No authorization controls.",
+            "pbac": "Policy-Based Access Control.",
+            "radac": "Risk-Adaptive Access Control.",
+            "rbac": "Role-Based Access Control.",
+            "rebac": "Relationship-Based Access Control."
+          }
+        },
+        {
+          "type": "object",
+          "title": "Custom Authorization Type",
+          "description": "A custom authorization model not covered by the predefined enumeration, allowing organisations to describe proprietary, domain-specific, or composite access control models.",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "minLength": 1,
+              "description": "The name of the custom authorization model."
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "A description of the custom authorization model, including how access decisions are made and any relevant constraints."
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev-threatmodeling/cyclonedx-party-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev-threatmodeling/cyclonedx-party-2.0.schema.json
@@ -1,0 +1,925 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-party-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Party Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "party": {
+      "type": "object",
+      "title": "Party",
+      "description": "Identifies an organization, individual, system, or abstract archetype that participates in supplying, producing, attesting, operating, owning, regulating, or otherwise relating to the subject. Each party plays one or more named roles. Roles may carry preference order (`role.order`) to express primary, alternate, and secondary rankings among parties sharing the same role.\n\nExactly one identity sub-shape (`organization`, `person`, `system`, or `persona`) shall be present. Optional sub-objects layer inter-party relationships and standard extension data.",
+      "required": [ "roles" ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "roles": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/role" },
+          "title": "Roles",
+          "description": "One or more roles the party fulfils. Each role may carry an `order` indicating preference among parties sharing the same role (for example, primary versus alternate supplier)."
+        },
+        "organization": {
+          "$ref": "#/$defs/organization",
+          "description": "Identity attributes valid when the party is an organization, company, government body, or other collective."
+        },
+        "person": {
+          "$ref": "#/$defs/person",
+          "description": "Identity attributes valid when the party is an individual person."
+        },
+        "system": {
+          "$ref": "#/$defs/system",
+          "title": "System",
+          "description": "Identity attributes valid when the party is a software system, hardware system, service account, automation, or autonomous agent."
+        },
+        "persona": {
+          "$ref": "#/$defs/persona",
+          "title": "Persona",
+          "description": "Identity attributes valid when the party is an abstract archetype rather than a specific named instance."
+        },
+        "relations": {
+          "$ref": "#/$defs/partyRelations",
+          "title": "Relations",
+          "description": "Links from this party to other parties."
+        },
+        "tags": { "$ref": "cyclonedx-common-2.0.schema.json#/$defs/tags" },
+        "properties": { "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties" },
+        "externalReferences": { "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReferences" }
+      },
+      "oneOf": [
+        { "required": [ "organization" ] },
+        { "required": [ "person" ] },
+        { "required": [ "system" ] },
+        { "required": [ "persona" ] }
+      ]
+    },
+    "parties": {
+      "type": "array",
+      "title": "Parties",
+      "description": "Parties associated with the subject. Each item identifies an organization, individual, system, or abstract archetype playing one or more named roles such as manufacturer, supplier, author, integrator, quality-control, or any custom role. The same party can hold multiple roles, each independently ranked via `role.order` to express preference (for example, primary supplier with order 1 and alternate supplier with order 2). Items may be inline party objects or references to parties declared elsewhere.",
+      "items": { "$ref": "#/$defs/partyChoice" }
+    },
+    "partyChoice": {
+      "title": "Party Choice",
+      "description": "A party represented either as a complete object or as a reference to a previously declared party.",
+      "oneOf": [
+        { "$ref": "#/$defs/party" },
+        {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "title": "Reference",
+          "description": "A refLinkType pointing to a previously declared party."
+        }
+      ]
+    },
+    "role": {
+      "title": "Role",
+      "description": "A role that a party fulfils. May be a predefined role from the CycloneDX role taxonomy or a custom role definition. The optional `order` property ranks parties that share the same role, supporting use cases such as primary versus alternate suppliers in hardware manufacturing supply chains.",
+      "oneOf": [
+        { "$ref": "#/$defs/preDefinedRole" },
+        {
+          "title": "Custom Role",
+          "type": "object",
+          "required": [ "name" ],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "title": "Name",
+              "description": "The name of the custom role.",
+              "examples": [ "Chief Executive Officer", "Data Protection Officer", "Release Manager" ]
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "A description of the custom role, including its responsibilities and scope."
+            },
+            "order": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Order",
+              "description": "Preference order among parties sharing this role. Lower values indicate higher preference. Ties are permitted. Absence means unranked."
+            }
+          }
+        }
+      ]
+    },
+    "preDefinedRole": {
+      "title": "Pre-Defined Role",
+      "type": "object",
+      "required": [ "role" ],
+      "additionalProperties": false,
+      "properties": {
+        "role": {
+          "type": "string",
+          "title": "Role",
+          "description": "A predefined role from the CycloneDX role taxonomy.",
+          "enum": [
+            "agent",
+            "assembler",
+            "asserter",
+            "attacker",
+            "auditor",
+            "author",
+            "broker",
+            "carrier",
+            "certificate-authority",
+            "committer",
+            "competitor",
+            "consignee",
+            "consignor",
+            "contributor",
+            "customer",
+            "custodian",
+            "customs-broker",
+            "data-controller",
+            "data-processor",
+            "data-recipient",
+            "data-subject",
+            "delegate",
+            "developer",
+            "distributor",
+            "end-user",
+            "engineer",
+            "exporter",
+            "freight-forwarder",
+            "holder",
+            "importer",
+            "insider-threat",
+            "inspector",
+            "insurer",
+            "integrator",
+            "issuer",
+            "key-escrow-agent",
+            "legal-contact",
+            "licensee",
+            "licensor",
+            "maintainer",
+            "manufacturer",
+            "operator",
+            "owner",
+            "packager",
+            "partner",
+            "principal",
+            "publisher",
+            "purchaser",
+            "quality-control",
+            "regulator",
+            "relying-party",
+            "repackager",
+            "researcher",
+            "reviewer",
+            "security-contact",
+            "signatory",
+            "steward",
+            "subject",
+            "supplier",
+            "support-contact",
+            "third-party-logistics",
+            "timestamp-authority",
+            "validation-authority",
+            "verifier",
+            "warehouse-operator"
+          ],
+          "meta:enum": {
+            "agent":                 "Software or AI agent acting autonomously or semi-autonomously, typically on behalf of a principal.",
+            "assembler":             "The party that assembles or integrates constituent parts into the subject. Common in hardware manufacturing and software build pipelines.",
+            "asserter":              "The party making assertions about the subject, such as patent ownership or compliance claims.",
+            "attacker":              "A hostile party targeting the subject.",
+            "auditor":               "The party that conducted an audit or assessment of the subject.",
+            "author":                "The party that created the subject. Common when the subject is created through manual processes.",
+            "broker":                "The party that acts as an intermediary in commercial transactions.",
+            "carrier":               "The party that physically transports goods, such as shipping lines, airlines, or trucking companies.",
+            "certificate-authority": "The party that issues, signs, and manages digital certificates within a public key infrastructure.",
+            "committer":             "The party who committed or pushed changes to a version control system.",
+            "competitor":            "A competing party in the same market or domain as the subject's organization.",
+            "consignee":             "The party designated to receive a shipment of goods.",
+            "consignor":             "The party that sends or ships goods to a consignee.",
+            "contributor":           "A party that contributed to the development of the subject without being the primary author.",
+            "customer":              "Customer of the organization that owns the subject.",
+            "custodian":             "The party responsible for the safe custody, transport, and storage of the subject.",
+            "customs-broker":        "The party that facilitates the clearance of goods through customs barriers.",
+            "data-controller":       "The party that determines the purposes and means of processing personal data.",
+            "data-processor":        "The party that processes personal data on behalf of a data controller.",
+            "data-recipient":        "The party to which personal data is disclosed.",
+            "data-subject":          "The natural person whose personal data is processed.",
+            "delegate":              "A party exercising authority on behalf of another party identified via relations.delegatedBy.",
+            "developer":             "Software developer or platform engineer.",
+            "distributor":           "The party that distributes the subject to downstream consumers or customers.",
+            "end-user":              "The end user of a system, service, or product.",
+            "engineer":              "Engineer responsible for designing, implementing, or operating a system.",
+            "exporter":              "The party that sends goods to another country for trade or sale.",
+            "freight-forwarder":     "The party that arranges the shipment and logistics of goods on behalf of shippers.",
+            "holder":                "The party that holds a verifiable credential, claim, or asset.",
+            "importer":              "The party that brings goods into a country from abroad for trade or sale.",
+            "insider-threat":        "A hostile or negligent party with legitimate access.",
+            "inspector":             "The party that inspects goods for quality, safety, or regulatory compliance.",
+            "insurer":               "The party that provides insurance coverage.",
+            "integrator":            "The party that integrates the subject into a larger system or product.",
+            "issuer":                "The party that issues a credential, claim, identifier, or asset.",
+            "key-escrow-agent":      "The party that holds copies of cryptographic keys in escrow.",
+            "legal-contact":         "The designated party to contact for legal matters.",
+            "licensee":              "The party to which a license for the subject has been granted.",
+            "licensor":              "The party that grants a license for the subject.",
+            "maintainer":            "The party responsible for ongoing maintenance, including updates, patches, and security fixes.",
+            "manufacturer":          "The party that manufactured or produced the subject. Common when the subject is produced through automated processes.",
+            "operator":              "The party responsible for operating or running the subject in a production environment.",
+            "owner":                 "The party that holds ownership rights over the subject.",
+            "packager":              "The party that packages goods for storage, shipment, or retail sale.",
+            "partner":               "Business partner with a defined relationship.",
+            "principal":             "The party on whose behalf another party acts, paired with delegate.",
+            "publisher":             "The party that published the subject, making it available for consumption.",
+            "purchaser":             "The party that purchased the subject or a license for its use.",
+            "quality-control":       "The party responsible for quality control activities, including inspection, testing, and verification.",
+            "regulator":             "Government or industry regulator with administrative authority over the subject.",
+            "relying-party":         "The party that relies on credentials, claims, or attestations issued by another party.",
+            "repackager":            "The party that repackages the subject, potentially combining it with other components.",
+            "researcher":            "Security researcher, bug bounty hunter, or academic conducting authorized study.",
+            "reviewer":              "The party that reviewed the subject or its associated evidence.",
+            "security-contact":     "The designated party to contact in the event of a security incident.",
+            "signatory":             "The party authorized to sign on behalf of an organization, affirming the validity or accuracy of statements or attestations.",
+            "steward":               "The party responsible for the content, context, and associated business rules of the subject.",
+            "subject":               "The party to whom an issued credential, claim, or identifier is bound.",
+            "supplier":              "The party that supplied the subject. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
+            "support-contact":      "The designated party to contact for technical support.",
+            "third-party-logistics": "The party that provides outsourced logistics services.",
+            "timestamp-authority":   "The party that issues trusted timestamps.",
+            "validation-authority":  "The party that provides certificate validation services.",
+            "verifier":              "The party that verifies credentials, claims, or attestations.",
+            "warehouse-operator":    "The party responsible for storing, handling, and managing inventory within a warehouse or distribution centre."
+          }
+        },
+        "order": {
+          "type": "integer",
+          "minimum": 1,
+          "title": "Order",
+          "description": "Preference order among parties sharing this role. Lower values indicate higher preference. Ties are permitted. Absence means unranked. For example, a primary supplier may have `order: 1` while an alternate supplier has `order: 2`.",
+          "examples": [ 1, 2, 3 ]
+        }
+      }
+    },
+    "organization": {
+      "type": "object",
+      "title": "Organization Identity",
+      "description": "Identity attributes for a party that is an organization, company, government body, or other collective.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The common display or trading name of the organization. Use when the registered legal name is unknown or when the everyday name differs from the legal one.",
+          "examples": [ "Acme", "Globex" ]
+        },
+        "legalName": {
+          "type": "string",
+          "title": "Legal Name",
+          "description": "The registered legal name of the organization, including any suffix such as Inc., S.r.l., GmbH, or LLC.",
+          "examples": [ "Acme Microcontrollers S.r.l.", "Acme Holdings, Inc." ]
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the organization itself, distinct from any role-specific or contextual description applied at the party wrapper level."
+        },
+        "logo": {
+          "type": "string",
+          "format": "iri-reference",
+          "title": "Logo",
+          "description": "URL to an image representing the organization. Useful for catalog, datasheet, and user interface views."
+        },
+        "foundingDate": {
+          "type": "string",
+          "format": "date",
+          "title": "Founding Date",
+          "description": "The date the organization was founded. Supports supplier due diligence and age-of-organization signals."
+        },
+        "dissolutionDate": {
+          "type": "string",
+          "format": "date",
+          "title": "Dissolution Date",
+          "description": "The date the organization was dissolved or wound down. When present, the organization is no longer active."
+        },
+        "jurisdiction": {
+          "type": "string",
+          "title": "Jurisdiction",
+          "description": "Country of registration as an ISO 3166-1 alpha-2 or alpha-3 code, optionally followed by an ISO 3166-2 subdivision separated by a hyphen.",
+          "examples": [ "US-DE", "IT-BO", "CHE" ]
+        },
+        "identifiers": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/identifier" },
+          "title": "Identifiers",
+          "description": "Identifiers issued to or associated with the organization. May include legal and registration identifiers (LEI, DUNS, CAGE, NCAGE, EORI, VAT, tax identifiers) and non-legal identifiers such as workload or machine identities."
+        },
+        "formerNames": {
+          "type": "array",
+          "items": { "type": "string" },
+          "title": "Former Names",
+          "description": "Prior names of the organization. Use when the entity has been renamed, merged, or acquired. Distinct from `aliases`, which captures concurrent alternate designations.",
+          "examples": [ [ "Atmel Corporation" ] ]
+        },
+        "aliases": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "title": "Aliases",
+          "description": "Concurrent alternate designations for the organization. Distinct from `formerNames`, which captures historical names. Common when modeling tracked threat-actor groups that are known by different designations across threat-intelligence vendors.",
+          "examples": [ [ "Fancy Bear", "STRONTIUM", "Sofacy", "Sednit", "Pawn Storm" ] ]
+        },
+        "url": {
+          "type": "array",
+          "title": "URLs",
+          "description": "URLs associated with the organization. Each entry carries a `name` label and a `url` value so producers can describe homepage, support portal, press, status, code repository, and similar without ambiguity.",
+          "items": {
+            "type": "object",
+            "required": [ "url" ],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name",
+                "description": "Label describing the URL, such as `homepage`, `support`, `press`, `status`, or `repository`.",
+                "examples": [ "homepage", "support", "press", "status", "repository" ]
+              },
+              "url": {
+                "type": "string",
+                "format": "iri-reference",
+                "title": "URL"
+              }
+            }
+          }
+        },
+        "addresses": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/postalAddress" },
+          "title": "Addresses",
+          "description": "Physical addresses associated with the organization."
+        }
+      }
+    },
+    "person": {
+      "type": "object",
+      "title": "Person Identity",
+      "description": "Identity attributes for a party that is an individual person. The name model is intentionally unstructured: a single freeform `name` captures the full name as the person wishes to be known, accommodating the wide variation of naming conventions across cultures. See https://www.w3.org/International/questions/qa-personal-names for background.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Name",
+          "description": "The person's full name as they wish to be known. A single freeform string. No assumption is made about given-versus-family ordering, mononym versus multi-component names, patronymics, or honorific embedding. Producers should use the form the person uses themselves.",
+          "examples": [ "Ada Lovelace", "Suharto", "Maria del Carmen García López", "Nguyễn Văn An" ]
+        },
+        "sortName": {
+          "type": "string",
+          "title": "Sort Name",
+          "description": "Optional sortable form of the name for catalog and index views. Use when the natural form of `name` does not sort intuitively, for example a comma-separated last-name-first form.",
+          "examples": [ "Lovelace, Ada", "García López, Maria del Carmen" ]
+        },
+        "honorificPrefix": {
+          "type": "string",
+          "title": "Honorific Prefix",
+          "description": "Honorific or title preceding the name, used in forms of address. Distinct from the name itself.",
+          "examples": [ "Dr.", "Prof." ]
+        },
+        "honorificSuffix": {
+          "type": "string",
+          "title": "Honorific Suffix",
+          "description": "Honorific or post-nominal letters following the name, used in forms of address. Distinct from the name itself.",
+          "examples": [ "PhD", "Esq." ]
+        },
+        "jobTitle": {
+          "type": "string",
+          "title": "Job Title",
+          "description": "The person's job title. Useful for credit lines and attribution.",
+          "examples": [ "Chief Information Security Officer", "Data Protection Officer", "Senior Software Engineer" ]
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the person, distinct from any role-specific or contextual description applied at the party wrapper level."
+        },
+        "email": {
+          "type": "array",
+          "title": "Email",
+          "description": "Email addresses associated with the person. Each entry carries a `name` label and an `address` value so producers can describe work, personal, support, and similar contexts without ambiguity.",
+          "items": {
+            "type": "object",
+            "required": [ "address" ],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name",
+                "description": "Label describing the email, such as `work`, `personal`, `support`, or `security`.",
+                "examples": [ "work", "personal", "support", "security" ]
+              },
+              "address": {
+                "type": "string",
+                "format": "idn-email",
+                "title": "Address"
+              }
+            }
+          }
+        },
+        "phone": {
+          "type": "array",
+          "title": "Phone",
+          "description": "Phone numbers associated with the person. Each entry carries a `name` label and a `number` value. Numbers should be expressed in E.164 form where possible.",
+          "items": {
+            "type": "object",
+            "required": [ "number" ],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name",
+                "description": "Label describing the phone, such as `office`, `mobile`, `fax`, or `pager`.",
+                "examples": [ "office", "mobile", "fax", "pager" ]
+              },
+              "number": {
+                "type": "string",
+                "title": "Number",
+                "examples": [ "+1-555-0100", "+44 20 7946 0958" ]
+              }
+            }
+          }
+        },
+        "url": {
+          "type": "array",
+          "title": "URLs",
+          "description": "URLs associated with the person. Each entry carries a `name` label and a `url` value so producers can describe homepage, social profiles, code repositories, and similar without ambiguity.",
+          "items": {
+            "type": "object",
+            "required": [ "url" ],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name",
+                "description": "Label describing the URL, such as `homepage`, `github`, `linkedin`, `mastodon`, or `orcid`.",
+                "examples": [ "homepage", "github", "linkedin", "orcid" ]
+              },
+              "url": {
+                "type": "string",
+                "format": "iri-reference",
+                "title": "URL"
+              }
+            }
+          }
+        },
+        "address": {
+          "$ref": "#/$defs/postalAddress",
+          "title": "Address"
+        },
+        "affiliation": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "title": "Affiliation",
+          "description": "Reference using bom-link or bom-ref to an organization party with which the person is affiliated."
+        }
+      }
+    },
+    "system": {
+      "type": "object",
+      "title": "System Identity",
+      "description": "Identity attributes for a party that is a software system, hardware system, service account, automation, or autonomous agent.",
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "title": "Kind",
+          "description": "The kind of system the party represents. May be a predefined kind from the CycloneDX system-kind taxonomy expressed as a plain string, or a custom kind expressed as an object with `name` and optional `description`.",
+          "oneOf": [
+            {
+              "title": "Pre-Defined Kind",
+              "type": "string",
+              "enum": [
+                "software-system",
+                "hardware-system",
+                "service-account",
+                "machine-identity",
+                "automation",
+                "agent",
+                "bot",
+                "oracle",
+                "smart-contract",
+                "device",
+                "robot"
+              ],
+              "meta:enum": {
+                "software-system":  "Application, service, or platform that performs actions as itself.",
+                "hardware-system":  "Physical device or appliance that performs actions. Includes vehicles, drones, satellites, medical devices, network equipment, and industrial controllers unless a more specific kind applies.",
+                "service-account":  "Non-human identity used by automation to authenticate.",
+                "machine-identity": "Cryptographic identity such as a certificate principal or workload identity.",
+                "automation":       "Pipeline, job, or scheduled task that performs actions deterministically.",
+                "agent":            "Autonomous or semi-autonomous agent that can plan and execute. Includes AI agents.",
+                "bot":              "Scripted automation that interacts with an interface. Includes chatbots, robotic process automation bots, and scraping bots.",
+                "oracle":           "External data feed or oracle, including blockchain oracles that bridge off-chain data into on-chain systems.",
+                "smart-contract":   "On-chain program that executes deterministically.",
+                "device":           "Physical end user device such as a phone or IoT device acting as a party in its own right.",
+                "robot":            "Physical robot or autonomous mechanical system. For software-only counterparts, see `bot`, `agent`, or `automation`."
+              }
+            },
+            {
+              "title": "Custom Kind",
+              "type": "object",
+              "required": [ "name" ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name",
+                  "description": "The name of the custom kind."
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom kind."
+                }
+              }
+            }
+          ]
+        },
+        "ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "title": "Reference",
+          "description": "Reference to any bom-ref'd object that represents this system. The referenced object provides the underlying identity (component, service, blueprint asset, or other object type). Use to associate the party with its concrete representation declared elsewhere."
+        },
+        "identifiers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/identifier" },
+          "title": "Identifiers",
+          "description": "Machine identifiers for the system, such as service principal, workload identity, certificate subject, or device serial."
+        },
+        "permissions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "title": "Permissions",
+          "description": "Capabilities or duties the system possesses."
+        }
+      }
+    },
+    "persona": {
+      "type": "object",
+      "title": "Persona Identity",
+      "description": "Identity attributes for a party that is an abstract archetype rather than a specific named instance. Use for generic users, generic suppliers, or hypothesized attackers when a specific party is intentionally not named. When the specific instance is known (for example a tracked APT group), use `organization` instead.",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Free-text description of the persona instance. Use to refine the archetype with details relevant to the threat model, such as the persona's assumed context, history, or behavioral pattern.",
+          "examples": [ "Disgruntled administrator with elevated access to the payment gateway and motive driven by recent performance review." ]
+        },
+        "archetype": {
+          "title": "Archetype",
+          "description": "The persona archetype. May be a predefined archetype from the CycloneDX persona-archetype taxonomy expressed as a plain string, or a custom archetype expressed as an object with `name` and optional `description`.",
+          "oneOf": [
+            {
+              "title": "Pre-Defined Archetype",
+              "type": "string",
+              "enum": [
+                "end-user",
+                "power-user",
+                "administrator",
+                "developer",
+                "operator",
+                "internal",
+                "external",
+                "anonymous",
+                "guest",
+                "customer",
+                "partner",
+                "supplier",
+                "vendor",
+                "contractor",
+                "third-party",
+                "auditor",
+                "researcher",
+                "regulator",
+                "law-enforcement",
+                "attacker",
+                "insider-threat",
+                "hacktivist",
+                "nation-state",
+                "organized-crime",
+                "competitor",
+                "public"
+              ],
+              "meta:enum": {
+                "end-user":         "Typical end user of the system.",
+                "power-user":       "Advanced user with higher than average privileges.",
+                "administrator":    "Administrative or privileged user.",
+                "developer":        "Application developer or platform engineer.",
+                "operator":         "Operational staff running the system.",
+                "internal":         "Generic internal party.",
+                "external":         "Generic external party without an account or operational relationship.",
+                "anonymous":        "Unauthenticated visitor interacting with the system.",
+                "guest":            "Semi-authenticated user with restricted privileges.",
+                "customer":         "Customer of the organization that owns the subject.",
+                "partner":          "Business partner with a defined relationship.",
+                "supplier":         "Generic supplier providing goods or services on a transactional basis.",
+                "vendor":           "Vendor delivering and operating goods or services with operational access to the subject.",
+                "contractor":       "Third party with operational access under contract.",
+                "third-party":      "Generic third party that does not fit partner, supplier, vendor, or contractor.",
+                "auditor":          "External auditor or assessor.",
+                "researcher":       "Security researcher, bug bounty hunter, or academic. Authorized probing party.",
+                "regulator":        "Government or industry regulator with administrative authority over the subject.",
+                "law-enforcement":  "Law enforcement entity with investigative authority.",
+                "attacker":         "Generic hostile external party.",
+                "insider-threat":   "Hostile or negligent party with legitimate access.",
+                "hacktivist":       "Hostile party motivated by ideology or activism.",
+                "nation-state":     "Hostile party sponsored or directed by a national government.",
+                "organized-crime":  "Hostile party operating as part of an organized criminal enterprise.",
+                "competitor":       "Generic competitor.",
+                "public":           "General public not in direct interaction with the subject."
+              }
+            },
+            {
+              "title": "Custom Archetype",
+              "type": "object",
+              "required": [ "name" ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name"
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description"
+                }
+              }
+            }
+          ]
+        },
+        "scope": {
+          "type": "string",
+          "title": "Scope",
+          "enum": [
+            "internal",
+            "external",
+            "mixed"
+          ],
+          "meta:enum": {
+            "internal": "Persona is internal to the organization that owns the subject.",
+            "external": "Persona is external to the organization that owns the subject.",
+            "mixed":    "Persona may appear in either internal or external contexts."
+          }
+        },
+        "permissions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "title": "Permissions",
+          "description": "Capabilities the persona is assumed to hold."
+        },
+        "assumedPosture": {
+          "type": "string",
+          "title": "Assumed Security Posture",
+          "description": "Assumed security posture of the persona in this context.",
+          "examples": [ "authenticated", "unauthenticated", "authorized", "privileged" ]
+        }
+      }
+    },
+    "partyRelations": {
+      "type": "object",
+      "title": "Party Relations",
+      "description": "Links from this party to other parties. Captures hierarchical, organizational, and delegation relationships. Order ranking is on the role itself (`role.order`), not here.",
+      "additionalProperties": false,
+      "properties": {
+        "parent": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "title": "Parent",
+          "description": "Reference to a parent party. Models organizational hierarchy, group membership, and corporate parent or subsidiary relationships."
+        },
+        "delegatedBy": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "title": "Delegated By",
+          "description": "Reference to another party that delegated authority to this one. Models situations such as an autonomous agent acting on behalf of a human user, a contractor acting on behalf of a principal, or a service account assuming a role."
+        }
+      }
+    },
+    "identifier": {
+      "type": "object",
+      "title": "Identifier",
+      "description": "An identifier issued by a recognized authority. Includes legal and registration identifiers as well as machine and workload identities.",
+      "required": [ "scheme", "value" ],
+      "additionalProperties": false,
+      "properties": {
+        "scheme": {
+          "title": "Scheme",
+          "description": "The identifier scheme. May be a predefined scheme from the CycloneDX identifier-scheme taxonomy expressed as a plain string, or a custom scheme expressed as an object with `name` and optional `description` and `url`.",
+          "oneOf": [
+            {
+              "title": "Pre-Defined Scheme",
+              "type": "string",
+              "enum": [
+                "lei",
+                "duns",
+                "ncage",
+                "cage",
+                "eori",
+                "vat",
+                "gst",
+                "ein",
+                "tin",
+                "ruc",
+                "bvd",
+                "swift-bic",
+                "sec-cik",
+                "isin",
+                "figi",
+                "opencorporates",
+                "gln",
+                "gtin",
+                "iso6523",
+                "ofac-sdn",
+                "un-lm",
+                "oidc-sub",
+                "spiffe",
+                "did",
+                "vc-id"
+              ],
+              "meta:enum": {
+                "lei":            "Legal Entity Identifier per ISO 17442.",
+                "duns":           "Dun and Bradstreet D-U-N-S Number.",
+                "ncage":          "NATO Commercial and Government Entity code.",
+                "cage":           "United States Commercial and Government Entity code.",
+                "eori":           "Economic Operator Registration and Identification number used in European Union customs.",
+                "vat":            "Value Added Tax registration number.",
+                "gst":            "Goods and Services Tax registration number.",
+                "ein":            "United States Employer Identification Number.",
+                "tin":            "Generic Taxpayer Identification Number.",
+                "ruc":            "Registro Unico de Contribuyentes used in several Latin American countries.",
+                "bvd":            "Bureau van Dijk identifier.",
+                "swift-bic":      "Business Identifier Code per ISO 9362.",
+                "sec-cik":        "United States Securities and Exchange Commission Central Index Key.",
+                "isin":           "International Securities Identification Number per ISO 6166.",
+                "figi":           "Financial Instrument Global Identifier.",
+                "opencorporates": "OpenCorporates company identifier.",
+                "gln":            "GS1 Global Location Number.",
+                "gtin":           "GS1 Global Trade Item Number when the party is also a registered trade entity.",
+                "iso6523":        "ISO 6523 organization identifier. The value should encode the four-digit International Code Designator (ICD) followed by the organization identifier per the registry referenced by the ICD.",
+                "ofac-sdn":       "United States Office of Foreign Assets Control Specially Designated Nationals list identifier.",
+                "un-lm":          "United Nations Locode for a specific facility or jurisdiction.",
+                "oidc-sub":       "OpenID Connect subject identifier for a machine or service identity.",
+                "spiffe":         "SPIFFE ID for a workload identity.",
+                "did":            "W3C Decentralized Identifier (DID) per https://www.w3.org/TR/did-core/. Common for autonomous agents, federated services, and verifiable-credential subjects.",
+                "vc-id":          "W3C Verifiable Credential identifier per https://www.w3.org/TR/vc-data-model/."
+              }
+            },
+            {
+              "title": "Custom Scheme",
+              "type": "object",
+              "required": [ "name" ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name"
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "iri-reference",
+                  "title": "URL",
+                  "description": "URL of the scheme registry or specification."
+                }
+              }
+            }
+          ]
+        },
+        "schemeVersion": {
+          "type": "string",
+          "title": "Scheme Version",
+          "description": "The version of the scheme that issued this identifier, if applicable."
+        },
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value of the identifier."
+        },
+        "issuedDate": {
+          "type": "string",
+          "format": "date",
+          "title": "Issued Date"
+        },
+        "expirationDate": {
+          "type": "string",
+          "format": "date",
+          "title": "Expiration Date"
+        },
+        "issuer": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "title": "Issuer",
+          "description": "Reference using bom-link or bom-ref to the party that issued the identifier."
+        }
+      }
+    },
+    "postalAddress": {
+      "type": "object",
+      "title": "Postal Address",
+      "description": "An address used to identify a contactable or operational location.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "Reference Identifier",
+          "description": "An optional identifier that can be used to reference the address from elsewhere. Every bom-ref shall be unique within the containing instance. The value should not start with the prefix 'urn:cdx:' to avoid conflicts with BOM-Link identifiers."
+        },
+        "country": {
+          "type": "string",
+          "title": "Country",
+          "description": "The country name or the two-letter ISO 3166-1 country code. When the isoCode property is present, the value of isoCode is authoritative."
+        },
+        "region": {
+          "type": "string",
+          "title": "Region",
+          "description": "The region or state in the country. When the isoCode property carries an ISO 3166-2 subdivision, the value of isoCode is authoritative.",
+          "examples": [ "Texas" ]
+        },
+        "isoCode": {
+          "type": "string",
+          "pattern": "^[A-Z]{2}(-[A-Z0-9]{1,3})?$",
+          "title": "ISO Code",
+          "description": "An ISO 3166-1 alpha-2 country code, optionally followed by an ISO 3166-2 subdivision code separated by a hyphen. When present, this property is authoritative over the free-text country and region properties.",
+          "examples": [ "IT-BO", "US-CA", "DE-BY" ]
+        },
+        "locality": {
+          "type": "string",
+          "title": "Locality",
+          "description": "The locality or city within the country.",
+          "examples": [ "Austin" ]
+        },
+        "postOfficeBoxNumber": {
+          "type": "string",
+          "title": "Post Office Box Number",
+          "description": "The post office box number.",
+          "examples": [ "901" ]
+        },
+        "postalCode": {
+          "type": "string",
+          "title": "Postal Code",
+          "description": "The postal code.",
+          "examples": [ "78758" ]
+        },
+        "streetAddress": {
+          "type": "string",
+          "title": "Street Address",
+          "description": "The street address. Multi-line addresses are expressed as a single string with line breaks (`\\n`) between lines. Implementations and serialization formats are not required to preserve the order of elements in an array, so a multi-line address shall not be modeled as an array.",
+          "examples": [
+            "100 Main Street",
+            "Acme Tower\nSuite 1200\n100 Main Street"
+          ]
+        },
+        "coordinates": {
+          "type": "object",
+          "title": "Geographic Coordinates",
+          "description": "Geographic coordinates of the address.",
+          "additionalProperties": false,
+          "required": [ "latitude", "longitude" ],
+          "properties": {
+            "latitude": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90,
+              "title": "Latitude",
+              "description": "Latitude in decimal degrees. Four or more decimal places are recommended for facility-level precision."
+            },
+            "longitude": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180,
+              "title": "Longitude",
+              "description": "Longitude in decimal degrees. Four or more decimal places are recommended for facility-level precision."
+            },
+            "altitude": {
+              "type": "number",
+              "title": "Altitude",
+              "description": "Altitude in meters above the reference ellipsoid identified by the datum property."
+            },
+            "datum": {
+              "type": "string",
+              "title": "Datum",
+              "description": "The geodetic datum used for the coordinates. WGS84 is assumed when omitted.",
+              "default": "WGS84",
+              "examples": [ "WGS84", "NAD83", "ETRS89" ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev-threatmodeling/cyclonedx-risk-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev-threatmodeling/cyclonedx-risk-2.0.schema.json
@@ -1,0 +1,1497 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-risk-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Risk Model",
+  "$comment": "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "risks": {
+      "type": "object",
+      "title": "Risks",
+      "description": "A collection of risks identified through risk analysis, together with the assessments that evaluate them. The model is framework-neutral and can document risk regardless of the risk management framework in use, including [ISO 31000](https://www.iso.org/iso-31000-risk-management.html), [NIST SP 800-30](https://csrc.nist.gov/pubs/sp/800/30/r1/final), the [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework), [COSO ERM](https://www.coso.org/), [ISO/IEC 27005](https://www.iso.org/standard/80585.html), and OCTAVE. It accommodates qualitative, semi-quantitative, and quantitative assessment, and each rating records the scoring methodology used, such as [FAIR](https://www.fairinstitute.org/), [OWASP Risk Rating](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology), DREAD, [FMEA](https://asq.org/quality-resources/fmea), NIST SP 800-30, or OCTAVE Allegro. Each risk separates inherent, residual, and target ratings so risk reduction is explicit.",
+      "additionalProperties": false,
+      "properties": {
+        "risks": {
+          "type": "array",
+          "title": "Risks",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/risk"
+          },
+          "description": "The documented risks identified through risk analysis."
+        },
+        "assessments": {
+          "type": "array",
+          "title": "Assessments",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/assessment"
+          },
+          "description": "Point-in-time risk assessment events, each evaluating one or more of the documented risks."
+        },
+        "riskAppetites": {
+          "type": "array",
+          "title": "Risk Appetites",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/riskAppetite"
+          },
+          "description": "The risk appetites that apply to this collection. Multiple entries support a document covering more than one party."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "riskDomain": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Type",
+          "description": "The domain or category of risk. Use the custom option for domains specific to an organization's risk taxonomy.",
+          "oneOf": [
+            {
+              "title": "Predefined Risk Domain",
+              "type": "string",
+              "enum": [
+                "security",
+                "privacy",
+                "operational",
+                "financial",
+                "compliance",
+                "strategic",
+                "reputational",
+                "safety",
+                "environmental",
+                "supply-chain",
+                "technical",
+                "project",
+                "ethical",
+                "societal",
+                "human-rights",
+                "health",
+                "legal"
+              ],
+              "meta:enum": {
+                "security": "Information security and cybersecurity risks.",
+                "privacy": "Data protection and privacy risks.",
+                "operational": "Business operations and continuity risks.",
+                "financial": "Financial loss and economic impact risks.",
+                "compliance": "Regulatory and legal compliance risks.",
+                "strategic": "Strategic business and market risks.",
+                "reputational": "Brand and reputation damage risks.",
+                "safety": "Human safety and physical security risks.",
+                "environmental": "Environmental impact and sustainability risks.",
+                "supply-chain": "Supply chain and third-party risks.",
+                "technical": "Technical and technology risks.",
+                "project": "Project delivery and execution risks.",
+                "ethical": "Ethical risks, including the responsible use of automated decision-making and artificial intelligence.",
+                "societal": "Risks to society, communities, or democratic and civic processes.",
+                "human-rights": "Risks to fundamental human rights, including discrimination and loss of autonomy.",
+                "health": "Risks to physical or mental health and wellbeing.",
+                "legal": "Legal exposure, including liability and contractual risks."
+              }
+            },
+            {
+              "title": "Custom Risk Domain",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name",
+                  "description": "The name of the custom risk domain."
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom risk domain."
+                }
+              }
+            }
+          ]
+        },
+        "priority": {
+          "$ref": "#/$defs/priority"
+        },
+        "description": {
+          "type": "string",
+          "description": "Additional context for this risk domain."
+        }
+      }
+    },
+    "riskAttribute": {
+      "title": "Risk Attribute",
+      "description": "A security or privacy attribute representing a potential impact area when a risk is realized. Use the custom option for attributes specific to an organization's risk taxonomy.",
+      "oneOf": [
+        {
+          "title": "Predefined Risk Attribute",
+          "type": "string",
+          "enum": [
+            "accountability",
+            "authentication",
+            "authorization",
+            "authenticity",
+            "availability",
+            "compliance",
+            "confidentiality",
+            "connectivity",
+            "control",
+            "data-subject-rights",
+            "integrity",
+            "minimization",
+            "non-repudiation",
+            "possession",
+            "privacy",
+            "purpose-limitation",
+            "transparency",
+            "utility"
+          ],
+          "meta:enum": {
+            "accountability": "Assigning responsibility for actions and decisions to individuals or entities.",
+            "authentication": "Verifying the identity of users, devices, or systems before granting access.",
+            "authorization": "Granting permissions based on identity and roles to perform specific actions or access resources.",
+            "authenticity": "Ensuring that data, communications, or entities are genuine and can be verified.",
+            "availability": "Ensuring systems, data, and services are accessible and operational when needed.",
+            "compliance": "Adherence to applicable laws, regulations, policies, and standards.",
+            "confidentiality": "Preventing unauthorized access to or disclosure of information.",
+            "connectivity": "Maintaining secure and reliable communication between systems or components.",
+            "control": "Enabling individuals to manage how their personal data is used and shared.",
+            "data-subject-rights": "Guaranteeing individuals' rights to access, correct, delete, or restrict their personal data.",
+            "integrity": "Ensuring information is accurate, complete, and unaltered by unauthorized actors.",
+            "minimization": "Limiting data collection and retention to what is strictly necessary for the intended purpose.",
+            "non-repudiation": "Providing proof of origin and delivery to prevent denial of actions or communications.",
+            "possession": "Ensuring control or custody over data or assets, regardless of ownership.",
+            "privacy": "Protecting individuals' personal information in accordance with legal and ethical standards.",
+            "purpose-limitation": "Ensuring that personal data is only used for the purpose explicitly specified at collection.",
+            "transparency": "Ensuring individuals are informed about data practices, including collection, use, and sharing.",
+            "utility": "Ensuring data is usable and in a format suitable for the intended purpose."
+          }
+        },
+        {
+          "title": "Custom Risk Attribute",
+          "type": "object",
+          "required": [
+            "name"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "title": "Name",
+              "description": "The name of the custom risk attribute."
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "A description of the custom risk attribute."
+            }
+          }
+        }
+      ]
+    },
+    "risk": {
+      "type": "object",
+      "required": [
+        "bom-ref",
+        "name",
+        "statement"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "name": {
+          "type": "string",
+          "description": "A human-readable name for the risk."
+        },
+        "statement": {
+          "type": "string",
+          "description": "Structured risk statement describing source, event, and impact."
+        },
+        "description": {
+          "type": "string",
+          "description": "Additional narrative about the risk."
+        },
+        "domains": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/riskDomain"
+          },
+          "description": "The risk domains this risk affects."
+        },
+        "affects": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the subjects this risk concerns. A subject may be a component, service, dataset, or model, or a party such as a person, persona, or organization, including a group at risk of being systematically disadvantaged."
+        },
+        "relatedThreats": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the threats or threat scenarios from a threat model that inform this risk. A reference may point to a discrete threat or to a threat scenario."
+        },
+        "relatedVulnerabilities": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the vulnerabilities that inform this risk."
+        },
+        "relatedWeaknesses": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the weaknesses that inform this risk."
+        },
+        "relatedRequirements": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the requirements whose absence or non-conformance gives rise to this risk, such as a requirement that is unmet or only partially met."
+        },
+        "relatedStandards": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the standards whose non-conformance gives rise to this risk."
+        },
+        "relatedClaims": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the conformance claims that give rise to this risk, such as a [CycloneDX Attestations](https://cyclonedx.org/capabilities/attestations/) claim recording that a requirement is unmet or only partially met. The degree of conformance is carried by the claim, not by the risk."
+        },
+        "relatedBusinessObjectives": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the business objectives this risk threatens."
+        },
+        "inherentRisk": {
+          "$ref": "#/$defs/rating",
+          "description": "The assessed risk before any responses are applied."
+        },
+        "residualRisk": {
+          "$ref": "#/$defs/rating",
+          "description": "The assessed risk remaining after responses are applied."
+        },
+        "targetRisk": {
+          "$ref": "#/$defs/rating",
+          "description": "The risk level the organization aims to reach for this risk. The overall risk appetite is recorded separately on the risks collection or assessment."
+        },
+        "responses": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/riskResponse"
+          },
+          "description": "The responses applied to this risk."
+        },
+        "status": {
+          "title": "Status",
+          "description": "The lifecycle status of the risk. Use the custom option for a status specific to an organization's risk process.",
+          "oneOf": [
+            {
+              "title": "Predefined Risk Status",
+              "type": "string",
+              "enum": [
+                "identified",
+                "assessed",
+                "mitigated",
+                "accepted",
+                "transferred",
+                "retired"
+              ],
+              "meta:enum": {
+                "identified": "Risk has been identified but not yet evaluated.",
+                "assessed": "Risk has been assessed and prioritized.",
+                "mitigated": "Responses are in place reducing this risk.",
+                "accepted": "Risk has been formally accepted.",
+                "transferred": "Risk has been transferred to another party.",
+                "retired": "Risk no longer applies."
+              }
+            },
+            {
+              "title": "Custom Risk Status",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name",
+                  "description": "The name of the custom status."
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom status."
+                }
+              }
+            }
+          ]
+        },
+        "owner": {
+          "$ref": "cyclonedx-party-2.0.schema.json#/$defs/partyChoice",
+          "description": "The party accountable for this risk. May be an inline party object or a reference to a previously declared party. The party's `roles` should include `owner`."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "rating": {
+      "type": "object",
+      "title": "Rating",
+      "description": "A methodology-neutral assessment of risk along likelihood and impact, with an overall score. The same shape expresses inherent, residual, and target risk so reductions can be compared. A rating can be qualitative (a `level`), semi-quantitative (a numeric `score` on a bounded scale), or quantitative (for example a probable monetary loss under [FAIR](https://www.fairinstitute.org/)). For a catalogue of assessment techniques, see [IEC 31010](https://www.iso.org/standard/72140.html).",
+      "additionalProperties": false,
+      "properties": {
+        "likelihood": {
+          "$ref": "#/$defs/likelihood"
+        },
+        "impact": {
+          "$ref": "#/$defs/impact"
+        },
+        "score": {
+          "$ref": "#/$defs/riskScore"
+        },
+        "detectability": {
+          "type": "object",
+          "title": "Detectability",
+          "additionalProperties": false,
+          "description": "The ease or likelihood of detecting the event before or as it is realized, used as a third axis by methodologies such as [FMEA](https://asq.org/quality-resources/fmea), whose risk priority number multiplies severity, occurrence, and detection.",
+          "properties": {
+            "score": {
+              "type": "number",
+              "minimum": 0,
+              "description": "The detection value on the scale defined by the methodology. For FMEA, a higher value indicates that the event is harder to detect and therefore riskier."
+            },
+            "description": {
+              "type": "string",
+              "description": "A narrative explanation of the detectability assessment."
+            }
+          }
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "title": "Confidence",
+          "description": "Confidence in this rating, expressed as a decimal from 0 to 1, where 1 is full confidence. Supports quantitative methods that reason over uncertainty."
+        },
+        "rationale": {
+          "type": "string",
+          "title": "Rationale",
+          "description": "The justification for this rating, including the method and the evidence considered."
+        }
+      }
+    },
+    "likelihood": {
+      "type": "object",
+      "required": [
+        "level"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "level": {
+          "type": "string",
+          "title": "Level",
+          "description": "The qualitative likelihood level representing the overall assessed probability of the risk or scenario being realized.",
+          "enum": [
+            "very-low",
+            "low",
+            "medium",
+            "high",
+            "very-high",
+            "certain"
+          ],
+          "meta:enum": {
+            "very-low": "Very unlikely to occur (less than 10% probability).",
+            "low": "Unlikely to occur (10 to 30% probability).",
+            "medium": "Possible to occur (30 to 60% probability).",
+            "high": "Likely to occur (60 to 85% probability).",
+            "very-high": "Very likely to occur (85 to 99% probability).",
+            "certain": "Almost certain to occur (greater than 99% probability)."
+          }
+        },
+        "score": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Numeric likelihood score on the scale defined by the methodology."
+        },
+        "probability": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Probability as a decimal from 0 to 1."
+        },
+        "frequency": {
+          "type": "number",
+          "minimum": 0,
+          "title": "Frequency",
+          "description": "The expected number of events within the timeframe, for frequency-based methods such as the [FAIR](https://www.fairinstitute.org/) loss event frequency. Unlike a probability, a frequency may exceed 1."
+        },
+        "timeframe": {
+          "type": "string",
+          "title": "Timeframe",
+          "description": "The period over which the probability or frequency is assessed, expressed as an [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) duration, for example P1Y for one year."
+        },
+        "range": {
+          "$ref": "#/$defs/estimateRange",
+          "description": "A range for the probability or frequency, supporting quantitative methods that reason over distributions."
+        },
+        "factors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/likelihoodFactor"
+          },
+          "description": "The factors considered when determining the likelihood level."
+        },
+        "rationale": {
+          "type": "string",
+          "description": "The justification for the likelihood rating."
+        }
+      }
+    },
+    "likelihoodFactor": {
+      "type": "object",
+      "title": "Likelihood Factor",
+      "description": "An individual contributing factor used to determine the overall likelihood of a risk or scenario being realized. Likelihood is rarely a single judgment. It is typically derived from multiple independent factors such as threat actor capability, exploit maturity, attack surface exposure, and control effectiveness. Each factor captures a discrete dimension of likelihood with its own rating, enabling transparent, auditable, and methodology-aligned risk assessments.",
+      "required": [
+        "name",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the likelihood factor being evaluated. Should clearly identify the dimension of likelihood being assessed, such as 'Threat Actor Capability', 'Exploit Availability', or 'Control Effectiveness'.",
+          "minLength": 1
+        },
+        "type": {
+          "title": "Type",
+          "description": "The category of likelihood factor being assessed. Predefined types align with common risk assessment methodologies including FAIR, OWASP Risk Rating, and NIST SP 800-30.",
+          "oneOf": [
+            {
+              "title": "Predefined Likelihood Factor Type",
+              "description": "A likelihood factor type defined by the CycloneDX standard, aligned with established risk assessment methodologies including FAIR, OWASP Risk Rating, and NIST SP 800-30.",
+              "type": "string",
+              "enum": [
+                "attack-vector",
+                "contact-frequency",
+                "control-effectiveness",
+                "detectability",
+                "discoverability",
+                "exploit-maturity",
+                "exposure",
+                "motivation",
+                "opportunity",
+                "targeting",
+                "threat-capability",
+                "vulnerability"
+              ],
+              "meta:enum": {
+                "attack-vector": "Accessibility of the attack path to the threat actor, considering network proximity, authentication requirements, and interaction complexity.",
+                "contact-frequency": "How often the threat actor comes into contact with the target asset, independent of any intent to act. Aligns with the FAIR contact frequency factor.",
+                "control-effectiveness": "Strength, reliability, and coverage of existing preventive, detective, or corrective controls that reduce the probability of successful exploitation. Corresponds to resistance strength in FAIR.",
+                "detectability": "Likelihood that the activity is detected before the risk is realized. Lower detectability increases the chance of a successful action. Aligns with the OWASP Risk Rating intrusion detection factor and the FMEA detection axis.",
+                "discoverability": "Ease with which the weakness or opportunity can be found by a potential actor. Aligns with the OWASP Risk Rating ease of discovery factor.",
+                "exploit-maturity": "Availability, reliability, and sophistication of known exploits, attack toolkits, or proof-of-concept code targeting the identified weakness.",
+                "exposure": "Degree to which the target asset, system, or service is visible, discoverable, or reachable by potential threat actors.",
+                "motivation": "Level of incentive, intent, or determination driving the threat actor to pursue exploitation, including financial gain, ideology, or competitive advantage.",
+                "opportunity": "Availability of the conditions, timing, or circumstances required for the threat actor to act, including access windows, environmental factors, and resource availability.",
+                "targeting": "Degree to which the threat actor specifically selects this asset or organization rather than acting opportunistically. Aligns with the NIST SP 800-30 targeting factor.",
+                "threat-capability": "Technical skill, resources, tooling, and sophistication of the threat actor relative to the complexity of the attack required.",
+                "vulnerability": "Presence, severity, and exploitability of weaknesses in the target system, application, or process that could be leveraged by a threat actor."
+              }
+            },
+            {
+              "title": "Custom Likelihood Factor Type",
+              "description": "A custom likelihood factor type not covered by predefined values, allowing organizations to extend the model with methodology-specific factors.",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "Name",
+                  "description": "The name of the custom likelihood factor type.",
+                  "minLength": 1
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom likelihood factor type and how it contributes to likelihood assessment."
+                }
+              }
+            }
+          ]
+        },
+        "level": {
+          "type": "string",
+          "title": "Level",
+          "description": "The qualitative rating assigned to this factor, representing the assessed degree to which this factor contributes to the overall likelihood of the risk being realized.",
+          "enum": [
+            "very-low",
+            "low",
+            "medium",
+            "high",
+            "very-high",
+            "certain"
+          ],
+          "meta:enum": {
+            "very-low": "This factor has minimal contribution to risk realization (less than 10% influence).",
+            "low": "This factor has limited contribution to risk realization (10 to 30% influence).",
+            "medium": "This factor moderately contributes to risk realization (30 to 60% influence).",
+            "high": "This factor strongly contributes to risk realization (60 to 85% influence).",
+            "very-high": "This factor very strongly contributes to risk realization (85 to 99% influence).",
+            "certain": "This factor almost certainly contributes to risk realization (greater than 99% influence)."
+          }
+        },
+        "score": {
+          "type": "number",
+          "title": "Score",
+          "description": "A numeric score representing the assessed value of this factor on the scale defined by the methodology, where a higher value indicates a greater contribution to likelihood.",
+          "minimum": 0
+        },
+        "weight": {
+          "type": "number",
+          "title": "Weight",
+          "description": "The relative importance or weight of this factor in the overall likelihood calculation, expressed as a decimal between 0 and 1. When multiple factors are present, weights can be used to produce a weighted average likelihood score. A weight of 1 indicates full importance; a weight of 0 indicates no importance.",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A narrative explanation of how this factor was evaluated, the evidence or reasoning supporting the assigned level or score, and how it contributes to the overall likelihood assessment."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "impact": {
+      "type": "object",
+      "required": [
+        "level"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "level": {
+          "type": "string",
+          "enum": [
+            "negligible",
+            "low",
+            "moderate",
+            "major",
+            "catastrophic"
+          ],
+          "description": "The qualitative impact severity level.",
+          "meta:enum": {
+            "negligible": "Minimal impact with no significant consequences.",
+            "low": "Minor impact with limited consequences.",
+            "moderate": "Moderate impact affecting some operations.",
+            "major": "Significant impact with serious consequences.",
+            "catastrophic": "Catastrophic impact with existential consequences."
+          }
+        },
+        "polarity": {
+          "type": "string",
+          "title": "Polarity",
+          "description": "Whether the impact represents a harm or a benefit. Benefits support modeling opportunities and positive risk.",
+          "enum": [
+            "harm",
+            "benefit"
+          ],
+          "meta:enum": {
+            "harm": "A negative impact or downside.",
+            "benefit": "A positive impact or upside."
+          }
+        },
+        "score": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Numeric impact score on the scale defined by the methodology."
+        },
+        "categories": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/impactCategory"
+          },
+          "description": "The categories of impact, including harms relevant to AI and societal risk."
+        },
+        "factors": {
+          "type": "array",
+          "title": "Factors",
+          "items": {
+            "$ref": "#/$defs/impactFactor"
+          },
+          "description": "The factors considered when determining the impact, allowing methodologies that derive impact from multiple weighted dimensions to record the breakdown."
+        },
+        "range": {
+          "$ref": "#/$defs/estimateRange",
+          "description": "A range for the impact score, supporting quantitative methods that reason over distributions."
+        },
+        "riskAttributes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/riskAttribute"
+          },
+          "description": "The risk attributes affected."
+        },
+        "quantification": {
+          "$ref": "#/$defs/impactQuantification"
+        },
+        "description": {
+          "type": "string",
+          "description": "A description of the potential impact."
+        }
+      }
+    },
+    "impactCategory": {
+      "title": "Impact Category",
+      "description": "A category of impact, including harms relevant to AI and societal risk. Use the custom option for categories specific to an organization's risk taxonomy.",
+      "oneOf": [
+        {
+          "title": "Predefined Impact Category",
+          "type": "string",
+          "enum": [
+            "confidentiality",
+            "integrity",
+            "availability",
+            "financial",
+            "reputation",
+            "regulatory",
+            "safety",
+            "privacy",
+            "operational",
+            "strategic",
+            "bias",
+            "discrimination",
+            "fairness",
+            "human-rights",
+            "environmental",
+            "societal",
+            "psychological",
+            "physical",
+            "health"
+          ],
+          "meta:enum": {
+            "confidentiality": "Impact on data confidentiality.",
+            "integrity": "Impact on data or system integrity.",
+            "availability": "Impact on service availability.",
+            "financial": "Financial loss or impact.",
+            "reputation": "Reputational damage.",
+            "regulatory": "Regulatory compliance impact.",
+            "safety": "Human safety impact.",
+            "privacy": "Privacy violation impact.",
+            "operational": "Operational disruption.",
+            "strategic": "Strategic business impact.",
+            "bias": "Systematic bias in automated outputs or decisions.",
+            "discrimination": "Unfair treatment of individuals or groups, including on the basis of protected attributes.",
+            "fairness": "Impact on the fair and equitable treatment of affected groups.",
+            "human-rights": "Impact on fundamental human rights, including autonomy and dignity.",
+            "environmental": "Environmental impact, including energy use and carbon emissions.",
+            "societal": "Impact on society, communities, or civic processes.",
+            "psychological": "Psychological or emotional harm.",
+            "physical": "Physical harm to people or property.",
+            "health": "Impact on physical or mental health."
+          }
+        },
+        {
+          "title": "Custom Impact Category",
+          "type": "object",
+          "required": [
+            "name"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "title": "Name",
+              "description": "The name of the custom impact category."
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "A description of the custom impact category."
+            }
+          }
+        }
+      ]
+    },
+    "impactFactor": {
+      "type": "object",
+      "title": "Impact Factor",
+      "description": "An individual contributing factor used to determine the overall impact of a risk or scenario. Methodologies such as OWASP Risk Rating, DREAD, and OCTAVE Allegro derive impact from several weighted dimensions, and each factor captures one dimension with its own rating.",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Name",
+          "description": "The name of the impact factor being evaluated, such as 'Financial damage' or 'Reputation damage'."
+        },
+        "category": {
+          "$ref": "#/$defs/impactCategory",
+          "description": "The impact dimension this factor measures."
+        },
+        "score": {
+          "type": "number",
+          "minimum": 0,
+          "title": "Score",
+          "description": "A numeric score representing the assessed value of this factor on the scale defined by the methodology, where a higher value indicates a greater contribution to impact."
+        },
+        "weight": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "title": "Weight",
+          "description": "The relative importance of this factor in the overall impact calculation, expressed as a decimal from 0 to 1. OCTAVE Allegro, for example, ranks impact areas and multiplies the ranking by the factor value."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A narrative explanation of how this factor was evaluated and how it contributes to the overall impact assessment."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "estimateRange": {
+      "type": "object",
+      "title": "Estimate Range",
+      "description": "A three-point estimate, supporting quantitative methods such as FAIR that reason over distributions rather than single values.",
+      "additionalProperties": false,
+      "properties": {
+        "minimum": {
+          "type": "number",
+          "description": "The minimum, or lower bound, estimate."
+        },
+        "mostLikely": {
+          "type": "number",
+          "description": "The most likely estimate."
+        },
+        "maximum": {
+          "type": "number",
+          "description": "The maximum, or upper bound, estimate."
+        }
+      }
+    },
+    "impactQuantification": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "financialLoss": {
+          "type": "number",
+          "description": "The estimated financial loss, in the units given by currency."
+        },
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$",
+          "description": "The currency of the financial values, as an [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) code."
+        },
+        "affectedUsers": {
+          "type": "integer",
+          "description": "The number of affected users."
+        },
+        "downtime": {
+          "type": "string",
+          "pattern": "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+(\\.\\d+)?S)?)?$",
+          "description": "The expected downtime, as an [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) duration."
+        },
+        "dataRecords": {
+          "type": "integer",
+          "description": "The number of data records affected."
+        },
+        "recovery": {
+          "type": "string",
+          "pattern": "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+(\\.\\d+)?S)?)?$",
+          "description": "The recovery time, as an [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) duration."
+        },
+        "financialLossRange": {
+          "$ref": "#/$defs/estimateRange",
+          "description": "A distribution of estimated financial loss, supporting quantitative methods such as FAIR that reason over ranges."
+        },
+        "affectedGroups": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "The number of distinct groups or populations affected."
+        }
+      }
+    },
+    "riskScore": {
+      "type": "object",
+      "title": "Risk Score",
+      "description": "The overall risk score, expressed as a qualitative `level`, a numeric `score`, or both, with `vector` and `methodology` recording how it was derived. The scale of `score` is defined by the methodology, since rating systems differ. For example, [OWASP Risk Rating](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology) averages factors from 0 to 9, [DREAD](https://en.wikipedia.org/wiki/DREAD_%28risk_assessment_model%29) averages five 1 to 10 ratings, [FMEA](https://asq.org/quality-resources/fmea) multiplies three 1 to 10 axes into a 1 to 1000 risk priority number, and [FAIR](https://www.fairinstitute.org/) expresses probable loss in monetary terms.",
+      "required": [
+        "level"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "level": {
+          "type": "string",
+          "enum": [
+            "info",
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ],
+          "description": "The overall qualitative risk level.",
+          "meta:enum": {
+            "info": "Informational.",
+            "low": "Low risk.",
+            "medium": "Medium risk.",
+            "high": "High risk.",
+            "critical": "Critical risk."
+          }
+        },
+        "score": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Numeric risk score on the scale defined by the methodology."
+        },
+        "vector": {
+          "type": "string",
+          "description": "A textual representation of the metric values used to derive the score, in the format defined by the methodology."
+        },
+        "methodology": {
+          "title": "Methodology",
+          "description": "The risk rating methodology used to derive this score. Only methodologies that define a scoring calculation are listed; governance frameworks such as [ISO 31000](https://www.iso.org/iso-31000-risk-management.html) are recorded as standards rather than as a score methodology. Use the custom option for methodologies not listed.",
+          "oneOf": [
+            {
+              "title": "Predefined Risk Methodology",
+              "type": "string",
+              "enum": [
+                "dread",
+                "fair",
+                "fmea",
+                "nist-sp-800-30",
+                "octave",
+                "owasp-risk-rating",
+                "qualitative-matrix"
+              ],
+              "meta:enum": {
+                "dread": "[DREAD](https://en.wikipedia.org/wiki/DREAD_%28risk_assessment_model%29) risk rating model, the average of five ratings (damage, reproducibility, exploitability, affected users, discoverability) each scored 1 to 10.",
+                "fair": "[Factor Analysis of Information Risk (FAIR)](https://www.fairinstitute.org/), a quantitative methodology expressing risk as loss event frequency multiplied by loss magnitude.",
+                "fmea": "[Failure Mode and Effects Analysis (FMEA)](https://asq.org/quality-resources/fmea), using a risk priority number of severity multiplied by occurrence multiplied by detection.",
+                "nist-sp-800-30": "[NIST SP 800-30](https://csrc.nist.gov/pubs/sp/800/30/r1/final) guide for conducting risk assessments, using its exemplary likelihood and impact scales.",
+                "octave": "[OCTAVE Allegro](https://www.sei.cmu.edu/documents/786/2007_005_001_14885.pdf), using its relative risk score.",
+                "owasp-risk-rating": "[OWASP Risk Rating](https://owasp.org/www-community/OWASP_Risk_Rating_Methodology), averaging likelihood and impact factors each scored 0 to 9.",
+                "qualitative-matrix": "A qualitative risk matrix that derives a risk level by plotting a likelihood band against an impact band, such as a five by five matrix producing a score from 1 to 25."
+              }
+            },
+            {
+              "title": "Custom Risk Methodology",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name",
+                  "description": "The name of the custom risk methodology."
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom risk methodology."
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "riskResponse": {
+      "type": "object",
+      "title": "Risk Response",
+      "description": "An action taken to modify a risk, pairing the chosen strategy with the controls that implement it. Covers the full set of dispositions, from avoiding or reducing a risk to accepting it or, for a positive risk, pursuing it.",
+      "required": [
+        "bom-ref",
+        "strategy"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "description": "An identifier which can be used to reference this response elsewhere using a bom-ref or bom-link."
+        },
+        "strategy": {
+          "type": "string",
+          "title": "Strategy",
+          "description": "The disposition chosen for the risk.",
+          "enum": [
+            "avoid",
+            "reduce",
+            "transfer",
+            "accept",
+            "exploit",
+            "enhance"
+          ],
+          "meta:enum": {
+            "avoid": "Eliminate the risk by removing its source or not proceeding with the activity.",
+            "reduce": "Lower the likelihood or impact of the risk through controls.",
+            "transfer": "Shift the risk to another party, for example through insurance or contract.",
+            "accept": "Take no further action and retain the risk.",
+            "exploit": "Pursue an opportunity so that a positive risk occurs.",
+            "enhance": "Increase the likelihood or benefit of a positive risk."
+          }
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the response."
+        },
+        "controls": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the controls that implement this response."
+        },
+        "status": {
+          "title": "Status",
+          "description": "The implementation status of the response.",
+          "$ref": "cyclonedx-control-2.0.schema.json#/$defs/implementationStatus"
+        },
+        "effectiveness": {
+          "$ref": "cyclonedx-control-2.0.schema.json#/$defs/effectiveness"
+        },
+        "cost": {
+          "type": "string",
+          "title": "Cost",
+          "enum": [
+            "trivial",
+            "low",
+            "medium",
+            "high",
+            "extreme"
+          ],
+          "meta:enum": {
+            "trivial": "Minimal cost and effort.",
+            "low": "Low cost and effort.",
+            "medium": "Moderate cost and effort.",
+            "high": "High cost and significant effort.",
+            "extreme": "Extreme cost and major effort."
+          }
+        },
+        "priority": {
+          "$ref": "#/$defs/priority"
+        },
+        "owner": {
+          "$ref": "cyclonedx-party-2.0.schema.json#/$defs/partyChoice",
+          "description": "The party accountable for this response. May be an inline party object or a reference to a previously declared party."
+        },
+        "targetDate": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Target Date",
+          "description": "The date by which this response is targeted to be implemented."
+        },
+        "addresses": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the items this response addresses, such as a threat, vulnerability, weakness, or another risk."
+        },
+        "externalReferences": {
+          "type": "array",
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReference"
+          }
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "assessment": {
+      "type": "object",
+      "required": [
+        "bom-ref",
+        "type",
+        "cadence",
+        "timestamp"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "A human-readable name for the assessment."
+        },
+        "type": {
+          "type": "array",
+          "title": "Type",
+          "minItems": 1,
+          "uniqueItems": true,
+          "description": "The kinds of assessment performed, given as one or more named exercises or instruments. The type classifies the assessment exercise; the domains of risk evaluated are carried by the referenced risks rather than restated here. Use the custom option for kinds specific to an organization's process.",
+          "items": {
+            "oneOf": [
+              {
+                "title": "Predefined Assessment Type",
+                "type": "string",
+                "enum": [
+                  "security",
+                  "privacy",
+                  "operational",
+                  "safety",
+                  "financial",
+                  "environmental",
+                  "supply-chain",
+                  "compliance",
+                  "data-protection-impact",
+                  "fundamental-rights-impact",
+                  "ai-impact",
+                  "business-impact",
+                  "third-party",
+                  "threat",
+                  "vulnerability",
+                  "model-risk",
+                  "fraud"
+                ],
+                "meta:enum": {
+                  "security": "Security risk assessment, evaluating threats to the confidentiality, integrity, and availability of a subject.",
+                  "privacy": "Privacy risk assessment, evaluating risks to individuals arising from the processing of personal data.",
+                  "operational": "Operational risk assessment, evaluating risks to ongoing operations and continuity.",
+                  "safety": "Safety risk assessment, evaluating risks of harm to people or property.",
+                  "financial": "Financial risk assessment, evaluating exposure to financial loss, such as credit, market, or liquidity risk.",
+                  "environmental": "Environmental risk assessment, evaluating the effect of an activity on the natural environment, including energy use and emissions.",
+                  "supply-chain": "Supply chain risk assessment, evaluating risks across the chain that delivers a product or service, including software and hardware provenance, for example following [NIST SP 800-161](https://csrc.nist.gov/pubs/sp/800/161/r1/final).",
+                  "compliance": "Compliance assessment, evaluating conformance with applicable laws, regulations, policies, or standards.",
+                  "data-protection-impact": "Data protection impact assessment (DPIA), assessing high-risk processing of personal data, for example as described under Article 35 of the [GDPR](https://gdpr-info.eu/art-35-gdpr/).",
+                  "fundamental-rights-impact": "Fundamental rights impact assessment (FRIA), evaluating the effect of a system on fundamental rights, for example as introduced for certain high-risk AI systems by the [EU AI Act](https://artificialintelligenceact.eu/).",
+                  "ai-impact": "Artificial intelligence impact assessment, evaluating the risks and impacts of an AI system, for example following the [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework).",
+                  "business-impact": "Business impact analysis (BIA), evaluating the operational and financial consequences of disruption to a business function.",
+                  "third-party": "Third-party risk assessment, evaluating the risk arising from a specific external party relationship, such as a vendor, supplier, or service provider, as distinct from the broader supply chain.",
+                  "threat": "Threat assessment, evaluating the threats and threat actors relevant to a subject.",
+                  "vulnerability": "Vulnerability assessment, evaluating weaknesses that could be exploited.",
+                  "model-risk": "Model risk assessment, evaluating the risk that a decision or quantitative model is incorrect or misused, including model validation.",
+                  "fraud": "Fraud risk assessment, evaluating exposure to fraudulent activity and the controls that detect or prevent it."
+                }
+              },
+              {
+                "title": "Custom Assessment Type",
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "title": "Name",
+                    "description": "The name of the custom assessment type."
+                  },
+                  "description": {
+                    "type": "string",
+                    "title": "Description",
+                    "description": "A description of the custom assessment type."
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "cadence": {
+          "title": "Cadence",
+          "description": "The temporal cadence or occasion on which the assessment is performed. Use the custom option for patterns specific to an organization's process.",
+          "oneOf": [
+            {
+              "title": "Predefined Assessment Cadence",
+              "type": "string",
+              "enum": [
+                "initial",
+                "periodic",
+                "continuous",
+                "triggered",
+                "ad-hoc"
+              ],
+              "meta:enum": {
+                "initial": "Initial, baseline assessment performed once at the outset.",
+                "periodic": "Scheduled, recurring assessment.",
+                "continuous": "Continuous, automated monitoring, as in a GRC engineering or continuous controls monitoring practice.",
+                "triggered": "Assessment triggered by a specific event, such as a change or an incident.",
+                "ad-hoc": "Unplanned, one-off assessment, neither scheduled nor triggered by a defined event."
+              }
+            },
+            {
+              "title": "Custom Assessment Cadence",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name",
+                  "description": "The name of the custom assessment cadence."
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom assessment cadence."
+                }
+              }
+            }
+          ]
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the assessment was performed."
+        },
+        "scope": {
+          "type": "string",
+          "title": "Scope",
+          "description": "The scope of the assessment, including the systems, boundaries, and what is in or out of scope."
+        },
+        "status": {
+          "title": "Status",
+          "description": "The lifecycle status of the assessment. Use the custom option for a status specific to an organization's process.",
+          "oneOf": [
+            {
+              "title": "Predefined Assessment Status",
+              "type": "string",
+              "enum": [
+                "draft",
+                "in-progress",
+                "completed",
+                "approved",
+                "superseded"
+              ],
+              "meta:enum": {
+                "draft": "The assessment is being prepared.",
+                "in-progress": "The assessment is underway.",
+                "completed": "The assessment is finished.",
+                "approved": "The assessment has been reviewed and approved.",
+                "superseded": "The assessment has been replaced by a later one."
+              }
+            },
+            {
+              "title": "Custom Assessment Status",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name",
+                  "description": "The name of the custom status."
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom status."
+                }
+              }
+            }
+          ]
+        },
+        "assessors": {
+          "type": "array",
+          "title": "Assessors",
+          "items": {
+            "$ref": "cyclonedx-party-2.0.schema.json#/$defs/partyChoice"
+          },
+          "description": "The parties that performed the assessment. Each may be an inline party or a reference to a previously declared party, and may be a person or an automated system, agent, or tool. Automated assessors support continuous and automated assessment, as in a GRC engineering practice. A party's `roles` should include `auditor` or `assessor`."
+        },
+        "summary": {
+          "type": "string",
+          "description": "An executive summary of the assessment."
+        },
+        "risks": {
+          "type": "array",
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to risk entries evaluated in this assessment."
+        },
+        "overallRisk": {
+          "type": "object",
+          "required": [
+            "method",
+            "score"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "method": {
+              "title": "Method",
+              "description": "The aggregation method used to derive the overall risk from the assessed risks. Use the custom option for methods not listed, such as a quantitative roll-up of loss distributions under FAIR.",
+              "oneOf": [
+                {
+                  "title": "Predefined Aggregation Method",
+                  "type": "string",
+                  "enum": [
+                    "maximum",
+                    "sum",
+                    "average",
+                    "weighted-average"
+                  ],
+                  "meta:enum": {
+                    "maximum": "The overall risk equals the highest individual risk.",
+                    "sum": "The overall risk is the sum of the individual risks, representing total exposure.",
+                    "average": "The overall risk is the mean of the individual risks.",
+                    "weighted-average": "The overall risk is a weighted mean of the individual risks."
+                  }
+                },
+                {
+                  "title": "Custom Aggregation Method",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1,
+                      "title": "Name",
+                      "description": "The name of the custom aggregation method."
+                    },
+                    "description": {
+                      "type": "string",
+                      "title": "Description",
+                      "description": "A description of the custom aggregation method."
+                    }
+                  }
+                }
+              ]
+            },
+            "score": {
+              "$ref": "#/$defs/riskScore"
+            },
+            "description": {
+              "type": "string",
+              "description": "An optional explanation for custom aggregation approaches."
+            }
+          },
+          "description": "The aggregated risk result for this assessment."
+        },
+        "assumptions": {
+          "type": "array",
+          "title": "Assumptions",
+          "items": {
+            "type": "string"
+          },
+          "description": "The assumptions, constraints, and limitations under which the assessment was made, to be re-evaluated when they change."
+        },
+        "recommendations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Recommendations from the assessment."
+        },
+        "nextReview": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the next review should occur."
+        },
+        "riskAppetites": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the risk appetites, declared under the risks collection, that applied for this assessment."
+        },
+        "externalReferences": {
+          "type": "array",
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReference"
+          }
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "priority": {
+      "type": "string",
+      "enum": [
+        "none",
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ],
+      "description": "Priority level.",
+      "meta:enum": {
+        "none": "No priority.",
+        "low": "Low priority.",
+        "medium": "Medium priority.",
+        "high": "High priority.",
+        "critical": "Critical priority."
+      }
+    },
+    "criticality": {
+      "type": "string",
+      "enum": [
+        "minimal",
+        "low",
+        "moderate",
+        "high",
+        "critical"
+      ],
+      "description": "Business criticality level.",
+      "meta:enum": {
+        "minimal": "Minimal impact on business operations.",
+        "low": "Low impact with minor inconvenience.",
+        "moderate": "Moderate impact affecting some operations.",
+        "high": "High impact affecting critical operations.",
+        "critical": "Critical impact with severe business consequences."
+      }
+    },
+    "appetiteLevel": {
+      "type": "string",
+      "description": "A qualitative risk appetite level, ranging from risk-averse to risk-seeking.",
+      "enum": [
+        "averse",
+        "minimal",
+        "cautious",
+        "open",
+        "hungry"
+      ],
+      "meta:enum": {
+        "averse": "Avoidance of risk is the priority, and only the lowest-risk options are acceptable.",
+        "minimal": "A preference for very low risk, accepting risk only where it is unavoidable.",
+        "cautious": "A preference for safe options, accepting limited and well-understood risk for reward.",
+        "open": "A willingness to accept higher risk where the potential reward justifies it.",
+        "hungry": "An active willingness to seek risk in pursuit of greater reward, within defined control limits."
+      }
+    },
+    "riskAppetite": {
+      "type": "object",
+      "title": "Risk Appetite",
+      "description": "The amount and type of risk a party is willing to pursue or retain, stated explicitly so that it is not left implicit in individual target ratings. An appetite may be attributed to a specific party through `party`, so a single document can record the appetites of more than one party, and it may be stated overall and refined per risk domain. Quantitative tolerances for a specific risk are expressed through that risk's target rating, and measurement of actual risk against the appetite is recorded through assessments.",
+      "required": [
+        "level"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "description": "An identifier which can be used to reference this risk appetite elsewhere, such as from an assessment."
+        },
+        "party": {
+          "$ref": "cyclonedx-party-2.0.schema.json#/$defs/partyChoice",
+          "description": "The party whose risk appetite this is. Set this when a single document captures the appetites of more than one party. May be an inline party object or a reference to a previously declared party."
+        },
+        "level": {
+          "$ref": "#/$defs/appetiteLevel",
+          "description": "The overall risk appetite level."
+        },
+        "statement": {
+          "type": "string",
+          "title": "Statement",
+          "description": "A narrative statement of the overall risk appetite, including any qualifications or context."
+        },
+        "rationale": {
+          "type": "string",
+          "description": "The justification for this appetite, such as the strategic objective or regulatory obligation that informs it."
+        },
+        "owner": {
+          "$ref": "cyclonedx-party-2.0.schema.json#/$defs/partyChoice",
+          "description": "The party accountable for setting and approving this appetite, such as a board or risk committee. May be an inline party object or a reference to a previously declared party."
+        },
+        "horizon": {
+          "type": "string",
+          "description": "The time horizon over which this appetite applies, expressed as an [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) duration, for example P1Y for one year."
+        },
+        "nextReview": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When this appetite is next due for review, since appetite changes with strategy, market conditions, and the threat landscape."
+        },
+        "categories": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "required": [
+              "domain",
+              "level"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "domain": {
+                "$ref": "#/$defs/riskDomain",
+                "description": "The risk domain this appetite entry applies to."
+              },
+              "level": {
+                "$ref": "#/$defs/appetiteLevel",
+                "description": "The appetite level for this risk domain."
+              },
+              "statement": {
+                "type": "string",
+                "description": "A narrative statement of the appetite for this risk domain."
+              },
+              "rationale": {
+                "type": "string",
+                "description": "The justification for the appetite for this risk domain."
+              }
+            }
+          },
+          "description": "Per-domain appetite, refining the overall appetite for specific risk domains such as security, privacy, or financial."
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev-threatmodeling/cyclonedx-threat-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev-threatmodeling/cyclonedx-threat-2.0.schema.json
@@ -1,0 +1,1476 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-threat-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Threat Model",
+  "$comment": "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "threats": {
+      "type": "object",
+      "title": "Threats",
+      "description": "Threat-modelling content, including the documented threats, the scenarios that realize them, the attack patterns and attack trees that describe how they are carried out, and the trust boundaries they cross.",
+      "additionalProperties": false,
+      "properties": {
+        "threats": {
+          "type": "array",
+          "title": "Threats",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/threat"
+          },
+          "description": "The documented threats. Each describes what can go wrong, independent of any specific actor or occurrence."
+        },
+        "scenarios": {
+          "type": "array",
+          "title": "Scenarios",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/threatScenario"
+          },
+          "description": "The threat scenarios, each realizing one or more documented threats in a specific way."
+        },
+        "attackPatterns": {
+          "type": "array",
+          "title": "Attack Patterns",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/attackPattern"
+          },
+          "description": "A library of attack patterns, typically aligned with CAPEC, that threats and scenarios can reference."
+        },
+        "attackTrees": {
+          "type": "array",
+          "title": "Attack Trees",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/attackTree"
+          },
+          "description": "Attack trees that decompose attacker goals into sub-goals and techniques."
+        },
+        "attackPaths": {
+          "type": "array",
+          "title": "Attack Paths",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/attackPath"
+          },
+          "description": "Attack paths that describe the ordered progression of an attack across elements and trust boundaries, including lateral movement."
+        },
+        "abuseCases": {
+          "type": "array",
+          "title": "Abuse Cases",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/abuseCase"
+          },
+          "description": "Abuse or misuse cases that describe how the system can be exercised by an adversary."
+        },
+        "trustBoundaries": {
+          "type": "array",
+          "title": "Trust Boundaries",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/trustBoundary"
+          },
+          "description": "The trust boundaries of the system, extending the architectural boundaries defined in a blueprint with trust semantics."
+        },
+        "methodologies": {
+          "type": "array",
+          "title": "Methodologies",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/methodology"
+          },
+          "description": "The threat modeling methodologies applied to produce this threat model, such as STRIDE, LINDDUN, PASTA, or attack trees."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "methodology": {
+      "title": "Threat Modeling Methodology",
+      "description": "A threat modeling methodology applied to produce this threat model. Use the custom option for methodologies not covered by the enumeration.",
+      "oneOf": [
+        {
+          "type": "string",
+          "title": "Predefined Threat Modeling Methodology",
+          "enum": [
+            "STRIDE",
+            "LINDDUN",
+            "PASTA",
+            "MAESTRO",
+            "OWASP",
+            "TRIKE",
+            "VAST",
+            "ATFAA",
+            "attack-tree"
+          ],
+          "meta:enum": {
+            "STRIDE": "Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege.",
+            "LINDDUN": "Linkability, Identifiability, Non-repudiation, Detectability, Disclosure of information, Unawareness, Non-compliance.",
+            "PASTA": "Process for Attack Simulation and Threat Analysis.",
+            "MAESTRO": "Multi-Agent Environment, Security, Threat, Risk, and Outcome.",
+            "OWASP": "OWASP threat modelling methodology.",
+            "TRIKE": "Risk-based threat modelling methodology.",
+            "VAST": "Visual, Agile, and Simple Threat modelling.",
+            "ATFAA": "Advanced Threat Framework for Autonomous AI Agents.",
+            "attack-tree": "Attack tree methodology, decomposing attacker goals into sub-goals and techniques."
+          }
+        },
+        {
+          "type": "object",
+          "title": "Custom Threat Modeling Methodology",
+          "required": [
+            "name"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "title": "Name",
+              "description": "The name of the custom threat modeling methodology."
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "A description of the custom threat modeling methodology."
+            }
+          }
+        }
+      ]
+    },
+    "threat": {
+      "type": "object",
+      "title": "Threat",
+      "description": "A documented threat, describing what can go wrong independent of any specific actor or occurrence. A threat can be catalogued on its own; a threat scenario references it to describe a specific realization.",
+      "additionalProperties": false,
+      "required": [
+        "bom-ref",
+        "name"
+      ],
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "description": "An identifier which can be used to reference the threat elsewhere using a bom-ref or bom-link."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Name",
+          "description": "The name of the threat."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the threat."
+        },
+        "source": {
+          "type": "string",
+          "title": "Source",
+          "description": "The source of the threat, such as a threat intelligence feed, a threat catalogue, or an analysis activity."
+        },
+        "origin": {
+          "title": "Origin",
+          "description": "The nature of the threat source that gives rise to this threat, following the threat source types of [NIST SP 800-30](https://csrc.nist.gov/pubs/sp/800/30/r1/final). Use the custom option for an origin not covered by the enumeration.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Predefined Origin",
+              "enum": [
+                "adversarial",
+                "accidental",
+                "structural",
+                "environmental"
+              ],
+              "meta:enum": {
+                "adversarial": "An adversary acting with intent, such as an individual, group, organization, or nation state.",
+                "accidental": "An erroneous action taken without malicious intent, such as a mistake by a privileged user or administrator.",
+                "structural": "A failure of equipment, software, or environmental controls, such as resource exhaustion or expiry of a component.",
+                "environmental": "A natural or human-made event outside the control of the organization, such as a fire, flood, or wide-area infrastructure outage."
+              }
+            },
+            {
+              "type": "object",
+              "title": "Custom Origin",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name",
+                  "description": "The name of the custom origin."
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom origin."
+                }
+              }
+            }
+          ]
+        },
+        "categories": {
+          "type": "array",
+          "title": "Categories",
+          "uniqueItems": true,
+          "description": "The methodology-specific categories that this threat falls under. A threat may be categorized under more than one methodology, for example STRIDE and MAESTRO. The methodology is one of the supported threat-modelling methodologies, and it determines which category values are permitted.",
+          "items": {
+            "type": "object",
+            "title": "Threat Category",
+            "description": "A threat category. The taxonomy determines the permitted category values.",
+            "additionalProperties": false,
+            "required": ["taxonomy", "category"],
+            "properties": {
+              "taxonomy": {
+                "type": "string",
+                "title": "Taxonomy",
+                "description": "The threat classification taxonomy that the category is drawn from.",
+                "enum": ["STRIDE", "LINDDUN", "MAESTRO", "MITRE-ATTACK"],
+                "meta:enum": {
+                  "STRIDE": "Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, and Elevation of Privilege.",
+                  "LINDDUN": "Linkability, Identifiability, Non-repudiation, Detectability, Disclosure of information, Unawareness, and Non-compliance.",
+                  "MAESTRO": "Multi-Agent Environment, Security, Threat, Risk, and Outcome, whose categories are its seven architectural layers.",
+                  "MITRE-ATTACK": "The MITRE ATT&CK framework, whose categories are its Enterprise tactics."
+                }
+              },
+              "category": {
+                "type": "string",
+                "minLength": 1,
+                "title": "Category",
+                "description": "The category within the taxonomy. The permitted values are determined by the taxonomy."
+              }
+            },
+            "allOf": [
+              {
+                "if": {
+                  "required": ["taxonomy"],
+                  "properties": { "taxonomy": { "const": "STRIDE" } }
+                },
+                "then": {
+                  "properties": {
+                    "category": {
+                      "enum": ["spoofing", "tampering", "repudiation", "information-disclosure", "denial-of-service", "elevation-of-privilege"],
+                      "meta:enum": {
+                        "spoofing": "Impersonating something or someone, violating authenticity.",
+                        "tampering": "Modifying data or code, violating integrity.",
+                        "repudiation": "Denying having performed an action, violating non-repudiation.",
+                        "information-disclosure": "Exposing information to unauthorized parties, violating confidentiality.",
+                        "denial-of-service": "Denying or degrading service to legitimate users, violating availability.",
+                        "elevation-of-privilege": "Gaining capabilities without proper authorization, violating authorization."
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "required": ["taxonomy"],
+                  "properties": { "taxonomy": { "const": "LINDDUN" } }
+                },
+                "then": {
+                  "properties": {
+                    "category": {
+                      "enum": ["linkability", "identifiability", "non-repudiation", "detectability", "disclosure-of-information", "unawareness", "non-compliance"],
+                      "meta:enum": {
+                        "linkability": "Linking data items to learn more about an individual.",
+                        "identifiability": "Identifying an individual from data.",
+                        "non-repudiation": "Being unable to deny a claim, harming plausible deniability.",
+                        "detectability": "Detecting that an item of interest exists.",
+                        "disclosure-of-information": "Revealing personal data, violating confidentiality.",
+                        "unawareness": "Individuals being unaware of the processing of their data.",
+                        "non-compliance": "Deviating from policy, regulation, or best practice."
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "required": ["taxonomy"],
+                  "properties": { "taxonomy": { "const": "MAESTRO" } }
+                },
+                "then": {
+                  "properties": {
+                    "category": {
+                      "enum": ["foundation-models", "data-operations", "agent-frameworks", "deployment-and-infrastructure", "evaluation-and-observability", "security-and-compliance", "agent-ecosystem"],
+                      "meta:enum": {
+                        "foundation-models": "Layer 1. The core models that provide the agent's capabilities.",
+                        "data-operations": "Layer 2. Storage, retrieval, and processing of the agent's data.",
+                        "agent-frameworks": "Layer 3. The frameworks and tools that build and run agents.",
+                        "deployment-and-infrastructure": "Layer 4. The infrastructure on which agents are deployed and scaled.",
+                        "evaluation-and-observability": "Layer 5. Evaluation, monitoring, and observability of agent behaviour.",
+                        "security-and-compliance": "Layer 6. The cross-cutting security and compliance controls.",
+                        "agent-ecosystem": "Layer 7. The applications and marketplace where agents deliver value to end-users."
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "required": ["taxonomy"],
+                  "properties": { "taxonomy": { "const": "MITRE-ATTACK" } }
+                },
+                "then": {
+                  "properties": {
+                    "category": {
+                      "enum": ["reconnaissance", "resource-development", "initial-access", "execution", "persistence", "privilege-escalation", "defense-evasion", "credential-access", "discovery", "lateral-movement", "collection", "command-and-control", "exfiltration", "impact"]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "weaknesses": {
+          "$ref": "cyclonedx-weakness-2.0.schema.json#/$defs/weaknesses",
+          "description": "The weaknesses, such as CWE classifications, that this threat exploits."
+        },
+        "relatedVulnerabilities": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the vulnerabilities that this threat exploits or that inform it."
+        },
+        "attackPatterns": {
+          "type": "array",
+          "title": "Attack Patterns",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the attack patterns by which this threat is carried out."
+        },
+        "attackTrees": {
+          "type": "array",
+          "title": "Attack Trees",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the attack trees that decompose this threat."
+        },
+        "abuseCases": {
+          "type": "array",
+          "title": "Abuse Cases",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the abuse cases that illustrate how this threat can be exercised."
+        },
+        "killChainPhase": {
+          "$ref": "#/$defs/killChainPhase",
+          "description": "The phase of the cyber kill chain at which this threat operates."
+        },
+        "behaviors": {
+          "type": "array",
+          "title": "Behaviors",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the declared behaviors that constitute the intent of this threat, drawn from the behavior taxonomy."
+        },
+        "indicators": {
+          "$ref": "#/$defs/indicators"
+        },
+        "affectedAssets": {
+          "type": "array",
+          "title": "Affected Assets",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the kinds of assets this threat affects."
+        },
+        "relatedBusinessObjectives": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the business objectives this threat endangers."
+        },
+        "mitigations": {
+          "type": "array",
+          "title": "Mitigations",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the controls that mitigate this threat."
+        },
+        "externalReferences": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReferences"
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "threatScenario": {
+      "type": "object",
+      "title": "Threat Scenario",
+      "description": "A specific realization of a threat, in which an actor seeks to cause harm. The scenario references the threat it realizes, supplies the actor by reference to a party, and carries the scenario-specific traits and risk assessment, such as motivation, intent, access level, likelihood, and impact.",
+      "additionalProperties": false,
+      "required": [
+        "bom-ref",
+        "name",
+        "threats"
+      ],
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "description": "An identifier which can be used to reference the threat scenario elsewhere using a bom-ref or bom-link."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Name",
+          "description": "The name of the threat scenario."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the threat scenario."
+        },
+        "threats": {
+          "type": "array",
+          "title": "Threats",
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the threats that this scenario realizes. A scenario realizes one or more threats."
+        },
+        "actor": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the party that is the actor in this scenario. Named adversary groups are organizations and abstract attacker classes are personas."
+        },
+        "threatProfile": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to a reusable threat profile that describes the durable capabilities of the actor."
+        },
+        "motivation": {
+          "type": "array",
+          "title": "Motivation",
+          "uniqueItems": true,
+          "description": "The motivations of the actor in this scenario.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "financial",
+              "political",
+              "personal",
+              "ideological",
+              "espionage",
+              "destruction",
+              "disruption",
+              "reputation",
+              "curiosity",
+              "competitive",
+              "revenge",
+              "activism"
+            ],
+            "meta:enum": {
+              "financial": "Motivated by financial gain.",
+              "political": "Motivated by political objectives.",
+              "personal": "Motivated by personal reasons.",
+              "ideological": "Motivated by ideology or belief.",
+              "espionage": "Motivated by intelligence gathering.",
+              "destruction": "Motivated by the desire to destroy.",
+              "disruption": "Motivated by the desire to disrupt operations.",
+              "reputation": "Motivated by reputational gain or harm.",
+              "curiosity": "Motivated by curiosity.",
+              "competitive": "Motivated by competitive advantage.",
+              "revenge": "Motivated by revenge.",
+              "activism": "Motivated by activism."
+            }
+          }
+        },
+        "intent": {
+          "type": "string",
+          "title": "Intent",
+          "description": "The intent of the actor in this scenario.",
+          "enum": [
+            "accidental",
+            "opportunistic",
+            "targeted",
+            "persistent"
+          ],
+          "meta:enum": {
+            "accidental": "The harm is caused without intent.",
+            "opportunistic": "The actor takes advantage of an opportunity as it arises.",
+            "targeted": "The actor deliberately targets the subject.",
+            "persistent": "The actor pursues the target persistently over time."
+          }
+        },
+        "accessLevel": {
+          "type": "string",
+          "title": "Access Level",
+          "description": "The level of access the actor is assumed to have in this scenario.",
+          "enum": [
+            "none",
+            "external",
+            "internal",
+            "privileged",
+            "physical"
+          ],
+          "meta:enum": {
+            "none": "No access.",
+            "external": "External access only.",
+            "internal": "Internal access, such as that of an ordinary user.",
+            "privileged": "Privileged or administrative access.",
+            "physical": "Physical access to the target."
+          }
+        },
+        "attackVector": {
+          "$ref": "#/$defs/attackVector"
+        },
+        "exploitability": {
+          "$ref": "#/$defs/exploitability"
+        },
+        "likelihood": {
+          "$ref": "cyclonedx-risk-2.0.schema.json#/$defs/likelihood"
+        },
+        "impact": {
+          "$ref": "cyclonedx-risk-2.0.schema.json#/$defs/impact"
+        },
+        "riskScore": {
+          "$ref": "cyclonedx-risk-2.0.schema.json#/$defs/riskScore"
+        },
+        "riskAttributes": {
+          "type": "array",
+          "title": "Risk Attributes",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-risk-2.0.schema.json#/$defs/riskAttribute"
+          },
+          "description": "The security and privacy attributes that this threat would compromise if realized."
+        },
+        "affectedAssets": {
+          "type": "array",
+          "title": "Affected Assets",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the assets affected in this scenario."
+        },
+        "relatedRisks": {
+          "type": "array",
+          "title": "Related Risks",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the risks that this scenario contributes to."
+        },
+        "relatedVulnerabilities": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the vulnerabilities exploited in this scenario."
+        },
+        "externalReferences": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReferences"
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "threatProfiles": {
+      "type": "array",
+      "title": "Threat Profiles",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/threatProfile"
+      },
+      "description": "Reusable threat profiles, each describing the durable characteristics of an actor that may pose a threat."
+    },
+    "threatProfile": {
+      "type": "object",
+      "title": "Threat Profile",
+      "description": "A durable, actor-level characterization of the capability to pose a threat, capturing attributes that persist across scenarios. Scenario-specific attributes, such as motivation, intent, and access level, belong on a threat scenario rather than on this profile.",
+      "additionalProperties": false,
+      "required": [
+        "bom-ref"
+      ],
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "description": "An identifier which can be used to reference this threat profile elsewhere using a bom-ref or bom-link."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Name",
+          "description": "The name of the threat profile."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the threat profile."
+        },
+        "sophistication": {
+          "type": "string",
+          "title": "Sophistication",
+          "description": "The level of technical sophistication an actor characterized by this profile is assumed to possess.",
+          "enum": ["none", "minimal", "intermediate", "advanced", "expert"],
+          "meta:enum": {
+            "none": "No technical sophistication.",
+            "minimal": "Minimal sophistication, relying on readily available tools and techniques.",
+            "intermediate": "Intermediate technical skills.",
+            "advanced": "Advanced skills consistent with a persistent and well-resourced actor.",
+            "expert": "Expert skills consistent with the most capable actors."
+          }
+        },
+        "resources": {
+          "type": "string",
+          "title": "Resources",
+          "description": "The level of resources an actor characterized by this profile is assumed to have available.",
+          "enum": ["minimal", "limited", "moderate", "substantial", "unlimited"],
+          "meta:enum": {
+            "minimal": "Minimal resources.",
+            "limited": "Limited resources.",
+            "moderate": "Moderate resources.",
+            "substantial": "Substantial resources.",
+            "unlimited": "Effectively unlimited resources."
+          }
+        },
+        "skillSet": {
+          "type": "array",
+          "title": "Skill Set",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "The specific skills an actor characterized by this profile is assumed to possess."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "attackVector": {
+      "type": "object",
+      "title": "Attack Vector",
+      "description": "The conditions under which an attack is possible, following the convention of common vulnerability scoring systems.",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "description": "The context by which an attack is possible.",
+          "enum": [
+            "network",
+            "adjacent",
+            "local",
+            "physical"
+          ],
+          "meta:enum": {
+            "network": "Remotely exploitable via a network.",
+            "adjacent": "Exploitable from an adjacent network.",
+            "local": "Requires local access.",
+            "physical": "Requires physical access."
+          }
+        },
+        "complexity": {
+          "type": "string",
+          "title": "Complexity",
+          "description": "The complexity of the attack.",
+          "enum": [
+            "low",
+            "high"
+          ],
+          "meta:enum": {
+            "low": "The attack has low complexity.",
+            "high": "The attack has high complexity."
+          }
+        },
+        "privileges": {
+          "type": "string",
+          "title": "Privileges",
+          "description": "The level of privileges required to carry out the attack.",
+          "enum": [
+            "none",
+            "low",
+            "high"
+          ],
+          "meta:enum": {
+            "none": "No privileges are required.",
+            "low": "Low privileges are required.",
+            "high": "High privileges are required."
+          }
+        },
+        "userInteraction": {
+          "type": "string",
+          "title": "User Interaction",
+          "description": "Whether the attack requires interaction from a user other than the attacker.",
+          "enum": [
+            "none",
+            "required"
+          ],
+          "meta:enum": {
+            "none": "No user interaction is required.",
+            "required": "User interaction is required."
+          }
+        },
+        "scope": {
+          "type": "string",
+          "title": "Scope",
+          "description": "Whether a successful attack affects resources beyond the vulnerable component.",
+          "enum": [
+            "unchanged",
+            "changed"
+          ],
+          "meta:enum": {
+            "unchanged": "The attack affects only the vulnerable component.",
+            "changed": "The attack affects resources beyond the vulnerable component."
+          }
+        }
+      }
+    },
+    "attackPattern": {
+      "type": "object",
+      "title": "Attack Pattern",
+      "description": "A description of the common attributes and approach of an attack, typically aligned with CAPEC. Techniques are aligned with MITRE ATT&CK.",
+      "additionalProperties": false,
+      "required": [
+        "bom-ref",
+        "name"
+      ],
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "description": "An identifier which can be used to reference the attack pattern elsewhere using a bom-ref or bom-link."
+        },
+        "capecId": {
+          "type": "integer",
+          "minimum": 1,
+          "title": "CAPEC Identifier",
+          "description": "The Common Attack Pattern Enumeration and Classification (CAPEC) identifier for this attack pattern."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Name",
+          "description": "The name of the attack pattern."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the attack pattern."
+        },
+        "prerequisites": {
+          "type": "array",
+          "title": "Prerequisites",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "The conditions that must hold for the attack to be possible."
+        },
+        "techniques": {
+          "type": "array",
+          "title": "Techniques",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/technique"
+          },
+          "description": "The techniques used to carry out the attack, typically aligned with MITRE ATT&CK."
+        },
+        "mitigations": {
+          "type": "array",
+          "title": "Mitigations",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the controls that mitigate this attack pattern."
+        },
+        "examples": {
+          "type": "array",
+          "title": "Examples",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "Real-world examples of the attack pattern."
+        }
+      }
+    },
+    "technique": {
+      "type": "object",
+      "title": "Technique",
+      "description": "A specific technique used to carry out an attack, typically aligned with MITRE ATT&CK.",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Identifier",
+          "description": "The identifier of the technique, such as a MITRE ATT&CK technique identifier."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the technique."
+        },
+        "tactic": {
+          "type": "string",
+          "title": "Tactic",
+          "description": "The tactic that the technique supports, such as a MITRE ATT&CK tactic."
+        },
+        "procedure": {
+          "type": "string",
+          "title": "Procedure",
+          "description": "The specific procedure by which the technique is carried out."
+        }
+      }
+    },
+    "attackTree": {
+      "type": "object",
+      "title": "Attack Tree",
+      "description": "A decomposition of an attacker goal into sub-goals and techniques, expressed as a flat collection of nodes. Each node lists its child nodes by reference together with an operator that says how those children combine, so the tree is expressed without nesting. One node is the root, representing the attacker goal.",
+      "additionalProperties": false,
+      "required": [
+        "bom-ref",
+        "nodes"
+      ],
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "description": "An identifier which can be used to reference the attack tree elsewhere using a bom-ref or bom-link."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the attack tree."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the attack tree."
+        },
+        "root": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "title": "Root BOM Reference",
+          "description": "Optional reference using bom-link or bom-ref to the root node within nodes, representing the attacker goal. When omitted, the root is the node that no other node lists as a child."
+        },
+        "nodes": {
+          "type": "array",
+          "title": "Nodes",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/attackTreeNode"
+          },
+          "description": "The nodes of the attack tree. Each node references its child nodes, which are themselves entries in this array, forming the hierarchy without nesting."
+        }
+      }
+    },
+    "attackTreeNode": {
+      "type": "object",
+      "title": "Attack Tree Node",
+      "description": "A node in an attack tree, representing an attacker goal, sub-goal, or technique. A node references its child nodes and carries an operator that says how those children combine. The hierarchy is expressed by these references rather than by nesting.",
+      "additionalProperties": false,
+      "required": [
+        "bom-ref",
+        "name"
+      ],
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "description": "An identifier which can be used to reference the node elsewhere using a bom-ref or bom-link."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Name",
+          "description": "The goal, sub-goal, or technique that the node represents."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the node."
+        },
+        "operator": {
+          "type": "string",
+          "title": "Operator",
+          "description": "Specifies how the nodes listed in 'children' combine to achieve this node. A value of 'and' requires every child node; a value of 'or' requires any single child node. For example, a node whose children are a phishing node and a credential-stuffing node uses 'or' when either alone achieves it, or 'and' when both are needed together. A node with no children is a leaf and omits this property.",
+          "enum": [
+            "and",
+            "or"
+          ],
+          "meta:enum": {
+            "and": "All child nodes are required to achieve this node.",
+            "or": "Any one child node is sufficient to achieve this node."
+          }
+        },
+        "children": {
+          "type": "array",
+          "title": "Children",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the child nodes that decompose this node. Each child node is a separate entry in the same nodes array, so the hierarchy is expressed without nesting. A child node may be shared by more than one parent."
+        },
+        "attackPattern": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the attack pattern that this node represents."
+        },
+        "weakness": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the weakness that this node exploits."
+        },
+        "cost": {
+          "type": "string",
+          "title": "Cost",
+          "description": "The relative cost to an attacker of achieving this node.",
+          "enum": [
+            "negligible",
+            "low",
+            "moderate",
+            "high",
+            "prohibitive"
+          ],
+          "meta:enum": {
+            "negligible": "Negligible cost.",
+            "low": "Low cost.",
+            "moderate": "Moderate cost.",
+            "high": "High cost.",
+            "prohibitive": "Prohibitive cost."
+          }
+        },
+        "skill": {
+          "type": "string",
+          "title": "Skill",
+          "description": "The skill level required to achieve this node.",
+          "enum": [
+            "none",
+            "basic",
+            "intermediate",
+            "advanced",
+            "expert"
+          ],
+          "meta:enum": {
+            "none": "No special skill is required.",
+            "basic": "Basic skill is required.",
+            "intermediate": "Intermediate skill is required.",
+            "advanced": "Advanced skill is required.",
+            "expert": "Expert skill is required."
+          }
+        },
+        "detectability": {
+          "type": "string",
+          "title": "Detectability",
+          "description": "How readily an attempt to achieve this node can be detected.",
+          "enum": [
+            "undetectable",
+            "low",
+            "moderate",
+            "high"
+          ],
+          "meta:enum": {
+            "undetectable": "The attempt is effectively undetectable.",
+            "low": "The attempt is difficult to detect.",
+            "moderate": "The attempt is moderately detectable.",
+            "high": "The attempt is readily detectable."
+          }
+        },
+        "mitigations": {
+          "type": "array",
+          "title": "Mitigations",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the controls that mitigate this node."
+        }
+      }
+    },
+    "abuseCase": {
+      "type": "object",
+      "title": "Abuse Case",
+      "description": "A description of how an adversary can misuse the system to achieve a malicious goal. An abuse case is the security counterpart of a use case and reuses its flow structure.",
+      "additionalProperties": false,
+      "required": [
+        "bom-ref",
+        "name"
+      ],
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "description": "An identifier which can be used to reference the abuse case elsewhere using a bom-ref or bom-link."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Name",
+          "description": "The name of the abuse case, typically expressed as a malicious goal."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A narrative describing how the system can be misused or abused."
+        },
+        "abuser": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the party that abuses the system, typically an attacker persona."
+        },
+        "realizes": {
+          "type": "array",
+          "title": "Realizes",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the threats that this abuse case realizes."
+        },
+        "preconditions": {
+          "type": "array",
+          "title": "Preconditions",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "The conditions that must hold before the abuse case can begin."
+        },
+        "mainFlow": {
+          "type": "array",
+          "title": "Main Flow",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-usecase-2.0.schema.json#/$defs/step"
+          },
+          "description": "The ordered steps the abuser follows."
+        },
+        "targets": {
+          "type": "array",
+          "title": "Targets",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the assets or flows targeted in this abuse case."
+        },
+        "detectionOpportunities": {
+          "type": "array",
+          "title": "Detection Opportunities",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "The signals, logs, or controls that present an opportunity to detect the abuse."
+        },
+        "mitigations": {
+          "type": "array",
+          "title": "Mitigations",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the controls that mitigate this abuse case."
+        }
+      }
+    },
+    "exploitability": {
+      "type": "object",
+      "title": "Exploitability",
+      "description": "The degree to which a threat can be exploited in practice.",
+      "additionalProperties": false,
+      "properties": {
+        "level": {
+          "type": "string",
+          "title": "Level",
+          "description": "The maturity of available exploitation capability.",
+          "enum": [
+            "theoretical",
+            "proof-of-concept",
+            "functional",
+            "weaponized"
+          ],
+          "meta:enum": {
+            "theoretical": "Exploitation is theoretically possible but has not been demonstrated.",
+            "proof-of-concept": "A proof of concept exists.",
+            "functional": "A functional exploit exists.",
+            "weaponized": "A weaponized exploit is in use."
+          }
+        },
+        "complexity": {
+          "type": "string",
+          "title": "Complexity",
+          "description": "The complexity of exploitation.",
+          "enum": [
+            "trivial",
+            "low",
+            "medium",
+            "high",
+            "very-high"
+          ],
+          "meta:enum": {
+            "trivial": "Exploitation is trivial.",
+            "low": "Exploitation has low complexity.",
+            "medium": "Exploitation has medium complexity.",
+            "high": "Exploitation has high complexity.",
+            "very-high": "Exploitation has very high complexity."
+          }
+        },
+        "skillRequired": {
+          "type": "string",
+          "title": "Skill Required",
+          "description": "The skill level required to exploit the threat.",
+          "enum": [
+            "none",
+            "basic",
+            "intermediate",
+            "advanced",
+            "expert"
+          ],
+          "meta:enum": {
+            "none": "No special skill is required.",
+            "basic": "Basic skill is required.",
+            "intermediate": "Intermediate skill is required.",
+            "advanced": "Advanced skill is required.",
+            "expert": "Expert skill is required."
+          }
+        },
+        "automatable": {
+          "type": "boolean",
+          "title": "Automatable",
+          "description": "Whether exploitation can be automated."
+        }
+      }
+    },
+    "indicators": {
+      "type": "object",
+      "title": "Indicators",
+      "description": "The observable indicators associated with a threat.",
+      "additionalProperties": false,
+      "properties": {
+        "compromise": {
+          "type": "array",
+          "title": "Indicators of Compromise",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "The indicators that a compromise has occurred."
+        },
+        "attack": {
+          "type": "array",
+          "title": "Indicators of Attack",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "The indicators that an attack is under way."
+        },
+        "signatures": {
+          "type": "array",
+          "title": "Signatures",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/signature"
+          },
+          "description": "The detection signatures associated with the threat."
+        }
+      }
+    },
+    "signature": {
+      "type": "object",
+      "title": "Signature",
+      "description": "A detection signature for a threat.",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "description": "The type of signature.",
+          "enum": [
+            "yara",
+            "snort",
+            "regex",
+            "hash",
+            "behavior"
+          ],
+          "meta:enum": {
+            "yara": "A YARA rule.",
+            "snort": "A Snort rule.",
+            "regex": "A regular expression.",
+            "hash": "A cryptographic hash.",
+            "behavior": "A behavioural signature."
+          }
+        },
+        "value": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Value",
+          "description": "The signature value or pattern."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of what the signature detects."
+        },
+        "confidence": {
+          "type": "string",
+          "title": "Confidence",
+          "description": "The confidence level of a detection by this signature.",
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "meta:enum": {
+            "low": "Low confidence.",
+            "medium": "Medium confidence.",
+            "high": "High confidence."
+          }
+        }
+      }
+    },
+    "trustBoundary": {
+      "type": "object",
+      "title": "Trust Boundary",
+      "description": "A security annotation marking an architectural boundary as one across which trust changes. It references a boundary defined in a blueprint, where the zones, type, and crossing requirements already live, and adds only the trust differential and the threats and controls at that boundary.",
+      "additionalProperties": false,
+      "required": [
+        "bom-ref",
+        "boundary"
+      ],
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "description": "An identifier which can be used to reference the trust boundary elsewhere using a bom-ref or bom-link."
+        },
+        "boundary": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the blueprint boundary that this trust boundary annotates."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the trust boundary."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the trust boundary."
+        },
+        "trustLevel": {
+          "type": "string",
+          "title": "Trust Level",
+          "description": "The trust level differential across the boundary.",
+          "enum": [
+            "untrusted",
+            "semi-trusted",
+            "trusted",
+            "highly-trusted"
+          ],
+          "meta:enum": {
+            "untrusted": "The boundary separates an untrusted zone.",
+            "semi-trusted": "The boundary separates a semi-trusted zone.",
+            "trusted": "The boundary separates a trusted zone.",
+            "highly-trusted": "The boundary separates a highly trusted zone."
+          }
+        },
+        "threatsAtBoundary": {
+          "type": "array",
+          "title": "Threats At Boundary",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the threats that could exploit this boundary."
+        },
+        "controlsAtBoundary": {
+          "type": "array",
+          "title": "Controls At Boundary",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the controls in place at this boundary. Intended primarily for referencing externally defined controls. Where the control and boundary are declared together, prefer the control's appliesTo property."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "killChainPhase": {
+      "type": "string",
+      "title": "Kill Chain Phase",
+      "description": "A phase of the cyber kill chain.",
+      "enum": [
+        "reconnaissance",
+        "weaponization",
+        "delivery",
+        "exploitation",
+        "installation",
+        "command-and-control",
+        "actions-on-objectives"
+      ],
+      "meta:enum": {
+        "reconnaissance": "Gathering information about the target.",
+        "weaponization": "Creating a malicious payload.",
+        "delivery": "Transmitting the payload to the target.",
+        "exploitation": "Exploiting a vulnerability or weakness.",
+        "installation": "Installing malicious software or establishing a foothold.",
+        "command-and-control": "Establishing a command and control channel.",
+        "actions-on-objectives": "Achieving the goals of the attack."
+      }
+    },
+    "attackPathStep": {
+      "type": "object",
+      "title": "Attack Path Step",
+      "description": "A single step in an attack path, describing one action in the progression of an attack.",
+      "required": [
+        "description"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "A short name for the step."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Description",
+          "description": "The action the adversary performs in this step."
+        },
+        "technique": {
+          "$ref": "#/$defs/technique",
+          "description": "The technique used in this step, typically aligned with MITRE ATT&CK."
+        },
+        "attackPattern": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the attack pattern applied in this step."
+        },
+        "killChainPhase": {
+          "$ref": "#/$defs/killChainPhase",
+          "description": "The phase of the cyber kill chain at which this step operates."
+        },
+        "source": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the element or zone from which this step originates."
+        },
+        "destination": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the element or zone this step reaches."
+        },
+        "boundaryCrossed": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the trust boundary this step crosses."
+        },
+        "exploits": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the weaknesses or vulnerabilities this step exploits."
+        },
+        "mitigations": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the controls that detect or prevent this step."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "attackPath": {
+      "type": "object",
+      "title": "Attack Path",
+      "description": "An ordered sequence of steps that an adversary follows to progress from initial access toward an objective, crossing elements and trust boundaries. An attack path complements an attack tree: the tree decomposes a goal into alternatives, whereas the path expresses the temporal progression of a single attack, including lateral movement.",
+      "required": [
+        "bom-ref",
+        "name",
+        "steps"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Name",
+          "description": "A human-readable name for the attack path."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the attack path."
+        },
+        "objective": {
+          "type": "string",
+          "title": "Objective",
+          "description": "The attacker objective that the path works toward, such as exfiltrating data or achieving code execution."
+        },
+        "actor": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the adversary that follows this path."
+        },
+        "steps": {
+          "type": "array",
+          "title": "Steps",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/attackPathStep"
+          },
+          "description": "The ordered steps of the path, from the initial action to the objective. The order of the array is significant."
+        },
+        "realizes": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the threats that this path realizes."
+        },
+        "relatedRisks": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the risks that this path contributes to."
+        },
+        "externalReferences": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReferences"
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev-threatmodeling/cyclonedx-usecase-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev-threatmodeling/cyclonedx-usecase-2.0.schema.json
@@ -1,0 +1,302 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-usecase-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Use Case Model",
+  "$comment": "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "useCases": {
+      "type": "array",
+      "title": "Use Cases",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/useCase"
+      },
+      "description": "A collection of use cases that describe how actors interact with the system to achieve specific goals."
+    },
+    "useCase": {
+      "type": "object",
+      "title": "Use Case",
+      "description": "A structured description of how one or more actors interact with the system to achieve a specific goal, including the primary flow, alternative paths, and exception scenarios.",
+      "required": [
+        "bom-ref",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "minLength": 1,
+          "description": "The name or title of the use case, typically expressed as a verb phrase that captures the goal from the actor's perspective (e.g., 'Place Order', 'Reset Password')."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A detailed narrative of the use case, including the actor's goal, the scope of the interaction, and any relevant business rules or constraints that govern its execution."
+        },
+        "actors": {
+          "type": "array",
+          "title": "Actors",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the actors that participate in this use case, representing anyone or anything that initiates or interacts with the described flow."
+        },
+        "preconditions": {
+          "type": "array",
+          "title": "Preconditions",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "Conditions that must hold true before the use case can begin execution, such as required system state, authenticated sessions, available resources, or prior completed use cases."
+        },
+        "postconditions": {
+          "type": "array",
+          "title": "Postconditions",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "Conditions that will be true after the use case completes successfully, describing the expected system state, data changes, notifications sent, or side effects produced."
+        },
+        "mainFlow": {
+          "type": "array",
+          "title": "Main Flow",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/step"
+          },
+          "description": "The primary sequence of steps representing the most common or expected path through the use case, from the triggering action to the successful outcome."
+        },
+        "alternativeFlows": {
+          "type": "array",
+          "title": "Alternative Flows",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/flow"
+          },
+          "description": "Variant paths that branch from the main flow under specific conditions, representing valid but less common ways to achieve the use case goal or a modified outcome."
+        },
+        "exceptions": {
+          "type": "array",
+          "title": "Exceptions",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/exception"
+          },
+          "description": "Error or failure scenarios that may interrupt the main or alternative flows, including the triggering condition and how the system responds to recover or terminate gracefully."
+        },
+        "successCriteria": {
+          "type": "array",
+          "title": "Success Criteria",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "Measurable or observable criteria that determine whether the use case has been completed successfully, used for validation, acceptance testing, and stakeholder sign-off."
+        },
+        "requirements": {
+          "type": "array",
+          "title": "Requirements",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the requirements that are implemented, validated, or addressed by this use case."
+        },
+        "businessObjectives": {
+          "type": "array",
+          "title": "Business Objectives",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "description": "References using bom-link or bom-ref to the business objectives this use case supports."
+        },
+        "notes": {
+          "type": "array",
+          "title": "Notes",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "Supplementary information, clarifications, open questions, or implementation guidance that provides additional context beyond the formal use case structure."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "step": {
+      "type": "object",
+      "title": "Step",
+      "description": "A single discrete action within a use case flow, performed by a specific actor, that advances the interaction toward the use case goal.",
+      "required": [
+        "number",
+        "description"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "number": {
+          "type": "integer",
+          "title": "Number",
+          "minimum": 1,
+          "description": "The sequence number indicating the ordinal position of this step within its flow, starting at 1."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "minLength": 1,
+          "description": "A clear, action-oriented statement describing what the actor does in this step and the expected system response, written in the form 'The [actor] [action]'."
+        },
+        "actor": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "description": "Reference using bom-link or bom-ref to the actor who initiates or performs this step, which may be a human user, an external system, or the system under design."
+        }
+      }
+    },
+    "flow": {
+      "type": "object",
+      "title": "Flow",
+      "description": "An alternative sequence of steps that branches from the main flow under a specific condition, representing a valid variant path through the use case.",
+      "required": [
+        "name",
+        "condition"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "minLength": 1,
+          "description": "A short, descriptive name identifying this alternative flow (e.g., 'Payment Declined', 'Guest Checkout')."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A narrative explaining the purpose and context of this alternative flow, including how it differs from the main flow and under what circumstances it applies."
+        },
+        "condition": {
+          "type": "string",
+          "title": "Condition",
+          "minLength": 1,
+          "description": "The specific condition, decision point, or triggering event that causes execution to diverge from the main flow into this alternative path."
+        },
+        "steps": {
+          "type": "array",
+          "title": "Steps",
+          "items": {
+            "$ref": "#/$defs/step"
+          },
+          "description": "The ordered sequence of steps that comprise this alternative flow, following the same structure as main flow steps."
+        }
+      }
+    },
+    "exception": {
+      "type": "object",
+      "title": "Exception",
+      "description": "An error or failure scenario that may interrupt the normal execution of a use case, including the condition that triggers it and how the system responds.",
+      "required": [
+        "name",
+        "condition"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "minLength": 1,
+          "description": "A short, descriptive name identifying this exception scenario (e.g., 'Session Timeout', 'Insufficient Funds', 'Service Unavailable')."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A narrative describing the nature of this exception, its potential causes, and its impact on the use case and the actors involved."
+        },
+        "condition": {
+          "type": "string",
+          "title": "Condition",
+          "minLength": 1,
+          "description": "The specific error condition, system state, or external event that triggers this exception during the execution of the use case."
+        },
+        "handling": {
+          "type": "string",
+          "title": "Handling",
+          "description": "The recovery strategy or response the system takes when this exception occurs, such as retrying the operation, rolling back changes, notifying the user, or escalating to support."
+        }
+      }
+    },
+    "useCaseAssertions": {
+      "type": "array",
+      "title": "Use Case Assertions",
+      "description": "A list of assertions describing how a component relates to use cases defined in the BOM.",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "title": "Use Case Assertion",
+        "description": "An assertion linking one or more use cases to a component, specifying the nature of the relationship.",
+        "required": [
+          "assertionType",
+          "useCaseRefs"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "bom-ref": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+            "title": "BOM Reference",
+            "description": "An identifier which can be used to reference the assertion elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+          },
+          "assertionType": {
+            "type": "string",
+            "title": "Assertion Type",
+            "description": "The type of assertion being made about the relationship between the component and the use case.",
+            "enum": [
+              "extends",
+              "implements",
+              "inhibits",
+              "not-applicable",
+              "not-assessed",
+              "other",
+              "participates-in",
+              "supports",
+              "triggers",
+              "validates"
+            ],
+            "meta:enum": {
+              "extends": "The component adds optional or conditional behavior to the use case, augmenting its primary flow with additional capability.",
+              "implements": "The component implements or realises the use case, providing the primary capability that makes the use case functional.",
+              "inhibits": "The component is known to interfere with or block the correct execution of the use case.",
+              "not-applicable": "The use case does not pertain to this component. The evaluator has reviewed the use case and determined it is irrelevant.",
+              "not-assessed": "The relationship between the component and the use case has not yet been evaluated.",
+              "other": "A relationship that does not fit into the other predefined assertion types.",
+              "participates-in": "The component participates in the use case but is not solely responsible for its implementation.",
+              "supports": "The component provides enabling infrastructure for the use case without directly implementing or participating in it.",
+              "triggers": "The component initiates or kicks off the use case without being responsible for its implementation.",
+              "validates": "The component validates, tests, or verifies the correct execution of the use case."
+            }
+          },
+          "useCaseRefs": {
+            "type": "array",
+            "title": "Use Case References",
+            "description": "A list of BOM references linking to use case objects defined in the BOM.",
+            "uniqueItems": true,
+            "items": {
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+            }
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "description": "Additional context or clarification regarding the assertion."
+          }
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-ai-modelcard-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-ai-modelcard-2.0.schema.json
@@ -1,0 +1,547 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-ai-modelcard-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX AI Model Card",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "modelCard": {
+      "$comment": "Model card support in CycloneDX is derived from TensorFlow Model Card Toolkit released under the Apache 2.0 license and available from https://github.com/tensorflow/model-card-toolkit/blob/main/model_card_toolkit/schema/v0.0.2/model_card.schema.json. In addition, CycloneDX model card support includes portions of VerifyML, also released under the Apache 2.0 license and available from https://github.com/cylynx/verifyml/blob/main/verifyml/model_card_toolkit/schema/v0.0.4/model_card.schema.json.",
+      "type": "object",
+      "title": "Model Card",
+      "description": "A model card describes the intended uses of a machine learning model and potential limitations, including biases and ethical considerations. Model cards typically contain the training parameters, which datasets were used to train the model, performance metrics, and other relevant data useful for ML transparency. This object SHOULD be specified for any component of type `machine-learning-model` and must not be specified for other component types.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the model card elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "modelParameters": {
+          "type": "object",
+          "title": "Model Parameters",
+          "description": "Hyper-parameters for construction of the model.",
+          "additionalProperties": false,
+          "properties": {
+            "approach": {
+              "type": "object",
+              "title": "Approach",
+              "description": "The overall approach to learning used by the model for problem solving.",
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "title": "Learning Type",
+                  "description": "Learning types describing the learning problem or hybrid learning problem.",
+                  "enum": [
+                    "supervised",
+                    "unsupervised",
+                    "reinforcement-learning",
+                    "semi-supervised",
+                    "self-supervised"
+                  ],
+                  "meta:enum": {
+                    "supervised": "Supervised machine learning involves training an algorithm on labeled data to predict or classify new data based on the patterns learned from the labeled examples.",
+                    "unsupervised": "Unsupervised machine learning involves training algorithms on unlabeled data to discover patterns, structures, or relationships without explicit guidance, allowing the model to identify inherent structures or clusters within the data.",
+                    "reinforcement-learning": "Reinforcement learning is a type of machine learning where an agent learns to make decisions by interacting with an environment to maximize cumulative rewards, through trial and error.",
+                    "semi-supervised": "Semi-supervised machine learning utilizes a combination of labeled and unlabeled data during training to improve model performance, leveraging the benefits of both supervised and unsupervised learning techniques.",
+                    "self-supervised": "Self-supervised machine learning involves training models to predict parts of the input data from other parts of the same data, without requiring external labels, enabling learning from large amounts of unlabeled data."
+                  }
+                }
+              }
+            },
+            "task": {
+              "type": "string",
+              "title": "Task",
+              "description": "Directly influences the input and/or output. Examples include classification, regression, clustering, etc."
+            },
+            "architectureFamily": {
+              "type": "string",
+              "title": "Architecture Family",
+              "description": "The model architecture family such as transformer network, convolutional neural network, residual neural network, LSTM neural network, etc."
+            },
+            "modelArchitecture": {
+              "type": "string",
+              "title": "Model Architecture",
+              "description": "The specific architecture of the model such as GPT-1, ResNet-50, YOLOv3, etc."
+            },
+            "datasets": {
+              "type": "array",
+              "title": "Datasets",
+              "description": "The datasets used to train and evaluate the model.",
+              "items" : {
+                "oneOf" : [
+                  {
+                    "title": "Inline Data Information",
+                    "$ref": "cyclonedx-component-2.0.schema.json#/$defs/componentData"
+                  },
+                  {
+                    "type": "object",
+                    "title": "Data Reference",
+                    "additionalProperties": false,
+                    "properties": {
+                      "ref": {
+                        "anyOf": [
+                          {
+                            "title": "Ref",
+                            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+                          },
+                          {
+                            "title": "BOM-Link Element",
+                            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/bomLinkElementType"
+                          }
+                        ],
+                        "title": "Reference",
+                        "type": "string",
+                        "description": "References a data component by the components bom-ref attribute"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "inputs": {
+              "type": "array",
+              "title": "Inputs",
+              "description": "The input format(s) of the model",
+              "items": { "$ref": "#/$defs/inputOutputMLParameters" }
+            },
+            "outputs": {
+              "type": "array",
+              "title": "Outputs",
+              "description": "The output format(s) from the model",
+              "items": { "$ref": "#/$defs/inputOutputMLParameters" }
+            }
+          }
+        },
+        "quantitativeAnalysis": {
+          "type": "object",
+          "title": "Quantitative Analysis",
+          "description": "A quantitative analysis of the model",
+          "additionalProperties": false,
+          "properties": {
+            "performanceMetrics": {
+              "type": "array",
+              "title": "Performance Metrics",
+              "description": "The model performance metrics being reported. Examples may include accuracy, F1 score, precision, top-3 error rates, MSC, etc.",
+              "items": { "$ref": "#/$defs/performanceMetric" }
+            },
+            "graphics": { "$ref": "#/$defs/graphicsCollection" }
+          }
+        },
+        "considerations": {
+          "type": "object",
+          "title": "Considerations",
+          "description": "What considerations should be taken into account regarding the model's construction, training, and application?",
+          "additionalProperties": false,
+          "properties": {
+            "users": {
+              "type": "array",
+              "title": "Users",
+              "description": "Who are the intended users of the model?",
+              "items": {
+                "type": "string"
+              }
+            },
+            "useCases": {
+              "type": "array",
+              "title": "Use Cases",
+              "description": "What are the intended use cases of the model?",
+              "items": {
+                "type": "string"
+              }
+            },
+            "technicalLimitations": {
+              "type": "array",
+              "title": "Technical Limitations",
+              "description": "What are the known technical limitations of the model? E.g. What kind(s) of data should the model be expected not to perform well on? What are the factors that might degrade model performance?",
+              "items": {
+                "type": "string"
+              }
+            },
+            "performanceTradeoffs": {
+              "type": "array",
+              "title": "Performance Tradeoffs",
+              "description": "What are the known tradeoffs in accuracy/performance of the model?",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ethicalConsiderations": {
+              "type": "array",
+              "title": "Ethical Considerations",
+              "description": "What are the ethical risks involved in the application of this model?",
+              "items": { "$ref": "#/$defs/risk" }
+            },
+            "environmentalConsiderations":{
+              "$ref": "#/$defs/environmentalConsiderations",
+              "title": "Environmental Considerations",
+              "description": "What are the various environmental impacts the corresponding machine learning model has exhibited across its lifecycle?"
+            },
+            "fairnessAssessments": {
+              "type": "array",
+              "title": "Fairness Assessments",
+              "description": "How does the model affect groups at risk of being systematically disadvantaged? What are the harms and benefits to the various affected groups?",
+              "items": {
+                "$ref": "#/$defs/fairnessAssessment"
+              }
+            }
+          }
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "inputOutputMLParameters": {
+      "type": "object",
+      "title": "Input and Output Parameters",
+      "additionalProperties": false,
+      "properties": {
+        "format": {
+          "title": "Input/Output Format",
+          "description": "The data format for input/output to the model.",
+          "type": "string",
+          "examples": [ "string", "image", "time-series"]
+        }
+      }
+    },
+    "environmentalConsiderations": {
+      "type": "object",
+      "title": "Environmental Considerations",
+      "description": "Describes various environmental impact metrics.",
+      "additionalProperties": false,
+      "properties": {
+        "energyConsumptions": {
+          "title": "Energy Consumptions",
+          "description": "Describes energy consumption information incurred for one or more component lifecycle activities.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/energyConsumption"
+          }
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/property"
+          }
+        }
+      }
+    },
+    "energyConsumption": {
+      "title": "Energy consumption",
+      "description": "Describes energy consumption information incurred for the specified lifecycle activity.",
+      "type": "object",
+      "required": [
+        "activity",
+        "energyProviders",
+        "activityEnergyCost"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "activity": {
+          "type": "string",
+          "title": "Activity",
+          "description": "The type of activity that is part of a machine learning model development or operational lifecycle.",
+          "enum": [
+            "design",
+            "data-collection",
+            "data-preparation",
+            "training",
+            "fine-tuning",
+            "validation",
+            "deployment",
+            "inference",
+            "other"
+          ],
+          "meta:enum": {
+            "design": "A model design including problem framing, goal definition and algorithm selection.",
+            "data-collection": "Model data acquisition including search, selection and transfer.",
+            "data-preparation": "Model data preparation including data cleaning, labeling and conversion.",
+            "training": "Model building, training and generalized tuning.",
+            "fine-tuning": "Refining a trained model to produce desired outputs for a given problem space.",
+            "validation": "Model validation including model output evaluation and testing.",
+            "deployment": "Explicit model deployment to a target hosting infrastructure.",
+            "inference": "Generating an output response from a hosted model from a set of inputs.",
+            "other": "A lifecycle activity type whose description does not match currently defined values."
+          }
+        },
+        "energyProviders": {
+          "title": "Energy Providers",
+          "description": "The provider(s) of the energy consumed by the associated model development lifecycle activity.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/energyProvider" }
+        },
+        "activityEnergyCost": {
+          "title": "Activity Energy Cost",
+          "description": "The total energy cost associated with the model lifecycle activity.",
+          "$ref": "#/$defs/energyMeasure"
+        },
+        "co2CostEquivalent": {
+          "title": "CO2 Equivalent Cost",
+          "description": "The CO2 cost (debit) equivalent to the total energy cost.",
+          "$ref": "#/$defs/co2Measure"
+        },
+        "co2CostOffset": {
+          "title": "CO2 Cost Offset",
+          "description": "The CO2 offset (credit) for the CO2 equivalent cost.",
+          "$ref": "#/$defs/co2Measure"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/property"
+          }
+        }
+      }
+    },
+    "energyMeasure": {
+      "type": "object",
+      "title": "Energy Measure",
+      "description": "A measure of energy.",
+      "required": [
+        "value",
+        "unit"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "type": "number",
+          "title": "Value",
+          "description": "Quantity of energy."
+        },
+        "unit": {
+          "type": "string",
+          "enum": [ "kWh" ],
+          "title": "Unit",
+          "description": "Unit of energy.",
+          "meta:enum": {
+            "kWh": "Kilowatt-hour (kWh) is the energy delivered by one kilowatt (kW) of power for one hour (h)."
+          }
+        }
+      }
+    },
+    "co2Measure": {
+      "type": "object",
+      "title": "CO2 Measure",
+      "description": "A measure of carbon dioxide (CO2).",
+      "required": [
+        "value",
+        "unit"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "type": "number",
+          "title": "Value",
+          "description": "Quantity of carbon dioxide (CO2)."
+        },
+        "unit": {
+          "type": "string",
+          "enum": [ "tCO2eq" ],
+          "title": "Unit",
+          "description": "Unit of carbon dioxide (CO2).",
+          "meta:enum": {
+            "tCO2eq": "Tonnes (t) of carbon dioxide (CO2) equivalent (eq)."
+          }
+        }
+      }
+    },
+    "energyProvider": {
+      "type": "object",
+      "title": "Energy Provider",
+      "description": "Describes the physical provider of energy used for model development or operations.",
+      "required": [
+        "organization",
+        "energySource",
+        "energyProvided"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the energy provider elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the energy provider."
+        },
+        "organization": {
+          "type": "object",
+          "title": "Organization",
+          "description": "The organization that provides energy.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity"
+        },
+        "energySource": {
+          "type": "string",
+          "enum": [
+            "coal",
+            "oil",
+            "natural-gas",
+            "nuclear",
+            "wind",
+            "solar",
+            "geothermal",
+            "hydropower",
+            "biofuel",
+            "unknown",
+            "other"
+          ],
+          "meta:enum": {
+            "coal": "Energy produced by types of coal.",
+            "oil": "Petroleum products (primarily crude oil and its derivative fuel oils).",
+            "natural-gas": "Hydrocarbon gas liquids (HGL) that occur as gases at atmospheric pressure and as liquids under higher pressures including Natural gas (C5H12 and heavier), Ethane (C2H6), Propane (C3H8), etc.",
+            "nuclear": "Energy produced from the cores of atoms (i.e., through nuclear fission or fusion).",
+            "wind": "Energy produced from moving air.",
+            "solar": "Energy produced from the sun (i.e., solar radiation).",
+            "geothermal": "Energy produced from heat within the earth.",
+            "hydropower": "Energy produced from flowing water.",
+            "biofuel": "Liquid fuels produced from biomass feedstocks (i.e., organic materials such as plants or animals).",
+            "unknown": "The energy source is unknown.",
+            "other": "An energy source that is not listed."
+          },
+          "title": "Energy Source",
+          "description": "The energy source for the energy provider."
+        },
+        "energyProvided": {
+          "$ref": "#/$defs/energyMeasure",
+          "title": "Energy Provided",
+          "description": "The energy provided by the energy source for an associated activity."
+        },
+        "externalReferences": {
+          "type": "array",
+          "items": {"$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReference"},
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+        }
+      }
+    },
+    "graphicsCollection": {
+      "type": "object",
+      "title": "Graphics Collection",
+      "description": "A collection of graphics that represent various measurements.",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "title": "Description",
+          "description": "A description of this collection of graphics.",
+          "type": "string"
+        },
+        "collection": {
+          "title": "Collection",
+          "description": "A collection of graphics.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/graphic" }
+        }
+      }
+    },
+    "graphic": {
+      "type": "object",
+      "title": "Graphic",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "The name of the graphic.",
+          "type": "string"
+        },
+        "image": {
+          "title": "Graphic Image",
+          "description": "The graphic (vector or raster). Base64 encoding must be specified for binary images.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/attachment"
+        }
+      }
+    },
+    "performanceMetric": {
+      "type": "object",
+      "title": "Performance Metric",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Type",
+          "description": "The type of performance metric.",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value",
+          "description": "The value of the performance metric.",
+          "type": "string"
+        },
+        "slice": {
+          "title": "Slice",
+          "description": "The name of the slice this metric was computed on. By default, assume this metric is not sliced.",
+          "type": "string"
+        },
+        "confidenceInterval": {
+          "title": "Confidence Interval",
+          "description": "The confidence interval of the metric.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "lowerBound": {
+              "title": "Lower Bound",
+              "description": "The lower bound of the confidence interval.",
+              "type": "string"
+            },
+            "upperBound": {
+              "title": "Upper Bound",
+              "description": "The upper bound of the confidence interval.",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "risk": {
+      "type": "object",
+      "title": "Risk",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "The name of the risk.",
+          "type": "string"
+        },
+        "mitigationStrategy": {
+          "title": "Mitigation Strategy",
+          "description": "Strategy used to address this risk.",
+          "type": "string"
+        }
+      }
+    },
+    "fairnessAssessment": {
+      "type": "object",
+      "title": "Fairness Assessment",
+      "description": "Information about the benefits and harms of the model to an identified at risk group.",
+      "additionalProperties": false,
+      "properties": {
+        "groupAtRisk": {
+          "type": "string",
+          "title": "Group at Risk",
+          "description": "The groups or individuals at risk of being systematically disadvantaged by the model."
+        },
+        "benefits": {
+          "type": "string",
+          "title": "Benefits",
+          "description": "Expected benefits to the identified groups."
+        },
+        "harms": {
+          "type": "string",
+          "title": "Harms",
+          "description": "Expected harms to the identified groups."
+        },
+        "mitigationStrategy": {
+          "type": "string",
+          "title": "Mitigation Strategy",
+          "description": "With respect to the benefits and harms outlined, please describe any mitigation strategy implemented."
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-annotation-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-annotation-2.0.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-annotation-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Annotation Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "annotations": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/annotation"},
+      "uniqueItems": true,
+      "title": "Annotations",
+      "description": "Comments made by people, organizations, or tools about any object with a bom-ref, such as components, services, vulnerabilities, or the BOM itself. Unlike inventory information, annotations may contain opinions or commentary from various stakeholders. Annotations may be inline (with inventory) or externalized via BOM-Link and may optionally be signed."
+    },
+    "annotation": {
+      "type": "object",
+      "title": "Annotations",
+      "description": "A comment, note, explanation, or similar textual content which provides additional context to the object(s) being annotated.",
+      "required": [
+        "subjects",
+        "annotator",
+        "timestamp",
+        "text"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the annotation elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "subjects": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "anyOf": [
+              {
+                "title": "Ref",
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "Subjects",
+          "description": "The object in the BOM identified by its bom-ref. This is often a component or service, but may be any object type supporting bom-refs."
+        },
+        "annotator": {
+          "type": "object",
+          "title": "Annotator",
+          "description": "The organization, person, component, or service which created the textual content of the annotation.",
+          "oneOf": [
+            {
+              "required": [
+                "organization"
+              ]
+            },
+            {
+              "required": [
+                "individual"
+              ]
+            },
+            {
+              "required": [
+                "component"
+              ]
+            },
+            {
+              "required": [
+                "service"
+              ]
+            }
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "organization": {
+              "description": "The organization that created the annotation",
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity"
+            },
+            "individual": {
+              "description": "The person that created the annotation",
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalContact"
+            },
+            "component": {
+              "description": "The tool or component that created the annotation",
+              "$ref": "cyclonedx-component-2.0.schema.json#/$defs/component"
+            },
+            "service": {
+              "description": "The service that created the annotation",
+              "$ref": "cyclonedx-service-2.0.schema.json#/$defs/service"
+            }
+          }
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The date and time (timestamp) when the annotation was created."
+        },
+        "text": {
+          "type": "string",
+          "title": "Text",
+          "description": "The textual content of the annotation."
+        },
+        "signature": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-citation-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-citation-2.0.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-citation-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Citation Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "citations": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/citation"},
+      "uniqueItems": true,
+      "title": "Citations",
+      "description": "A collection of attributions indicating which entity supplied information for specific fields within the BOM."
+    },
+    "citation": {
+      "type": "object",
+      "title": "Citation",
+      "description": "Details a specific attribution of data within the BOM to a contributing entity or process.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "BOM Reference"
+        },
+        "pointers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Field Reference",
+            "description": "A [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) identifying the BOM field to which the attribution applies."
+          },
+          "minItems": 1,
+          "title": "Field References",
+          "description": "One or more [JSON Pointers](https://datatracker.ietf.org/doc/html/rfc6901) identifying the BOM fields to which the attribution applies.\nExactly one of the \"pointers\" or \"expressions\" elements must be present."
+        },
+        "expressions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "Path Expression",
+            "description": "Specifies a [JSONPath](https://datatracker.ietf.org/doc/html/rfc9535) expression used to locate a value within a BOM."
+          },
+          "minItems": 1,
+          "title": "Path Expressions",
+          "description": "One or more path expressions used to locate values within a BOM.\nExactly one of the \"pointers\" or \"expressions\" elements must be present."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The date and time when the attribution was made or the information was supplied."
+        },
+        "attributedTo": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "title": "Attributed To",
+          "description": "The `bom-ref` of an object, such as a component, service, tool, organisational entity, or person that supplied the cited information.\nAt least one of the \"attributedTo\" or \"process\" elements must be present."
+        },
+        "process": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "title": "Process Reference",
+          "description": "The `bom-ref` to a process (such as a formula, workflow, task, or step) defined in the `formulation` section that executed or generated the attributed data.\nAt least one of the \"attributedTo\" or \"process\" elements must be present."
+        },
+        "note": {
+          "type": "string",
+          "title": "Note",
+          "description": "A description or comment about the context or quality of the data attribution."
+        },
+        "signature": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/signature",
+          "title": "Signature",
+          "description": "A digital signature verifying the authenticity or integrity of the attribution."
+        }
+      },
+      "required": ["timestamp"],
+      "anyOf": [
+        { "required": ["attributedTo"] },
+        { "required": ["process"] }
+      ],
+      "oneOf": [
+        { "required": ["pointers"] },
+        { "required": ["expressions"] }
+      ]
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-common-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-common-2.0.schema.json
@@ -1,0 +1,774 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-common-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Common Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "refType": {
+      "description": "Identifier for referable and therefore interlinkable elements.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+      "type": "string",
+      "minLength": 1,
+      "$comment": "TODO (breaking change): add a format constraint that prevents the value from staring with 'urn:cdx:'"
+    },
+    "refLinkType": {
+      "description": "Descriptor for an element identified by the attribute 'bom-ref' in the same BOM document.\nIn contrast to `bomLinkElementType`.",
+      "$ref": "#/$defs/refType"
+    },
+    "bomLinkDocumentType": {
+      "title": "BOM-Link Document",
+      "description": "Descriptor for another BOM document. See https://cyclonedx.org/capabilities/bomlink/",
+      "type": "string",
+      "format": "iri-reference",
+      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*$",
+      "$comment": "part of the pattern is based on `bom.serialNumber`'s pattern"
+    },
+    "bomLinkElementType": {
+      "title": "BOM-Link Element",
+      "description": "Descriptor for an element in a BOM document. See https://cyclonedx.org/capabilities/bomlink/",
+      "type": "string",
+      "format": "iri-reference",
+      "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*#.+$",
+      "$comment": "part of the pattern is based on `bom.serialNumber`'s pattern"
+    },
+    "bomLink": {
+      "title": "BOM-Link",
+      "anyOf": [
+        {
+          "title": "BOM-Link Document",
+          "$ref": "#/$defs/bomLinkDocumentType"
+        },
+        {
+          "title": "BOM-Link Element",
+          "$ref": "#/$defs/bomLinkElementType"
+        }
+      ]
+    },
+    "hash": {
+      "type": "object",
+      "title": "Hash",
+      "required": [
+        "alg",
+        "content"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alg": {
+          "$ref": "#/$defs/hashAlgorithm"
+        },
+        "content": {
+          "$ref": "#/$defs/hashValue"
+        }
+      }
+    },
+    "hashAlgorithm": {
+      "type": "string",
+      "title": "Hash Algorithm",
+      "description": "The algorithm that generated the hash value.",
+      "enum": [
+        "MD5",
+        "SHA-1",
+        "SHA-256",
+        "SHA-384",
+        "SHA-512",
+        "SHA3-256",
+        "SHA3-384",
+        "SHA3-512",
+        "BLAKE2b-256",
+        "BLAKE2b-384",
+        "BLAKE2b-512",
+        "BLAKE3",
+        "Streebog-256",
+        "Streebog-512"
+      ]
+    },
+    "hashValue": {
+      "type": "string",
+      "title": "Hash Value",
+      "description": "The value of the hash.",
+      "examples": ["3942447fac867ae5cdb3229b658f4d48"],
+      "pattern": "^([a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$"
+    },
+    "mediaType": {
+      "type": "string",
+      "title": "Media Type",
+      "description": "The media type of the object. The media type can provide additional context about the kind of data being represented, such as an image, font, or executable.",
+      "examples": [
+        "text/plain",
+        "application/json",
+        "image/png"
+      ],
+      "pattern": "^[-+a-z0-9.]+/[-+a-z0-9.]+$"
+    },
+    "attachment": {
+      "type": "object",
+      "title": "Attachment",
+      "description": "Specifies the metadata and content for an attachment.",
+      "required": [
+        "content"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "mediaType": {
+          "$ref": "#/$defs/mediaType"
+        },
+        "encoding": {
+          "type": "string",
+          "title": "Encoding",
+          "description": "Specifies the optional encoding the text is represented in.",
+          "enum": [
+            "base64"
+          ],
+          "meta:enum": {
+            "base64": "Base64 is a binary-to-text encoding scheme that represents binary data in an ASCII string."
+          }
+        },
+        "content": {
+          "type": "string",
+          "title": "Attachment Text",
+          "description": "The attachment data. Proactive controls such as input validation and sanitization should be employed to prevent misuse of attachment text."
+        }
+      }
+    },
+    "base64": {
+      "type": "string",
+      "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+      "description": "A Base64-encoded string."
+    },
+    "externalReferences": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/externalReference"},
+      "title": "External References",
+      "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+    },
+    "externalReference": {
+      "type": "object",
+      "title": "External Reference",
+      "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM.",
+      "required": [
+        "url",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "anyOf": [
+            {
+              "title": "URL",
+              "type": "string",
+              "format": "iri-reference"
+            },
+            {
+              "title": "BOM-Link",
+              "$ref": "#/$defs/bomLink"
+            }
+          ],
+          "title": "URL",
+          "description": "The URI (URL or URN) to the external reference. External references are URIs and therefore can accept any URL scheme including https ([RFC-7230](https://www.ietf.org/rfc/rfc7230.txt)), mailto ([RFC-2368](https://www.ietf.org/rfc/rfc2368.txt)), tel ([RFC-3966](https://www.ietf.org/rfc/rfc3966.txt)), and dns ([RFC-4501](https://www.ietf.org/rfc/rfc4501.txt)). External references may also include formally registered URNs such as [CycloneDX BOM-Link](https://cyclonedx.org/capabilities/bomlink/) to reference CycloneDX BOMs or any object within a BOM. BOM-Link transforms applicable external references into relationships that can be expressed in a BOM or across BOMs."
+        },
+        "comment": {
+          "type": "string",
+          "title": "Comment",
+          "description": "A comment describing the external reference"
+        },
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "description": "Specifies the type of external reference.",
+          "enum": [
+            "vcs",
+            "issue-tracker",
+            "website",
+            "advisories",
+            "bom",
+            "mailing-list",
+            "social",
+            "chat",
+            "documentation",
+            "support",
+            "source-distribution",
+            "distribution",
+            "distribution-intake",
+            "license",
+            "build-meta",
+            "build-system",
+            "release-notes",
+            "security-contact",
+            "model-card",
+            "log",
+            "configuration",
+            "evidence",
+            "formulation",
+            "attestation",
+            "threat-model",
+            "adversary-model",
+            "risk-assessment",
+            "vulnerability-assertion",
+            "exploitability-statement",
+            "pentest-report",
+            "static-analysis-report",
+            "dynamic-analysis-report",
+            "runtime-analysis-report",
+            "component-analysis-report",
+            "maturity-report",
+            "certification-report",
+            "codified-infrastructure",
+            "quality-metrics",
+            "poam",
+            "perspective",
+            "electronic-signature",
+            "digital-signature",
+            "rfc-9116",
+            "patent",
+            "patent-family",
+            "patent-assertion",
+            "citation",
+            "other"
+          ],
+          "meta:enum": {
+            "vcs": "Version Control System",
+            "issue-tracker": "Issue or defect tracking system, or an Application Lifecycle Management (ALM) system",
+            "website": "Website",
+            "advisories": "Security advisories",
+            "bom": "Bill of Materials (SBOM, OBOM, HBOM, SaaSBOM, etc)",
+            "mailing-list": "Mailing list or discussion group",
+            "social": "Social media account",
+            "chat": "Real-time chat platform",
+            "documentation": "Documentation, guides, or how-to instructions",
+            "support": "Community or commercial support",
+            "source-distribution": "The location where the source code distributable can be obtained. This is often an archive format such as zip or tgz. The source-distribution type complements use of the version control (vcs) type.",
+            "distribution": "Direct or repository download location",
+            "distribution-intake": "The location where a component was published to. This is often the same as \"distribution\" but may also include specialized publishing processes that act as an intermediary.",
+            "license": "The reference to the license file. If a license URL has been defined in the license node, it should also be defined as an external reference for completeness.",
+            "build-meta": "Build-system specific meta file (i.e. pom.xml, package.json, .nuspec, etc)",
+            "build-system": "Reference to an automated build system",
+            "release-notes": "Reference to release notes",
+            "security-contact": "Specifies a way to contact the maintainer, supplier, or provider in the event of a security incident. Common URIs include links to a disclosure procedure, a mailto (RFC-2368) that specifies an email address, a tel (RFC-3966) that specifies a phone number, or dns (RFC-4501) that specifies the records containing DNS Security TXT.",
+            "model-card": "A model card describes the intended uses of a machine learning model, potential limitations, biases, ethical considerations, training parameters, datasets used to train the model, performance metrics, and other relevant data useful for ML transparency.",
+            "log": "A record of events that occurred in a computer system or application, such as problems, errors, or information on current operations.",
+            "configuration": "Parameters or settings that may be used by other components or services.",
+            "evidence": "Information used to substantiate a claim.",
+            "formulation": "Describes the formulation of any referencable object within the BOM, including components, services, metadata, declarations, or the BOM itself.",
+            "attestation": "Human or machine-readable statements containing facts, evidence, or testimony.",
+            "threat-model": "An enumeration of identified weaknesses, threats, and countermeasures, dataflow diagram (DFD), attack tree, and other supporting documentation in human-readable or machine-readable format.",
+            "adversary-model": "The defined assumptions, goals, and capabilities of an adversary.",
+            "risk-assessment": "Identifies and analyzes the potential of future events that may negatively impact individuals, assets, and/or the environment. Risk assessments may also include judgments on the tolerability of each risk.",
+            "vulnerability-assertion": "A Vulnerability Disclosure Report (VDR) which asserts the known and previously unknown vulnerabilities that affect a component, service, or product including the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on a component, service, or product.",
+            "exploitability-statement": "A Vulnerability Exploitability eXchange (VEX) which asserts the known vulnerabilities that do not affect a product, product family, or organization, and optionally the ones that do. The VEX should include the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on the product, product family, or organization.",
+            "pentest-report": "Results from an authorized simulated cyberattack on a component or service, otherwise known as a penetration test.",
+            "static-analysis-report": "SARIF or proprietary machine or human-readable report for which static analysis has identified code quality, security, and other potential issues with the source code.",
+            "dynamic-analysis-report": "Dynamic analysis report that has identified issues such as vulnerabilities and misconfigurations.",
+            "runtime-analysis-report": "Report generated by analyzing the call stack of a running application.",
+            "component-analysis-report": "Report generated by Software Composition Analysis (SCA), container analysis, or other forms of component analysis.",
+            "maturity-report": "Report containing a formal assessment of an organization, business unit, or team against a maturity model.",
+            "certification-report": "Industry, regulatory, or other certification from an accredited (if applicable) certification body.",
+            "codified-infrastructure": "Code or configuration that defines and provisions virtualized infrastructure, commonly referred to as Infrastructure as Code (IaC).",
+            "quality-metrics": "Report or system in which quality metrics can be obtained.",
+            "poam": "Plans of Action and Milestones (POA&M) complement an \"attestation\" external reference. POA&M is defined by NIST as a \"document that identifies tasks needing to be accomplished. It details resources required to accomplish the elements of the plan, any milestones in meeting the tasks and scheduled completion dates for the milestones\".",
+            "perspective": "A CycloneDX perspective defines a domain-specific view, enabling different audiences to interpret and navigate the data through their own conceptual lens.",
+            "electronic-signature": "An e-signature is commonly a scanned representation of a written signature or a stylized script of the person's name.",
+            "digital-signature": "A signature that leverages cryptography, typically public/private key pairs, which provides strong authenticity verification.",
+            "rfc-9116": "Document that complies with [RFC 9116](https://www.ietf.org/rfc/rfc9116.html) (A File Format to Aid in Security Vulnerability Disclosure)",
+            "patent": "References information about patents which may be defined in human-readable documents or in machine-readable formats such as CycloneDX or ST.96. For detailed patent information or to reference the information provided directly by patent offices, it is recommended to leverage standards from the World Intellectual Property Organization (WIPO) such as [ST.96](https://www.wipo.int/standards/en/st96).",
+            "patent-family": "References information about a patent family which may be defined in human-readable documents or in machine-readable formats such as CycloneDX or ST.96. A patent family is a group of related patent applications or granted patents that cover the same or similar invention. For detailed patent family information or to reference the information provided directly by patent offices, it is recommended to leverage standards from the World Intellectual Property Organization (WIPO) such as [ST.96](https://www.wipo.int/standards/en/st96).",
+            "patent-assertion" : "References assertions made regarding patents associated with a component or service. Assertions distinguish between ownership, licensing, and other relevant interactions with patents.",
+            "citation": "A reference to external citations applicable to the object identified by this BOM entry or the BOM itself. When used with a BOM-Link, this allows offloading citations into a separate CycloneDX BOM.",
+            "other": "Use this if no other types accurately describe the purpose of the external reference."
+          }
+        },
+        "hashes": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/hash"},
+          "title": "Hashes",
+          "description": "The hashes of the external reference (if applicable)."
+        },
+        "properties": {
+          "$ref": "#/$defs/properties"
+        }
+      }
+    },
+    "postalAddress": {
+      "type": "object",
+      "title": "Postal address",
+      "description": "An address used to identify a contactable location.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the address elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "#/$defs/refType"
+        },
+        "country": {
+          "type": "string",
+          "title": "Country",
+          "description": "The country name or the two-letter ISO 3166-1 country code."
+        },
+        "region": {
+          "type": "string",
+          "title": "Region",
+          "description": "The region or state in the country.",
+          "examples": [ "Texas" ]
+        },
+        "locality": {
+          "type": "string",
+          "title": "Locality",
+          "description": "The locality or city within the country.",
+          "examples": [ "Austin" ]
+        },
+        "postOfficeBoxNumber": {
+          "type": "string",
+          "title": "Post Office Box Number",
+          "description": "The post office box number.",
+          "examples": [ "901" ]
+        },
+        "postalCode": {
+          "type": "string",
+          "title": "Postal Code",
+          "description": "The postal code.",
+          "examples": [ "78758" ]
+        },
+        "streetAddress": {
+          "type": "string",
+          "title": "Street Address",
+          "description": "The street address.",
+          "examples": [ "100 Main Street" ]
+        }
+      }
+    },
+    "organizationalEntity": {
+      "type": "object",
+      "title": "Organizational Entity",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/$defs/refType",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "name": {
+          "type": "string",
+          "title": "Organization Name",
+          "description": "The name of the organization",
+          "examples": [
+            "Example Inc."
+          ]
+        },
+        "address": {
+          "$ref": "#/$defs/postalAddress",
+          "title": "Organization Address",
+          "description": "The physical address (location) of the organization"
+        },
+        "url": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "iri-reference"
+          },
+          "title": "Organization URL(s)",
+          "description": "The URL of the organization. Multiple URLs are allowed.",
+          "examples": ["https://example.com"]
+        },
+        "contact": {
+          "type": "array",
+          "title": "Organizational Contact",
+          "description": "A contact at the organization. Multiple contacts are allowed.",
+          "items": {"$ref": "#/$defs/organizationalContact"}
+        }
+      }
+    },
+    "organizationalContact": {
+      "type": "object",
+      "title": "Organizational Contact",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "#/$defs/refType",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of a contact",
+          "examples": ["Contact name"]
+        },
+        "email": {
+          "type": "string",
+          "format": "idn-email",
+          "title": "Email Address",
+          "description": "The email address of the contact.",
+          "examples": ["firstname.lastname@example.com"]
+        },
+        "phone": {
+          "type": "string",
+          "title": "Phone",
+          "description": "The phone number of the contact.",
+          "examples": ["800-555-1212"]
+        }
+      }
+    },
+    "organizationalEntityOrContact": {
+
+    },
+    "properties": {
+      "type": "array",
+      "title": "Properties",
+      "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+      "items": {
+        "$ref": "#/$defs/property"
+      }
+    },
+    "property": {
+      "type": "object",
+      "title": "Lightweight name-value pair",
+      "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the property. Duplicate names are allowed, each potentially having a different value."
+        },
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "The value of the property."
+        }
+      },
+      "additionalProperties": false
+    },
+    "extensibleProperties": {
+      "type": "object",
+      "title": "Extensible Properties",
+      "patternProperties": {
+        "^ext:[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}:.+$": {
+          "description": "CycloneDX supports a structured and namespace-aware mechanism for extensibility through the use of extensible properties. This mechanism enables organizations, ecosystems, and tool vendors to safely introduce custom properties without conflicting with the core schema or other extensions.\n\nExtensible properties are defined as a JSON object whose keys must conform to a strict pattern that resembles a reverse domain name structure, prefixed with ext:. This pattern provides a namespacing convention that aligns with well-established practices in other structured formats (e.g., XML namespaces).",
+          "examples": [
+            "ext:<domain>:<name>",
+            "ext:example.org:myExtension"
+          ],
+          "if": {
+            "type": ["object", "array"]
+          },
+          "then": {
+            "type": "object",
+            "required": ["$schema"],
+            "properties": {
+              "$schema": {
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          },
+          "else": {
+            "type": ["string", "number", "boolean", "null"]
+          }
+        }
+      }
+    },
+    "baseObject": {
+      "description": "Base object for all CycloneDX entities. Automatically includes support for extensible properties.",
+      "allOf": [
+        { "$ref": "cyclonedx-common-2.0.schema.json#/$defs/extensibleProperties" }
+      ],
+      "properties": {
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        },
+        "externalReferences": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReferences"
+        }
+      }
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "title": "Timestamp",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z$",
+      "description": "An RFC 3339-compliant UTC timestamp using Zulu time (i.e., ending with 'Z'). The format must be 'YYYY-MM-DDTHH:MM:SSZ' or include optional fractional seconds, e.g., 'YYYY-MM-DDTHH:MM:SS.sssZ'. Offsets such as '+00:00' are not allowed."
+    },
+    "lifecycle": {
+      "type": "object",
+      "title": "Lifecycle",
+      "description": "The product lifecycle(s) that this BOM represents.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/preDefinedLifecyclePhase"
+        },
+        {
+          "title": "Custom Lifecycle Phase",
+          "required": ["name"],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The name of the lifecycle phase"
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "The description of the lifecycle phase"
+            }
+          }
+        }
+      ]
+    },
+    "lifecycles": {
+      "type": "array",
+      "title": "Lifecycles",
+      "description": "Lifecycles communicate the stage(s) in which data in the BOM was captured. Different types of data may be available at various phases of a lifecycle, such as the Software Development Lifecycle (SDLC), IT Asset Management (ITAM), and Software Asset Management (SAM). Thus, a BOM may include data specific to or only obtainable in a given lifecycle.",
+      "items": { "$ref":  "#/$defs/lifecycle"}
+    },
+    "preDefinedLifecyclePhase": {
+      "title": "Pre-Defined Phase",
+      "required": ["phase"],
+      "additionalProperties": false,
+      "properties": {
+        "phase": {
+          "type": "string",
+          "title": "Phase",
+          "description": "A pre-defined phase in the product lifecycle.",
+          "enum": [
+            "design",
+            "pre-build",
+            "build",
+            "post-build",
+            "operations",
+            "discovery",
+            "decommission"
+          ],
+          "meta:enum": {
+            "design": "BOM produced early in the development lifecycle containing an inventory of components and services that are proposed or planned to be used. The inventory may need to be procured, retrieved, or resourced prior to use.",
+            "pre-build": "BOM consisting of information obtained prior to a build process and may contain source files and development artifacts and manifests. The inventory may need to be resolved and retrieved prior to use.",
+            "build": "BOM consisting of information obtained during a build process where component inventory is available for use. The precise versions of resolved components are usually available at this time as well as the provenance of where the components were retrieved from.",
+            "post-build": "BOM consisting of information obtained after a build process has completed and the resulting components(s) are available for further analysis. Built components may exist as the result of a CI/CD process, may have been installed or deployed to a system or device, and may need to be retrieved or extracted from the system or device.",
+            "operations": "BOM produced that represents inventory that is running and operational. This may include staging or production environments and will generally encompass multiple SBOMs describing the applications and operating system, along with HBOMs describing the hardware that makes up the system. Operations Bill of Materials (OBOM) can provide full-stack inventory of runtime environments, configurations, and additional dependencies.",
+            "discovery": "BOM consisting of information observed through network discovery providing point-in-time enumeration of embedded, on-premise, and cloud-native services such as server applications, connected devices, microservices, and serverless functions.",
+            "decommission": "BOM containing inventory that will be, or has been retired from operations."
+          }
+        }
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "title": "Tags",
+      "description": "Textual strings that aid in discovery, search, and retrieval of the associated object. Tags often serve as a way to group or categorize similar or related objects by various attributes.",
+      "examples": [
+        "json-parser",
+        "object-persistence",
+        "text-to-image",
+        "translation",
+        "object-detection"
+      ]
+    },
+    "commit": {
+      "type": "object",
+      "title": "Commit",
+      "description": "Specifies an individual commit",
+      "additionalProperties": false,
+      "properties": {
+        "uid": {
+          "type": "string",
+          "title": "UID",
+          "description": "A unique identifier of the commit. This may be version control specific. For example, Subversion uses revision numbers whereas git uses commit hashes."
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "The URL to the commit. This URL will typically point to a commit in a version control system.",
+          "format": "iri-reference"
+        },
+        "author": {
+          "title": "Author",
+          "description": "The author who created the changes in the commit",
+          "$ref": "#/$defs/identifiableAction"
+        },
+        "committer": {
+          "title": "Committer",
+          "description": "The person who committed or pushed the commit",
+          "$ref": "#/$defs/identifiableAction"
+        },
+        "message": {
+          "type": "string",
+          "title": "Message",
+          "description": "The text description of the contents of the commit"
+        }
+      }
+    },
+    "patch": {
+      "type": "object",
+      "title": "Patch",
+      "description": "Specifies an individual patch",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "unofficial",
+            "monkey",
+            "backport",
+            "cherry-pick"
+          ],
+          "meta:enum": {
+            "unofficial": "A patch which is not developed by the creators or maintainers of the software being patched. Refer to [https://en.wikipedia.org/wiki/Unofficial_patch](https://en.wikipedia.org/wiki/Unofficial_patch).",
+            "monkey": "A patch which dynamically modifies runtime behavior. Refer to [https://en.wikipedia.org/wiki/Monkey_patch](https://en.wikipedia.org/wiki/Monkey_patch).",
+            "backport": "A patch which takes code from a newer version of the software and applies it to older versions of the same software. Refer to [https://en.wikipedia.org/wiki/Backporting](https://en.wikipedia.org/wiki/Backporting).",
+            "cherry-pick": "A patch created by selectively applying commits from other versions or branches of the same software."
+          },
+          "title": "Patch Type",
+          "description": "Specifies the purpose for the patch including the resolution of defects, security issues, or new behavior or functionality."
+        },
+        "diff": {
+          "title": "Diff",
+          "description": "The patch file (or diff) that shows changes. Refer to [https://en.wikipedia.org/wiki/Diff](https://en.wikipedia.org/wiki/Diff)",
+          "$ref": "#/$defs/diff"
+        },
+        "resolves": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/issue"},
+          "title": "Resolves",
+          "description": "A collection of issues the patch resolves"
+        }
+      }
+    },
+    "diff": {
+      "type": "object",
+      "title": "Diff",
+      "description": "The patch file (or diff) that shows changes. Refer to https://en.wikipedia.org/wiki/Diff",
+      "additionalProperties": false,
+      "properties": {
+        "text": {
+          "title": "Diff text",
+          "description": "Specifies the optional text of the diff",
+          "$ref": "#/$defs/attachment"
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "Specifies the URL to the diff",
+          "format": "iri-reference"
+        }
+      }
+    },
+    "issue": {
+      "type": "object",
+      "title": "Issue",
+      "description": "An individual issue that has been resolved.",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "defect",
+            "enhancement",
+            "security"
+          ],
+          "meta:enum": {
+            "defect": "A fault, flaw, or bug in software.",
+            "enhancement": "A new feature or behavior in software.",
+            "security": "A special type of defect which impacts security."
+          },
+          "title": "Issue Type",
+          "description": "Specifies the type of issue"
+        },
+        "id": {
+          "type": "string",
+          "title": "Issue ID",
+          "description": "The identifier of the issue assigned by the source of the issue"
+        },
+        "name": {
+          "type": "string",
+          "title": "Issue Name",
+          "description": "The name of the issue"
+        },
+        "description": {
+          "type": "string",
+          "title": "Issue Description",
+          "description": "A description of the issue"
+        },
+        "source": {
+          "type": "object",
+          "title": "Source",
+          "description": "The source of the issue where it is documented",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The name of the source.",
+              "examples": [
+                "National Vulnerability Database",
+                "NVD",
+                "Apache"
+              ]
+            },
+            "url": {
+              "type": "string",
+              "title": "URL",
+              "description": "The url of the issue documentation as provided by the source",
+              "format": "iri-reference"
+            }
+          }
+        },
+        "references": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "iri-reference"
+          },
+          "title": "References",
+          "description": "A collection of URL's for reference. Multiple URLs are allowed.",
+          "examples": ["https://example.com"]
+        }
+      }
+    },
+    "identifiableAction": {
+      "type": "object",
+      "title": "Identifiable Action",
+      "description": "Specifies an individual commit",
+      "additionalProperties": false,
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The timestamp in which the action occurred"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the individual who performed the action"
+        },
+        "email": {
+          "type": "string",
+          "format": "idn-email",
+          "title": "E-mail",
+          "description": "The email address of the individual who performed the action"
+        }
+      }
+    },
+    "locale": {
+      "type": "string",
+      "pattern": "^([a-z]{2})(-[A-Z]{2})?$",
+      "title": "Locale",
+      "description": "Defines a syntax for representing two character language code (ISO-639) followed by an optional two character country code. The language code must be lower case. If the country code is specified, the country code must be upper case. The language code and country code must be separated by a minus sign. Examples: en, en-US, fr, fr-CA"
+    },
+    "signature": {
+      "$ref": "../jsf-0.82.schema.json#/definitions/signature",
+      "title": "Signature",
+      "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-component-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-component-2.0.schema.json
@@ -1,0 +1,738 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-component-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Component Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "components": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/component"},
+      "uniqueItems": true,
+      "title": "Components"
+    },
+    "component": {
+      "type": "object",
+      "title": "Component",
+      "required": [
+        "type",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "application",
+            "framework",
+            "library",
+            "container",
+            "platform",
+            "operating-system",
+            "device",
+            "device-driver",
+            "firmware",
+            "file",
+            "machine-learning-model",
+            "data",
+            "cryptographic-asset"
+          ],
+          "meta:enum": {
+            "application": "A software application. Refer to [https://en.wikipedia.org/wiki/Application_software](https://en.wikipedia.org/wiki/Application_software) for information about applications.",
+            "framework": "A software framework. Refer to [https://en.wikipedia.org/wiki/Software_framework](https://en.wikipedia.org/wiki/Software_framework) for information on how frameworks vary slightly from libraries.",
+            "library": "A software library. Refer to [https://en.wikipedia.org/wiki/Library_(computing)](https://en.wikipedia.org/wiki/Library_(computing)) for information about libraries. All third-party and open source reusable components will likely be a library. If the library also has key features of a framework, then it should be classified as a framework. If not, or is unknown, then specifying library is recommended.",
+            "container": "A packaging and/or runtime format, not specific to any particular technology, which isolates software inside the container from software outside of a container through virtualization technology. Refer to [https://en.wikipedia.org/wiki/OS-level_virtualization](https://en.wikipedia.org/wiki/OS-level_virtualization).",
+            "platform": "A runtime environment that interprets or executes software. This may include runtimes such as those that execute bytecode, just-in-time compilers, interpreters, or low-code/no-code application platforms.",
+            "operating-system": "A software operating system without regard to deployment model (i.e. installed on physical hardware, virtual machine, image, etc) Refer to [https://en.wikipedia.org/wiki/Operating_system](https://en.wikipedia.org/wiki/Operating_system).",
+            "device": "A hardware device such as a processor or chip-set. A hardware device containing firmware SHOULD include a component for the physical hardware itself and another component of type 'firmware' or 'operating-system' (whichever is relevant), describing information about the software running on the device. See also the list of [known device properties](https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/device.md).",
+            "device-driver": "A special type of software that operates or controls a particular type of device. Refer to [https://en.wikipedia.org/wiki/Device_driver](https://en.wikipedia.org/wiki/Device_driver).",
+            "firmware": "A special type of software that provides low-level control over a device's hardware. Refer to [https://en.wikipedia.org/wiki/Firmware](https://en.wikipedia.org/wiki/Firmware).",
+            "file": "A computer file. Refer to [https://en.wikipedia.org/wiki/Computer_file](https://en.wikipedia.org/wiki/Computer_file) for information about files.",
+            "machine-learning-model": "A model based on training data that can make predictions or decisions without being explicitly programmed to do so.",
+            "data": "A collection of discrete values that convey information.",
+            "cryptographic-asset": "A cryptographic asset including algorithms, protocols, certificates, keys, tokens, and secrets."
+          },
+          "title": "Component Type",
+          "description": "Specifies the type of component. For software components, classify as application if no more specific appropriate classification is available or cannot be determined for the component.",
+          "examples": ["library"]
+        },
+        "mime-type": {
+          "type": "string",
+          "title": "Mime-Type",
+          "description": "The mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented, such as an image, font, or executable. Some library or framework components may also have an associated mime-type.",
+          "examples": ["image/jpeg"],
+          "pattern": "^[-+a-z0-9.]+/[-+a-z0-9.]+$"
+        },
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the component elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "supplier": {
+          "title": "Component Supplier",
+          "description": " The organization that supplied the component. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity"
+        },
+        "manufacturer": {
+          "title": "Component Manufacturer",
+          "description": "The organization that created the component.\nManufacturer is common in components created through automated processes. Components created through manual means may have `@.authors` instead.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity"
+        },
+        "authors" :{
+          "type": "array",
+          "title": "Component Authors",
+          "description": "The person(s) who created the component.\nAuthors are common in components created through manual processes. Components created through automated means may have `@.manufacturer` instead.",
+          "items": {"$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalContact"}
+        },
+        "publisher": {
+          "type": "string",
+          "title": "Component Publisher",
+          "description": "The person(s) or organization(s) that published the component",
+          "examples": ["Acme Inc"]
+        },
+        "group": {
+          "type": "string",
+          "title": "Component Group",
+          "description": "The grouping name or identifier. This will often be a shortened, single name of the company or project that produced the component, or the source package or domain name. Whitespace and special characters should be avoided. Examples include: apache, org.apache.commons, and apache.org.",
+          "examples": ["com.acme"]
+        },
+        "name": {
+          "type": "string",
+          "title": "Component Name",
+          "description": "The name of the component. This will often be a shortened, single name of the component. Examples: commons-lang3 and jquery",
+          "examples": ["tomcat-catalina"]
+        },
+        "version": {
+          "$ref": "#/$defs/version",
+          "title": "Component Version",
+          "description": "The component version. The version should ideally comply with semantic versioning but is not enforced.\nMust be used exclusively, either 'version' or 'versionRange', but not both."
+        },
+        "versionRange": {
+          "$ref": "#/$defs/versionRange",
+          "title": "Component Version Range",
+          "description": "For an external component, this specifies the accepted version range.\nThe value must adhere to the Package URL Version Range syntax (vers), as defined at <https://github.com/package-url/vers-spec\nMay only be used if `.isExternal` is set to `true`.\nMust be used exclusively, either 'version' or 'versionRange', but not both."
+        },
+        "isExternal": {
+          "type": "boolean",
+          "title": "Component Is External",
+          "description": "Determine whether this component is external.\nAn external component is one that is not part of an assembly, but is expected to be provided by the environment, regardless of the component's `.scope`. This setting can be useful for distinguishing which components are bundled with the product and which can be relied upon to be present in the deployment environment.\nThis may be set to `true` for runtime components only. For `$.metadata.component`, it must be set to `false`.",
+          "default": false
+        },
+        "description": {
+          "type": "string",
+          "title": "Component Description",
+          "description": "Specifies a description for the component"
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "required",
+            "optional",
+            "excluded"
+          ],
+          "meta:enum": {
+            "required": "The component is required for runtime",
+            "optional": "The component is optional at runtime. Optional components are components that are not capable of being called due to them not being installed or otherwise accessible by any means. Components that are installed but due to configuration or other restrictions are prohibited from being called must be scoped as 'required'.",
+            "excluded": "Components that are excluded provide the ability to document component usage for test and other non-runtime purposes. Excluded components are not reachable within a call graph at runtime."
+          },
+          "title": "Component Scope",
+          "description": "Specifies the scope of the component. If scope is not specified, 'required' scope SHOULD be assumed by the consumer of the BOM.",
+          "default": "required"
+        },
+        "hashes": {
+          "type": "array",
+          "title": "Component Hashes",
+          "description": "The hashes of the component.",
+          "items": {"$ref": "cyclonedx-common-2.0.schema.json#/$defs/hash"}
+        },
+        "licenses": {
+          "$ref": "cyclonedx-license-2.0.schema.json#/$defs/licenseChoice",
+          "title": "Component License(s)"
+        },
+        "copyright": {
+          "$ref": "#/$defs/copyrightText"
+        },
+        "patentAssertions": {
+          "$ref": "cyclonedx-patent-2.0.schema.json#/$defs/patentAssertions",
+          "title": "Component Patent(s)"
+        },
+        "cpe": {
+          "type": "string",
+          "title": "Common Platform Enumeration (CPE)",
+          "description": "Asserts the identity of the component using CPE. The CPE must conform to the CPE 2.2 or 2.3 specification. See [https://nvd.nist.gov/products/cpe](https://nvd.nist.gov/products/cpe). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
+          "examples": ["cpe:2.3:a:acme:component_framework:-:*:*:*:*:*:*:*"]
+        },
+        "purl": {
+          "type": "string",
+          "title": "Package URL (purl)",
+          "description": "Asserts the identity of the component using package-url (purl). The purl, if specified, must be valid and conform to the specification defined at: [https://github.com/package-url/purl-spec](https://github.com/package-url/purl-spec). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
+          "examples": ["pkg:maven/com.acme/tomcat-catalina@9.0.14?packaging=jar"]
+        },
+        "omniborId": {
+          "type": "array",
+          "title": "OmniBOR Artifact Identifier (gitoid)",
+          "description": "Asserts the identity of the component using the OmniBOR Artifact ID. The OmniBOR, if specified, must be valid and conform to the specification defined at: [https://www.iana.org/assignments/uri-schemes/prov/gitoid](https://www.iana.org/assignments/uri-schemes/prov/gitoid). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
+          "items": { "type": "string" },
+          "examples": [
+            "gitoid:blob:sha1:a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+            "gitoid:blob:sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+          ]
+        },
+        "swhid": {
+          "type": "array",
+          "title": "Software Heritage Identifier",
+          "description": "Asserts the identity of the component using the Software Heritage persistent identifier (SWHID). The SWHID, if specified, must be valid and conform to the specification defined at: [https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html](https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity.",
+          "items": { "type": "string" },
+          "examples": ["swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2"]
+        },
+        "swid": {
+          "$ref": "#/$defs/swid",
+          "title": "SWID Tag",
+          "description": "Asserts the identity of the component using [ISO-IEC 19770-2 Software Identification (SWID) Tags](https://www.iso.org/standard/65666.html). Refer to `@.evidence.identity` to optionally provide evidence that substantiates the assertion of the component's identity."
+        },
+        "pedigree": {
+          "type": "object",
+          "title": "Component Pedigree",
+          "description": "Component pedigree is a way to document complex supply chain scenarios where components are created, distributed, modified, redistributed, combined with other components, etc. Pedigree supports viewing this complex chain from the beginning, the end, or anywhere in the middle. It also provides a way to document variants where the exact relation may not be known.",
+          "additionalProperties": false,
+          "properties": {
+            "ancestors": {
+              "type": "array",
+              "title": "Ancestors",
+              "description": "Describes zero or more components in which a component is derived from. This is commonly used to describe forks from existing projects where the forked version contains an ancestor node containing the original component it was forked from. For example, Component A is the original component. Component B is the component being used and documented in the BOM. However, Component B contains a pedigree node with a single ancestor documenting Component A - the original component from which Component B is derived from.",
+              "items": {"$ref": "#/$defs/component"}
+            },
+            "descendants": {
+              "type": "array",
+              "title": "Descendants",
+              "description": "Descendants are the exact opposite of ancestors. This provides a way to document all forks (and their forks) of an original or root component.",
+              "items": {"$ref": "#/$defs/component"}
+            },
+            "variants": {
+              "type": "array",
+              "title": "Variants",
+              "description": "Variants describe relations where the relationship between the components is not known. For example, if Component A contains nearly identical code to Component B. They are both related, but it is unclear if one is derived from the other, or if they share a common ancestor.",
+              "items": {"$ref": "#/$defs/component"}
+            },
+            "commits": {
+              "type": "array",
+              "title": "Commits",
+              "description": "A list of zero or more commits which provide a trail describing how the component deviates from an ancestor, descendant, or variant.",
+              "items": {"$ref": "cyclonedx-common-2.0.schema.json#/$defs/commit"}
+            },
+            "patches": {
+              "type": "array",
+              "title": "Patches",
+              "description": ">A list of zero or more patches describing how the component deviates from an ancestor, descendant, or variant. Patches may be complementary to commits or may be used in place of commits.",
+              "items": {"$ref": "cyclonedx-common-2.0.schema.json#/$defs/patch"}
+            },
+            "notes": {
+              "type": "string",
+              "title": "Notes",
+              "description": "Notes, observations, and other non-structured commentary describing the components pedigree."
+            }
+          }
+        },
+        "components": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/component"},
+          "uniqueItems": true,
+          "title": "Components",
+          "description": "A list of software and hardware components included in the parent component. This is not a dependency tree. It provides a way to specify a hierarchical representation of component assemblies, similar to system &#8594; subsystem &#8594; parts assembly in physical supply chains."
+        },
+        "evidence": {
+          "$ref": "#/$defs/componentEvidence",
+          "title": "Evidence",
+          "description": "Provides the ability to document evidence collected through various forms of extraction or analysis."
+        },
+        "releaseNotes": {
+          "$ref": "cyclonedx-release-notes-2.0.schema.json#/$defs/releaseNotes",
+          "title": "Release notes",
+          "description": "Specifies release notes."
+        },
+        "modelCard": {
+          "$ref": "cyclonedx-ai-modelcard-2.0.schema.json#/$defs/modelCard",
+          "title": "AI/ML Model Card"
+        },
+        "data": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/componentData"},
+          "title": "Data",
+          "description": "This object SHOULD be specified for any component of type `data` and must not be specified for other component types."
+        },
+        "cryptoProperties": {
+          "$ref": "cyclonedx-cryptography-2.0.schema.json#/$defs/cryptoProperties",
+          "title": "Cryptographic Properties"
+        },
+        "tags": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/tags",
+          "title": "Tags"
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        },
+        "externalReferences": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReferences"
+        },
+        "signature": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      },
+      "allOf": [
+        {
+          "description": "Requirement: ensure that `version` and `versionRange` are not present simultaneously.",
+          "not": {
+            "required": ["version", "versionRange"]
+          }
+        },
+        {
+          "description": "Requirement: 'versionRange' must not be present when 'isExternal' is `false`.",
+          "if": {
+            "properties": { "isExternal": { "const": false } }
+          },
+          "then": {
+            "not": { "required": ["versionRange"] }
+          },
+          "else": true
+        }
+      ]
+    },
+    "version": {
+      "description": "A single disjunctive version identifier, for a component or service.",
+      "type": "string",
+      "maxLength": 1024,
+      "examples": [
+        "9.0.14",
+        "v1.33.7",
+        "7.0.0-M1",
+        "2.0pre1",
+        "1.0.0-beta1",
+        "0.8.15"
+      ]
+    },
+    "versionRange": {
+      "description": "A version range specified in Package-URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096,
+      "examples": [
+        "vers:cargo/9.0.14",
+        "vers:npm/1.2.3|>=2.0.0|<5.0.0",
+        "vers:pypi/0.0.0|0.0.1|0.0.2|0.0.3|1.0|2.0pre1",
+        "vers:tomee/>=1.0.0-beta1|<=1.7.5|>=7.0.0-M1|<=7.0.7|>=7.1.0|<=7.1.2|>=8.0.0-M1|<=8.0.1",
+        "vers:gem/>=2.2.0|!= 2.2.1|<2.3.0"
+      ]
+    },
+    "copyrightText": {
+      "type": "string",
+      "title": "Component Copyright",
+      "description": "A copyright notice informing users of the underlying claims to copyright ownership in a published work.",
+      "examples": ["Acme Inc"]
+    },
+    "copyright": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/copyrightObject"},
+      "title": "Copyright",
+      "description": "Captures intellectual property assertions, providing evidence of possible ownership and legal protection."
+    },
+    "copyrightObject": {
+      "type": "object",
+      "title": "Copyright",
+      "description": "A copyright notice informing users of the underlying claims to copyright ownership in a published work.",
+      "required": [
+        "text"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "text": {
+          "type": "string",
+          "title": "Copyright Text",
+          "description": "The textual content of the copyright."
+        }
+      }
+    },
+    "swid": {
+      "type": "object",
+      "title": "SWID Tag",
+      "description": "Specifies metadata and content for ISO-IEC 19770-2 Software Identification (SWID) Tags.",
+      "required": [
+        "tagId",
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "tagId": {
+          "type": "string",
+          "title": "Tag ID",
+          "description": "Maps to the tagId of a SoftwareIdentity."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Maps to the name of a SoftwareIdentity."
+        },
+        "version": {
+          "type": "string",
+          "title": "Version",
+          "default": "0.0",
+          "description": "Maps to the version of a SoftwareIdentity."
+        },
+        "tagVersion": {
+          "type": "integer",
+          "title": "Tag Version",
+          "default": 0,
+          "description": "Maps to the tagVersion of a SoftwareIdentity."
+        },
+        "patch": {
+          "type": "boolean",
+          "title": "Patch",
+          "default": false,
+          "description": "Maps to the patch of a SoftwareIdentity."
+        },
+        "text": {
+          "title": "Attachment text",
+          "description": "Specifies the metadata and content of the SWID tag.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/attachment"
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "The URL to the SWID file.",
+          "format": "iri-reference"
+        }
+      }
+    },
+    "componentEvidence": {
+      "type": "object",
+      "title": "Evidence",
+      "description": "Provides the ability to document evidence collected through various forms of extraction or analysis.",
+      "additionalProperties": false,
+      "properties": {
+        "identity": {
+          "type": "array",
+          "title": "Identity Evidence",
+          "description": "Evidence that substantiates the identity of a component. The identity may be an object or an array of identity objects. Support for specifying identity as a single object was introduced in CycloneDX v1.5. Arrays were introduced in v1.6. It is recommended that all implementations use arrays, even if only one identity object is specified.",
+          "items": { "$ref": "#/$defs/componentIdentityEvidence" }
+        },
+        "occurrences": {
+          "type": "array",
+          "title": "Occurrences",
+          "description": "Evidence of individual instances of a component spread across multiple locations.",
+          "items": {
+            "type": "object",
+            "required": [ "location" ],
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+                "title": "BOM Reference",
+                "description": "An identifier which can be used to reference the occurrence elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+              },
+              "location": {
+                "type": "string",
+                "title": "Location",
+                "description": "The location or path to where the component was found."
+              },
+              "line": {
+                "type": "integer",
+                "minimum": 0,
+                "title": "Line Number",
+                "description": "The line number where the component was found."
+              },
+              "offset": {
+                "type": "integer",
+                "minimum": 0,
+                "title": "Offset",
+                "description": "The offset where the component was found."
+              },
+              "symbol": {
+                "type": "string",
+                "title": "Symbol",
+                "description": "The symbol name that was found associated with the component."
+              },
+              "additionalContext": {
+                "type": "string",
+                "title": "Additional Context",
+                "description": "Any additional context of the detected component (e.g. a code snippet)."
+              },
+              "accountInfo": {
+                "type": "string",
+                "title": "Account Information",
+                "description": "The account or user information associated with the occurrence."
+              },
+              "systemOwner": {
+                "type": "string",
+                "title": "System Owner",
+                "description": "The owner of the system where the component was found."
+              },
+              "startTime": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Start Time",
+                "description": "The date and time when the process detecting the occurrence started."
+              },
+              "endTime": {
+                "type": "string",
+                "format": "date-time",
+                "title": "End Time",
+                "description": "The date and time when the process detecting the occurrence ended."
+              },
+              "usageCount": {
+                "type": "integer",
+                "minimum": 0,
+                "title": "Usage Count",
+                "description": "The number of times the component occurred in the detecting process."
+              }
+            }
+          }
+        },
+        "callstack": {
+          "type": "object",
+          "title": "Call Stack",
+          "description": "Evidence of the components use through the callstack.",
+          "additionalProperties": false,
+          "properties": {
+            "frames": {
+              "type": "array",
+              "title": "Frames",
+              "description": "Within a call stack, a frame is a discrete unit that encapsulates an execution context, including local variables, parameters, and the return address. As function calls are made, frames are pushed onto the stack, forming an array-like structure that orchestrates the flow of program execution and manages the sequence of function invocations.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "module"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "package": {
+                    "title": "Package",
+                    "description": "A package organizes modules into namespaces, providing a unique namespace for each type it contains.",
+                    "type": "string"
+                  },
+                  "module": {
+                    "title": "Module",
+                    "description": "A module or class that encloses functions/methods and other code.",
+                    "type": "string"
+                  },
+                  "function": {
+                    "title": "Function",
+                    "description": "A block of code designed to perform a particular task.",
+                    "type": "string"
+                  },
+                  "parameters": {
+                    "title": "Parameters",
+                    "description": "Arguments that are passed to the module or function.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "line": {
+                    "title": "Line",
+                    "description": "The line number the code that is called resides on.",
+                    "type": "integer"
+                  },
+                  "column": {
+                    "title": "Column",
+                    "description": "The column the code that is called resides.",
+                    "type": "integer"
+                  },
+                  "fullFilename": {
+                    "title": "Full Filename",
+                    "description": "The full path and filename of the module.",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "licenses": {
+          "$ref": "cyclonedx-license-2.0.schema.json#/$defs/licenseChoice",
+          "title": "License Evidence"
+        },
+        "copyright": {
+          "$ref": "#/$defs/copyright"
+        }
+      }
+    },
+    "componentIdentityEvidence": {
+      "type": "object",
+      "title": "Identity Evidence",
+      "description": "Evidence that substantiates the identity of a component.",
+      "required": [ "field" ],
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "type": "string",
+          "enum": [
+            "group", "name", "version", "purl", "cpe", "omniborId", "swhid", "swid", "hash"
+          ],
+          "title": "Field",
+          "description": "The identity field of the component which the evidence describes."
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "title": "Confidence",
+          "description": "The overall confidence of the evidence from 0 - 1, where 1 is 100% confidence."
+        },
+        "concludedValue": {
+          "type": "string",
+          "title": "Concluded Value",
+          "description": "The value of the field (cpe, purl, etc) that has been concluded based on the aggregate of all methods (if available)."
+        },
+        "methods": {
+          "type": "array",
+          "title": "Methods",
+          "description": "The methods used to extract and/or analyze the evidence.",
+          "items": {
+            "type": "object",
+            "required": [
+              "technique" ,
+              "confidence"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "technique": {
+                "title": "Technique",
+                "description": "The technique used in this method of analysis.",
+                "type": "string",
+                "enum": [
+                  "source-code-analysis",
+                  "binary-analysis",
+                  "manifest-analysis",
+                  "ast-fingerprint",
+                  "hash-comparison",
+                  "instrumentation",
+                  "dynamic-analysis",
+                  "filename",
+                  "attestation",
+                  "other"
+                ]
+              },
+              "confidence": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "title": "Confidence",
+                "description": "The confidence of the evidence from 0 - 1, where 1 is 100% confidence. Confidence is specific to the technique used. Each technique of analysis can have independent confidence."
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "The value or contents of the evidence."
+              }
+            }
+          }
+        },
+        "tools": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "anyOf": [
+              {
+                "title": "Ref",
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "BOM References",
+          "description": "The object in the BOM identified by its bom-ref. This is often a component or service but may be any object type supporting bom-refs. Tools used for analysis should already be defined in the BOM, either in the metadata/tools, components, or formulation."
+        }
+      }
+    },
+    "componentData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the dataset elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "type": {
+          "type": "string",
+          "title": "Type of Data",
+          "description": "The general theme or subject matter of the data being specified.",
+          "enum": [
+            "source-code",
+            "configuration",
+            "dataset",
+            "definition",
+            "other"
+          ],
+          "meta:enum": {
+            "source-code": "Any type of code, code snippet, or data-as-code.",
+            "configuration": "Parameters or settings that may be used by other components.",
+            "dataset": "A collection of data.",
+            "definition": "Data that can be used to create new instances of what the definition defines.",
+            "other": "Any other type of data that does not fit into existing definitions."
+          }
+        },
+        "name": {
+          "title": "Dataset Name",
+          "description": "The name of the dataset.",
+          "type": "string"
+        },
+        "contents": {
+          "type": "object",
+          "title": "Data Contents",
+          "description": "The contents or references to the contents of the data being described.",
+          "additionalProperties": false,
+          "properties": {
+            "attachment": {
+              "title": "Data Attachment",
+              "description": "A way to include textual or encoded data.",
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/attachment"
+            },
+            "url": {
+              "type": "string",
+              "title": "Data URL",
+              "description": "The URL to where the data can be retrieved.",
+              "format": "iri-reference"
+            },
+            "properties": {
+              "type": "array",
+              "title": "Configuration Properties",
+              "description": "Provides the ability to document name-value parameters used for configuration.",
+              "items": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/property"
+              }
+            }
+          }
+        },
+        "classification": {
+          "$ref": "cyclonedx-data-2.0.schema.json#/$defs/dataClassification"
+        },
+        "sensitiveData": {
+          "type": "array",
+          "title": "Sensitive Data",
+          "description": "A description of any sensitive data in a dataset.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "graphics": { "$ref": "cyclonedx-ai-modelcard-2.0.schema.json#/$defs/graphicsCollection" },
+        "description": {
+          "title": "Dataset Description",
+          "description": "A description of the dataset. Can describe size of dataset, whether it's used for source code, training, testing, or validation, etc.",
+          "type": "string"
+        },
+        "governance": {
+          "title": "Data Governance",
+          "$ref": "cyclonedx-data-2.0.schema.json#/$defs/dataGovernance"
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-composition-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-composition-2.0.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-composition-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Composition Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "compositions": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/composition"},
+      "uniqueItems": true,
+      "title": "Compositions",
+      "description": "Compositions describe constituent parts (including components, services, and dependency relationships) and their completeness. The completeness of vulnerabilities expressed in a BOM may also be described."
+    },
+    "composition": {
+      "type": "object",
+      "title": "Compositions",
+      "required": [
+        "aggregate"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the composition elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "aggregate": {
+          "$ref": "#/$defs/aggregateType",
+          "title": "Aggregate",
+          "description": "Specifies an aggregate type that describes how complete a relationship is."
+        },
+        "assemblies": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "anyOf": [
+              {
+                "title": "Ref",
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "BOM references",
+          "description": "The bom-ref identifiers of the components or services being described. Assemblies refer to nested relationships whereby a constituent part may include other constituent parts. References do not cascade to child parts. References are explicit for the specified constituent part only."
+        },
+        "dependencies": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "title": "BOM references",
+          "description": "The bom-ref identifiers of the components or services being described. Dependencies refer to a relationship whereby an independent constituent part requires another independent constituent part. References do not cascade to transitive dependencies. References are explicit for the specified dependency only."
+        },
+        "vulnerabilities": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "title": "BOM references",
+          "description": "The bom-ref identifiers of the vulnerabilities being described."
+        },
+        "signature": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
+    },
+    "aggregateType": {
+      "type": "string",
+      "default": "not_specified",
+      "enum": [
+        "complete",
+        "incomplete",
+        "incomplete_first_party_only",
+        "incomplete_first_party_proprietary_only",
+        "incomplete_first_party_opensource_only",
+        "incomplete_third_party_only",
+        "incomplete_third_party_proprietary_only",
+        "incomplete_third_party_opensource_only",
+        "unknown",
+        "not_specified"
+      ],
+      "meta:enum": {
+        "complete": "The relationship is complete. No further relationships including constituent components, services, or dependencies are known to exist.",
+        "incomplete": "The relationship is incomplete. Additional relationships exist and may include constituent components, services, or dependencies.",
+        "incomplete_first_party_only": "The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented.",
+        "incomplete_first_party_proprietary_only": "The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.",
+        "incomplete_first_party_opensource_only": "The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are opensource.",
+        "incomplete_third_party_only": "The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented.",
+        "incomplete_third_party_proprietary_only": "The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.",
+        "incomplete_third_party_opensource_only": "The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are opensource.",
+        "unknown": "The relationship may be complete or incomplete. This usually signifies a 'best-effort' to obtain constituent components, services, or dependencies but the completeness is inconclusive.",
+        "not_specified": "The relationship completeness is not specified."
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-cryptography-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-cryptography-2.0.schema.json
@@ -1,0 +1,1151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-cryptography-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Cryptography Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "cryptoProperties": {
+      "type": "object",
+      "title": "Cryptographic Properties",
+      "description": "Cryptographic assets have properties that uniquely define them and that make them actionable for further reasoning. As an example, it makes a difference if one knows the algorithm family (e.g. AES) or the specific variant or instantiation (e.g. AES-128-GCM). This is because the security level and the algorithm primitive (authenticated encryption) are only defined by the definition of the algorithm variant. The presence of a weak cryptographic algorithm like SHA1 vs. HMAC-SHA1 also makes a difference.",
+      "additionalProperties": false,
+      "required": [
+        "assetType"
+      ],
+      "properties": {
+        "assetType": {
+          "type": "string",
+          "title": "Asset Type",
+          "description": "Cryptographic assets occur in several forms. Algorithms and protocols are most commonly implemented in specialized cryptographic libraries. They may, however, also be 'hardcoded' in software components. Certificates and related cryptographic material like keys, tokens, secrets or passwords are other cryptographic assets to be modelled.",
+          "enum": [
+            "algorithm",
+            "certificate",
+            "protocol",
+            "related-crypto-material"
+          ],
+          "meta:enum": {
+            "algorithm": "Mathematical function commonly used for data encryption, authentication, and digital signatures.",
+            "certificate": "An electronic document that is used to provide the identity or validate a public key.",
+            "protocol": "A set of rules and guidelines that govern the behavior and communication with each other.",
+            "related-crypto-material": "Other cryptographic assets related to algorithms, certificates, and protocols such as keys and tokens."
+          }
+        },
+        "algorithmProperties": {
+          "type": "object",
+          "title": "Algorithm Properties",
+          "description": "Additional properties specific to a cryptographic algorithm.",
+          "additionalProperties": false,
+          "properties": {
+            "primitive": {
+              "type": "string",
+              "title": "primitive",
+              "description": "Cryptographic building blocks used in higher-level cryptographic systems and protocols. Primitives represent different cryptographic routines: deterministic random bit generators (drbg, e.g. CTR_DRBG from NIST SP800-90A-r1), message authentication codes (mac, e.g. HMAC-SHA-256), blockciphers (e.g. AES), streamciphers (e.g. Salsa20), signatures (e.g. ECDSA), hash functions (e.g. SHA-256), public-key encryption schemes (pke, e.g. RSA), extended output functions (xof, e.g. SHAKE256), key derivation functions (e.g. pbkdf2), key agreement algorithms (e.g. ECDH), key encapsulation mechanisms (e.g. ML-KEM), authenticated encryption (ae, e.g. AES-GCM) and the combination of multiple algorithms (combiner, e.g. SP800-56Cr2).",
+              "enum": [
+                "drbg",
+                "mac",
+                "block-cipher",
+                "stream-cipher",
+                "signature",
+                "hash",
+                "pke",
+                "xof",
+                "kdf",
+                "key-agree",
+                "kem",
+                "ae",
+                "combiner",
+                "key-wrap",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "drbg": "Deterministic Random Bit Generator (DRBG) is a type of pseudorandom number generator designed to produce a sequence of bits from an initial seed value. DRBGs are commonly used in cryptographic applications where reproducibility of random values is important.",
+                "mac": "In cryptography, a Message Authentication Code (MAC) is information used for authenticating and integrity-checking a message.",
+                "block-cipher": "A block cipher is a symmetric key algorithm that operates on fixed-size blocks of data. It encrypts or decrypts the data in block units, providing confidentiality. Block ciphers are widely used in various cryptographic modes and protocols for secure data transmission.",
+                "stream-cipher": "A stream cipher is a symmetric key cipher where plaintext digits are combined with a pseudorandom cipher digit stream (keystream).",
+                "signature": "In cryptography, a signature is a digital representation of a message or data that proves its origin, identity, and integrity. Digital signatures are generated using cryptographic algorithms and are widely used for authentication and verification in secure communication.",
+                "hash": "A hash function is a mathematical algorithm that takes an input (or 'message') and produces a fixed-size string of characters, which is typically a hash value. Hash functions are commonly used in various cryptographic applications, including data integrity verification and password hashing.",
+                "pke": "Public Key Encryption (PKE) is a type of encryption that uses a pair of public and private keys for secure communication. The public key is used for encryption, while the private key is used for decryption. PKE is a fundamental component of public-key cryptography.",
+                "xof": "An XOF is an extendable output function that can take arbitrary input and creates a stream of output, up to a limit determined by the size of the internal state of the hash function that underlies the XOF.",
+                "kdf": "A Key Derivation Function (KDF) derives key material from another source of entropy while preserving the entropy of the input.",
+                "key-agree": "In cryptography, a key-agreement is a protocol whereby two or more parties agree on a cryptographic key in such a way that both influence the outcome.",
+                "kem": "A Key Encapsulation Mechanism (KEM) algorithm is a mechanism for transporting random keying material to a recipient using the recipient's public key.",
+                "ae": "Authenticated Encryption (AE) is a cryptographic process that provides both confidentiality and data integrity. It ensures that the encrypted data has not been tampered with and comes from a legitimate source. AE is commonly used in secure communication protocols.",
+                "combiner": "A combiner aggregates many candidates for a cryptographic primitive and generates a new candidate for the same primitive.",
+                "key-wrap": "Key-wrap is a cryptographic technique used to securely encrypt and protect cryptographic keys using algorithms like AES.",
+                "other": "Another primitive type.",
+                "unknown": "The primitive is not known."
+              }
+            },
+            "algorithmFamily": {
+              "$ref": "../cryptography-defs.schema.json#/definitions/algorithmFamiliesEnum",
+              "title": "Algorithm Family",
+              "description": "A valid algorithm family identifier. If specified, this value shall be one of the enumeration of valid algorithm Family identifiers defined in the `cryptography-defs.schema.json` subschema.",
+              "examples": [
+                "3DES",
+                "Blowfish",
+                "ECDH"
+              ]
+            },
+            "parameterSetIdentifier": {
+              "type": "string",
+              "title": "Parameter Set Identifier",
+              "description": "An identifier for the parameter set of the cryptographic algorithm. Examples: in AES128, '128' identifies the key length in bits, in SHA256, '256' identifies the digest length, '128' in SHAKE128 identifies its maximum security level in bits, and 'SHA2-128s' identifies a parameter set used in SLH-DSA (FIPS205)."
+            },
+            "ellipticCurve": {
+              "$ref": "../cryptography-defs.schema.json#/definitions/ellipticCurvesEnum",
+              "title": "Elliptic Curve",
+              "description": "The specific underlying Elliptic Curve (EC) definition employed which is an indicator of the level of security strength, performance and complexity. If specified, this value shall be one of the enumeration of valid elliptic curves identifiers defined in the `cryptography-defs.schema.json` subschema."
+            },
+            "executionEnvironment": {
+              "type": "string",
+              "title": "Execution Environment",
+              "description": "The target and execution environment in which the algorithm is implemented in.",
+              "enum": [
+                "software-plain-ram",
+                "software-encrypted-ram",
+                "software-tee",
+                "hardware",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "software-plain-ram": "A software implementation running in plain unencrypted RAM.",
+                "software-encrypted-ram": "A software implementation running in encrypted RAM.",
+                "software-tee": "A software implementation running in a trusted execution environment.",
+                "hardware": "A hardware implementation.",
+                "other": "Another implementation environment.",
+                "unknown": "The execution environment is not known."
+              }
+            },
+            "implementationPlatform": {
+              "type": "array",
+              "title": "Implementation platforms",
+              "description": "The target platforms for which the algorithm is implemented. The implementation can be 'generic', running on any platform or for a specific platform.",
+              "items": {
+                "type": "string",
+                "title": "Platform",
+                "description": "The target platform for the implementation.",
+                "enum": [
+                  "generic",
+                  "x86_32",
+                  "x86_64",
+                  "armv7-a",
+                  "armv7-m",
+                  "armv8-a",
+                  "armv8-m",
+                  "armv9-a",
+                  "armv9-m",
+                  "s390x",
+                  "ppc64",
+                  "ppc64le",
+                  "riscv32",
+                  "riscv64",
+                  "other",
+                  "unknown"
+                ],
+                "meta:enum": {
+                  "generic": "Platform-independent implementation.",
+                  "x86_32": "Intel/AMD 32-bit x86 architecture.",
+                  "x86_64": "Intel/AMD 64-bit x86-64 architecture.",
+                  "armv7-a": "ARM 32-bit application profile (Cortex-A).",
+                  "armv7-m": "ARM 32-bit microcontroller profile (Cortex-M).",
+                  "armv8-a": "ARM 64-bit application profile (AArch64).",
+                  "armv8-m": "ARM 32-bit microcontroller with TrustZone.",
+                  "armv9-a": "ARM 64-bit with enhanced security features.",
+                  "armv9-m": "ARM microcontroller with advanced security.",
+                  "s390x": "IBM Z series mainframe 64-bit.",
+                  "ppc64": "IBM PowerPC 64-bit big-endian.",
+                  "ppc64le": "IBM PowerPC 64-bit little-endian.",
+                  "riscv32": "RISC-V 32-bit open standard architecture.",
+                  "riscv64": "RISC-V 64-bit open standard architecture.",
+                  "other": "Another platform.",
+                  "unknown": "The platform is not known."
+                }
+              }
+            },
+            "certificationLevel": {
+              "type": "array",
+              "title": "Certification Level",
+              "description": "The certification that the implementation of the cryptographic algorithm has received, if any. Certifications include revisions and levels of FIPS 140 or Common Criteria of different Extended Assurance Levels (CC-EAL).",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "fips140-1-l1",
+                  "fips140-1-l2",
+                  "fips140-1-l3",
+                  "fips140-1-l4",
+                  "fips140-2-l1",
+                  "fips140-2-l2",
+                  "fips140-2-l3",
+                  "fips140-2-l4",
+                  "fips140-3-l1",
+                  "fips140-3-l2",
+                  "fips140-3-l3",
+                  "fips140-3-l4",
+                  "cc-eal1",
+                  "cc-eal1+",
+                  "cc-eal2",
+                  "cc-eal2+",
+                  "cc-eal3",
+                  "cc-eal3+",
+                  "cc-eal4",
+                  "cc-eal4+",
+                  "cc-eal5",
+                  "cc-eal5+",
+                  "cc-eal6",
+                  "cc-eal6+",
+                  "cc-eal7",
+                  "cc-eal7+",
+                  "cavp",
+                  "other",
+                  "unknown"
+                ],
+                "meta:enum": {
+                  "none": "No certification obtained",
+                  "fips140-1-l1": "FIPS 140-1 Level 1",
+                  "fips140-1-l2": "FIPS 140-1 Level 2",
+                  "fips140-1-l3": "FIPS 140-1 Level 3",
+                  "fips140-1-l4": "FIPS 140-1 Level 4",
+                  "fips140-2-l1": "FIPS 140-2 Level 1",
+                  "fips140-2-l2": "FIPS 140-2 Level 2",
+                  "fips140-2-l3": "FIPS 140-2 Level 3",
+                  "fips140-2-l4": "FIPS 140-2 Level 4",
+                  "fips140-3-l1": "FIPS 140-3 Level 1",
+                  "fips140-3-l2": "FIPS 140-3 Level 2",
+                  "fips140-3-l3": "FIPS 140-3 Level 3",
+                  "fips140-3-l4": "FIPS 140-3 Level 4",
+                  "cc-eal1": "Common Criteria - Evaluation Assurance Level 1",
+                  "cc-eal1+": "Common Criteria - Evaluation Assurance Level 1 (Augmented)",
+                  "cc-eal2": "Common Criteria - Evaluation Assurance Level 2",
+                  "cc-eal2+": "Common Criteria - Evaluation Assurance Level 2 (Augmented)",
+                  "cc-eal3": "Common Criteria - Evaluation Assurance Level 3",
+                  "cc-eal3+": "Common Criteria - Evaluation Assurance Level 3 (Augmented)",
+                  "cc-eal4": "Common Criteria - Evaluation Assurance Level 4",
+                  "cc-eal4+": "Common Criteria - Evaluation Assurance Level 4 (Augmented)",
+                  "cc-eal5": "Common Criteria - Evaluation Assurance Level 5",
+                  "cc-eal5+": "Common Criteria - Evaluation Assurance Level 5 (Augmented)",
+                  "cc-eal6": "Common Criteria - Evaluation Assurance Level 6",
+                  "cc-eal6+": "Common Criteria - Evaluation Assurance Level 6 (Augmented)",
+                  "cc-eal7": "Common Criteria - Evaluation Assurance Level 7",
+                  "cc-eal7+": "Common Criteria - Evaluation Assurance Level 7 (Augmented)",
+                  "cavp": "Cryptographic Algorithm Validation Program",
+                  "other": "Another certification",
+                  "unknown": "The certification level is not known"
+                }
+              }
+            },
+            "mode": {
+              "type": "string",
+              "title": "Mode",
+              "description": "The mode of operation in which the cryptographic algorithm (block cipher) is used.",
+              "enum": [
+                "cbc",
+                "ecb",
+                "ccm",
+                "gcm",
+                "cfb",
+                "ofb",
+                "ctr",
+                "siv",
+                "gcm-siv",
+                "ocb",
+                "eax",
+                "kw",
+                "kwp",
+                "cts",
+                "xts",
+                "gmac",
+                "cmac",
+                "xpn",
+                "ff1",
+                "ff3-1",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "cbc": "Cipher Block Chaining mode.",
+                "ecb": "Electronic Codebook mode.",
+                "ccm": "Counter with CBC-MAC (AEAD).",
+                "gcm": "Galois/Counter Mode (AEAD).",
+                "cfb": "Cipher Feedback mode.",
+                "ofb": "Output Feedback mode.",
+                "ctr": "Counter mode.",
+                "siv": "Synthetic Initialization Vector mode.",
+                "gcm-siv": "GCM with Synthetic IV (nonce-misuse resistant).",
+                "ocb": "Offset Codebook Mode (AEAD).",
+                "eax": "Encrypt-then-Authenticate-then-Translate mode.",
+                "kw": "AES Key Wrap (RFC 3394).",
+                "kwp": "AES Key Wrap with Padding (RFC 5649).",
+                "cts": "Ciphertext Stealing mode.",
+                "xts": "XEX Tweaked-codebook with Stealing (disk encryption).",
+                "gmac": "Galois Message Authentication Code",
+                "cmac": "Cipher-based Message Authentication Code",
+                "xpn": "Extended Packet Numbering mode.",
+                "ff1": "Format-preserving encryption mode 1.",
+                "ff3-1": "Format-preserving encryption mode 3, update 1.",
+                "other": "Another mode of operation.",
+                "unknown": "The mode is not known."
+              }
+            },
+            "padding": {
+              "type": "string",
+              "title": "Padding",
+              "description": "The padding scheme that is used for the cryptographic algorithm.",
+              "enum": [
+                "pkcs5",
+                "pkcs7",
+                "pkcs1v15",
+                "oaep",
+                "raw",
+                "pss",
+                "x931",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "pkcs5": "PKCS#5 padding for password-based cryptography.",
+                "pkcs7": "PKCS#7 padding with length-indicating bytes.",
+                "pkcs1v15": "PKCS#1 v1.5 padding for RSA.",
+                "oaep": "Optimal Asymmetric Encryption Padding for RSA.",
+                "raw": "No padding applied.",
+                "pss": "Probabilistic Signature Scheme for RSA signatures.",
+                "x931": "ANSI X9.31 padding for RSA.",
+                "other": "Another padding scheme.",
+                "unknown": "The padding scheme is not known."
+              }
+            },
+            "cryptoFunctions": {
+              "type": "array",
+              "title": "Cryptographic functions",
+              "description": "The cryptographic functions implemented by the cryptographic algorithm.",
+              "items": {
+                "$ref": "#/$defs/cryptographicFunction"
+              }
+            },
+            "classicalSecurityLevel": {
+              "type": "integer",
+              "title": "classical security level",
+              "description": "The classical security level that a cryptographic algorithm provides (in bits).",
+              "minimum": 0
+            },
+            "nistQuantumSecurityLevel": {
+              "type": "integer",
+              "title": "NIST security strength category",
+              "description": "The NIST security strength category as defined in https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/evaluation-criteria/security-(evaluation-criteria). A value of 0 indicates that none of the categories are met.",
+              "minimum": 0,
+              "maximum": 6
+            },
+            "secProperties": {
+              "type": "array",
+              "title": "Security Properties",
+              "description": "Formal guarantees about an algorithm's resistance to specific adversarial capabilities under a defined threat model. Example: Key Encapsulation Mechanisms (KEMs) may target IND-CPA or IND-CCA security; choosing IND-CCA impacts safe use in settings with active/chosen-ciphertext attacks.",
+              "items": {
+                "type": "string",
+                "title": "Security Property",
+                "examples": [
+                  "IND-CPA",
+                  "IND-CCA",
+                  "IND-CCA2",
+                  "SUF-CMA",
+                  "EUF-CMA",
+                  "collision-resistant",
+                  "preimage-resistant",
+                  "second-preimage-resistant"
+                ]
+              }
+            }
+          }
+        },
+        "certificateProperties": {
+          "type": "object",
+          "title": "Certificate Properties",
+          "description": "Properties for cryptographic assets of asset type 'certificate'.",
+          "additionalProperties": false,
+          "properties": {
+            "serialNumber": {
+              "type": "string",
+              "title": "Serial Number",
+              "description": "The serial number is a unique identifier for the certificate issued by a CA."
+            },
+            "subjectName": {
+              "type": "string",
+              "title": "Subject Name",
+              "description": "The subject name for the certificate."
+            },
+            "issuerName": {
+              "type": "string",
+              "title": "Issuer Name",
+              "description": "The issuer name for the certificate."
+            },
+            "notValidBefore": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Not Valid Before",
+              "description": "The date and time according to ISO-8601 standard from which the certificate is valid."
+            },
+            "notValidAfter": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Not Valid After",
+              "description": "The date and time according to ISO-8601 standard from which the certificate is not valid anymore."
+            },
+            "certificateFormat": {
+              "type": "string",
+              "title": "Certificate Format",
+              "description": "The format of the certificate.",
+              "examples": [
+                "X.509",
+                "PEM",
+                "DER",
+                "CVC"
+              ]
+            },
+            "certificateFileExtension": {
+              "type": "string",
+              "title": "Certificate File Extension",
+              "description": "The file extension of the certificate.",
+              "examples": [
+                "crt",
+                "pem",
+                "cer",
+                "der",
+                "p12"
+              ]
+            },
+            "fingerprint": {
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/hash",
+              "title": "Certificate Fingerprint",
+              "description": "The fingerprint is a cryptographic hash of the certificate excluding it's signature."
+            },
+            "certificateState": {
+              "type": "array",
+              "title": "Certificate Lifecycle State",
+              "description": "The certificate lifecycle is a comprehensive process that manages digital certificates from their initial creation to eventual expiration or revocation. It typically involves several stages.",
+              "items": {
+                "type": "object",
+                "title": "State",
+                "description": "The state of the certificate.",
+                "oneOf": [
+                  {
+                    "title": "Pre-Defined State",
+                    "required": [
+                      "state"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "state": {
+                        "type": "string",
+                        "title": "State",
+                        "description": "A pre-defined state in the certificate lifecycle.",
+                        "enum": [
+                          "pre-activation",
+                          "active",
+                          "suspended",
+                          "deactivated",
+                          "revoked",
+                          "destroyed"
+                        ],
+                        "meta:enum": {
+                          "pre-activation": "The certificate has been issued by the issuing certificate authority (CA) but has not been authorized for use.",
+                          "active": "The certificate may be used to cryptographically protect information, cryptographically process previously protected information, or both.",
+                          "deactivated": "Certificates in the deactivated state shall not be used to apply cryptographic protection but, in some cases, may be used to process cryptographically protected information.",
+                          "suspended": "The use of a certificate may be suspended for several possible reasons.",
+                          "revoked": "A revoked certificate is a digital certificate that has been invalidated by the issuing certificate authority (CA) before its scheduled expiration date.",
+                          "destroyed": "The certificate has been destroyed."
+                        }
+                      },
+                      "reason": {
+                        "type": "string",
+                        "title": "Reason",
+                        "description": "A reason for the certificate being in this state."
+                      }
+                    }
+                  },
+                  {
+                    "title": "Custom State",
+                    "required": [
+                      "name"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "title": "State",
+                        "description": "The name of the certificate lifecycle state."
+                      },
+                      "description": {
+                        "type": "string",
+                        "title": "Description",
+                        "description": "The description of the certificate lifecycle state."
+                      },
+                      "reason": {
+                        "type": "string",
+                        "title": "Reason",
+                        "description": "A reason for the certificate being in this state."
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "creationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Creation Date",
+              "description": "The date and time (timestamp) when the certificate was created or pre-activated."
+            },
+            "activationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Activation Date",
+              "description": "The date and time (timestamp) when the certificate was activated."
+            },
+            "deactivationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Deactivation Date",
+              "description": "The date and time (timestamp) when the related certificate was deactivated."
+            },
+            "revocationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Revocation Date",
+              "description": "The date and time (timestamp) when the certificate was revoked."
+            },
+            "destructionDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Destruction Date",
+              "description": "The date and time (timestamp) when the certificate was destroyed."
+            },
+            "certificateExtensions": {
+              "type": "array",
+              "title": "Certificate Extensions",
+              "description": "A certificate extension is a field that provides additional information about the certificate or its use. Extensions are used to convey additional information beyond the standard fields.",
+              "items": {
+                "type": "object",
+                "title": "Extension",
+                "description": "",
+                "oneOf": [
+                  {
+                    "title": "Common Extensions",
+                    "required": [
+                      "commonExtensionName",
+                      "commonExtensionValue"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "commonExtensionName": {
+                        "type": "string",
+                        "title": "name",
+                        "description": "The name of the extension.",
+                        "enum": [
+                          "basicConstraints",
+                          "keyUsage",
+                          "extendedKeyUsage",
+                          "subjectAlternativeName",
+                          "authorityKeyIdentifier",
+                          "subjectKeyIdentifier",
+                          "authorityInformationAccess",
+                          "certificatePolicies",
+                          "crlDistributionPoints",
+                          "signedCertificateTimestamp"
+                        ],
+                        "meta:enum": {
+                          "basicConstraints": "Specifies whether a certificate can be used as a CA certificate or not.",
+                          "keyUsage": "Specifies the allowed uses of the public key in the certificate.",
+                          "extendedKeyUsage": "Specifies additional purposes for which the public key can be used.",
+                          "subjectAlternativeName": "Allows inclusion of additional names to identify the entity associated with the certificate.",
+                          "authorityKeyIdentifier": "Identifies the public key of the CA that issued the certificate.",
+                          "subjectKeyIdentifier": "Identifies the public key associated with the entity the certificate was issued to.",
+                          "authorityInformationAccess": "Contains CA issuers and OCSP information.",
+                          "certificatePolicies": "Defines the policies under which the certificate was issued and can be used.",
+                          "crlDistributionPoints": "Contains one or more URLs where a Certificate Revocation List (CRL) can be obtained.",
+                          "signedCertificateTimestamp": "Shows that the certificate has been publicly logged, which helps prevent the issuance of rogue certificates by a CA. Log ID, timestamp and signature as proof."
+                        }
+                      },
+                      "commonExtensionValue": {
+                        "type": "string",
+                        "title": "Value",
+                        "description": "The value of the certificate extension."
+                      }
+                    }
+                  },
+                  {
+                    "title": "Custom Extensions",
+                    "description": "Custom extensions may convey application-specific or vendor-specific data not covered by standard extensions. The structure and semantics of custom extensions are typically defined outside of public standards. CycloneDX leverages properties to support this capability.",
+                    "required": [
+                      "customExtensionName"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "customExtensionName": {
+                        "type": "string",
+                        "title": "Name",
+                        "description": "The name for the custom certificate extension."
+                      },
+                      "customExtensionValue": {
+                        "type": "string",
+                        "title": "Value",
+                        "description": "The description of the custom certificate extension."
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "relatedCryptographicAssets": {
+              "$ref": "#/$defs/relatedCryptographicAssets"
+            }
+          }
+        },
+        "relatedCryptoMaterialProperties": {
+          "type": "object",
+          "title": "Related Cryptographic Material Properties",
+          "description": "Properties for cryptographic assets of asset type: `related-crypto-material`.",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "title": "relatedCryptoMaterialType",
+              "description": "The type for the related cryptographic material.",
+              "enum": [
+                "private-key",
+                "public-key",
+                "secret-key",
+                "key",
+                "ciphertext",
+                "signature",
+                "digest",
+                "initialization-vector",
+                "nonce",
+                "seed",
+                "salt",
+                "shared-secret",
+                "tag",
+                "additional-data",
+                "password",
+                "credential",
+                "token",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "private-key": "The confidential key of a key pair used in asymmetric cryptography.",
+                "public-key": "The non-confidential key of a key pair used in asymmetric cryptography.",
+                "secret-key": "A key used to encrypt and decrypt messages in symmetric cryptography.",
+                "key": "A piece of information, usually an octet string, which, when processed through a cryptographic algorithm, processes cryptographic data.",
+                "ciphertext": "The result of encryption performed on plaintext using an algorithm (or cipher).",
+                "signature": "A cryptographic value that is calculated from the data and a key known only by the signer.",
+                "digest": "The output of the hash function.",
+                "initialization-vector": "A fixed-size random or pseudo-random value used as an input parameter for cryptographic algorithms.",
+                "nonce": "A random or pseudo-random number that can only be used once in a cryptographic communication.",
+                "seed": "The input to a pseudo-random number generator. Different seeds generate different pseudo-random sequences.",
+                "salt": "A value used in a cryptographic process, usually to ensure that the results of computations for one instance cannot be reused by an attacker.",
+                "shared-secret": "A piece of data known only to the parties involved, in a secure communication.",
+                "tag": "A message authentication code (MAC), sometimes known as an authentication tag, is a short piece of information used for authenticating and integrity-checking a message.",
+                "additional-data": "An unspecified collection of data with relevance to cryptographic activity.",
+                "password": "A secret word, phrase, or sequence of characters used during authentication or authorization.",
+                "credential": "Establishes the identity of a party to communication, usually in the form of cryptographic keys or passwords.",
+                "token": "An object encapsulating a security identity.",
+                "other": "Another type of cryptographic asset.",
+                "unknown": "The type of cryptographic asset is not known."
+              }
+            },
+            "id": {
+              "type": "string",
+              "title": "ID",
+              "description": "The unique identifier for the related cryptographic material."
+            },
+            "state": {
+              "type": "string",
+              "title": "State",
+              "description": "The key state as defined by NIST SP 800-57.",
+              "enum": [
+                "pre-activation",
+                "active",
+                "suspended",
+                "deactivated",
+                "compromised",
+                "destroyed"
+              ]
+            },
+            "creationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Creation Date",
+              "description": "The date and time (timestamp) when the related cryptographic material was created."
+            },
+            "activationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Activation Date",
+              "description": "The date and time (timestamp) when the related cryptographic material was activated."
+            },
+            "updateDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Update Date",
+              "description": "The date and time (timestamp) when the related cryptographic material was updated."
+            },
+            "expirationDate": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Expiration Date",
+              "description": "The date and time (timestamp) when the related cryptographic material expires."
+            },
+            "value": {
+              "type": "string",
+              "title": "Value",
+              "description": "The associated value of the cryptographic material."
+            },
+            "size": {
+              "type": "integer",
+              "title": "Size",
+              "description": "The size of the cryptographic asset (in bits)."
+            },
+            "format": {
+              "type": "string",
+              "title": "Format",
+              "description": "The format of the related cryptographic material (e.g. P8, PEM, DER)."
+            },
+            "securedBy": {
+              "$ref": "#/$defs/securedBy",
+              "title": "Secured By",
+              "description": "The mechanism by which the cryptographic asset is secured by."
+            },
+            "fingerprint": {
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/hash",
+              "title": "Fingerprint",
+              "description": "The fingerprint is a cryptographic hash of the asset."
+            },
+            "relatedCryptographicAssets": {
+              "$ref": "#/$defs/relatedCryptographicAssets"
+            },
+            "keyUsage": {
+              "type": "array",
+              "title": "Key Usage",
+              "description": "Defines the permitted cryptographic usage for the asset.",
+              "items": {
+                "$ref": "#/$defs/cryptographicFunction",
+                "title": "Usage",
+                "description": "A permitted cryptographic usage."
+              }
+            }
+          }
+        },
+        "protocolProperties": {
+          "type": "object",
+          "title": "Protocol Properties",
+          "description": "Properties specific to cryptographic assets of type: `protocol`.",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "description": "The concrete protocol type.",
+              "enum": [
+                "tls",
+                "ssh",
+                "ipsec",
+                "ike",
+                "sstp",
+                "wpa",
+                "dtls",
+                "quic",
+                "eap-aka",
+                "eap-aka-prime",
+                "prins",
+                "5g-aka",
+                "other",
+                "unknown"
+              ],
+              "meta:enum": {
+                "tls": "Transport Layer Security",
+                "ssh": "Secure Shell",
+                "ipsec": "Internet Protocol Security",
+                "ike": "Internet Key Exchange",
+                "sstp": "Secure Socket Tunneling Protocol",
+                "wpa": "Wi-Fi Protected Access",
+                "dtls": "Datagram Transport Layer Security",
+                "quic": "Quick UDP Internet Connections",
+                "eap-aka": "Extensible Authentication Protocol variant",
+                "eap-aka-prime": "Enhanced version of EAP-AKA",
+                "prins": "Protection of Inter-Network Signaling",
+                "5g-aka": "Authentication and Key Agreement for 5G",
+                "other": "Another protocol type",
+                "unknown": "The protocol type is not known"
+              }
+            },
+            "version": {
+              "type": "string",
+              "title": "Protocol Version",
+              "description": "The version of the protocol.",
+              "examples": [
+                "1.0",
+                "1.2",
+                "1.99"
+              ]
+            },
+            "cipherSuites": {
+              "type": "array",
+              "title": "Cipher Suites",
+              "description": "A list of cipher suites related to the protocol.",
+              "items": {
+                "$ref": "#/$defs/cipherSuite",
+                "title": "Cipher Suite"
+              }
+            },
+            "ikev2TransformTypes": {
+              "type": "object",
+              "title": "IKEv2 Transform Types",
+              "description": "The IKEv2 transform types supported (types 1-4), defined in [RFC 7296 section 3.3.2](https://www.ietf.org/rfc/rfc7296.html#section-3.3.2), and additional properties.",
+              "additionalProperties": false,
+              "properties": {
+                "encr": {
+                  "type": "array",
+                  "title": "Encryption Algorithms (ENCR)",
+                  "description": "Transform Type 1: encryption algorithms.",
+                  "items": {
+                    "$ref": "#/$defs/ikeV2Enc",
+                    "title": "Encryption Algorithm (ENCR)"
+                  }
+                },
+                "prf": {
+                  "type": "array",
+                  "title": "Pseudorandom Functions (PRF)",
+                  "description": "Transform Type 2: pseudorandom functions.",
+                  "items": {
+                    "$ref": "#/$defs/ikeV2Prf",
+                    "title": "Pseudorandom Function (PRF)"
+                  }
+                },
+                "integ": {
+                  "type": "array",
+                  "title": "Integrity Algorithms (INTEG)",
+                  "description": "Transform Type 3: integrity algorithms.",
+                  "items": {
+                    "$ref": "#/$defs/ikeV2Integ",
+                    "title": "Integrity Algorithm (INTEG)"
+                  }
+                },
+                "ke": {
+                  "type": "array",
+                  "title": "Key Exchange Methods (KE)",
+                  "description": "Transform Type 4: Key Exchange Method (KE) per [RFC 9370](https://www.ietf.org/rfc/rfc9370.html), formerly called Diffie-Hellman Group (D-H).",
+                  "items": {
+                    "$ref": "#/$defs/ikeV2Ke"
+                  }
+                },
+                "esn": {
+                  "type": "boolean",
+                  "title": "Extended Sequence Number (ESN)",
+                  "description": "Specifies if an Extended Sequence Number (ESN) is used."
+                },
+                "auth": {
+                  "type": "array",
+                  "title": "IKEv2 Authentication methods",
+                  "description": "IKEv2 Authentication method per [RFC9593](https://www.ietf.org/rfc/rfc9593.html).",
+                  "items": {
+                    "$ref": "#/$defs/ikeV2Auth",
+                    "title": "IKEv2 Authentication Method"
+                  }
+                }
+              }
+            },
+            "relatedCryptographicAssets": {
+              "$ref": "#/$defs/relatedCryptographicAssets"
+            }
+          }
+        },
+        "oid": {
+          "type": "string",
+          "title": "OID",
+          "description": "The object identifier (OID) of the cryptographic asset."
+        }
+      }
+    },
+    "cipherSuite": {
+      "type": "object",
+      "title": "Cipher Suite",
+      "description": "Object representing a cipher suite.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Common Name",
+          "description": "A common name for the cipher suite.",
+          "examples": [
+            "TLS_DHE_RSA_WITH_AES_128_CCM"
+          ]
+        },
+        "algorithms": {
+          "type": "array",
+          "title": "Related Algorithms",
+          "description": "A list of algorithms related to the cipher suite.",
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+            "title": "Algorithm reference",
+            "description": "The bom-ref to algorithm cryptographic asset."
+          }
+        },
+        "identifiers": {
+          "type": "array",
+          "title": "Cipher Suite Identifiers",
+          "description": "A list of common identifiers for the cipher suite.",
+          "items": {
+            "type": "string",
+            "title": "identifier",
+            "description": "Cipher suite identifier.",
+            "examples": [
+              "0xC0",
+              "0x9E"
+            ]
+          }
+        },
+        "tlsGroups": {
+          "type": "array",
+          "title": "TLS Groups",
+          "description": "A list of TLS named groups (formerly known as curves) for this cipher suite. These groups define the parameters for key exchange algorithms like ECDHE.",
+          "items": {
+            "type": "string",
+            "title": "Group Name",
+            "description": "The name of the TLS group.",
+            "examples": [
+              "x25519",
+              "ffdhe2048"
+            ]
+          }
+        },
+        "tlsSignatureSchemes": {
+          "type": "array",
+          "title": "TLS Signature Schemes",
+          "description": "A list of signature schemes supported for cipher suite. These schemes specify the algorithms used for digital signatures in TLS handshakes and certificate verification.",
+          "items": {
+            "type": "string",
+            "title": "Signature Scheme",
+            "description": "The name of the TLS signature scheme.",
+            "examples": [
+              "ecdsa_secp256r1_sha256",
+              "rsa_pss_rsae_sha256",
+              "ed25519"
+            ]
+          }
+        }
+      }
+    },
+    "ikeV2Enc": {
+      "type": "object",
+      "title": "Encryption Algorithm (ENCR)",
+      "description": "Object representing an encryption algorithm (ENCR).",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "A name for the encryption method.",
+          "examples": [
+            "ENCR_AES_GCM_16"
+          ]
+        },
+        "keyLength": {
+          "type": "integer",
+          "title": "Encryption algorithm key length",
+          "description": "The key length of the encryption algorithm."
+        },
+        "algorithm": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "Algorithm reference",
+          "description": "The bom-ref to algorithm cryptographic asset."
+        }
+      }
+    },
+    "ikeV2Prf": {
+      "type": "object",
+      "title": "Pseudorandom Function (PRF)",
+      "description": "Object representing a pseudorandom function (PRF).",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "A name for the pseudorandom function.",
+          "examples": [
+            "PRF_HMAC_SHA2_256"
+          ]
+        },
+        "algorithm": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "Algorithm reference",
+          "description": "The bom-ref to algorithm cryptographic asset."
+        }
+      }
+    },
+    "ikeV2Integ": {
+      "type": "object",
+      "title": "Integrity Algorithm (INTEG)",
+      "description": "Object representing an integrity algorithm (INTEG).",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "A name for the integrity algorithm.",
+          "examples": [
+            "AUTH_HMAC_SHA2_256_128"
+          ]
+        },
+        "algorithm": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "Algorithm reference",
+          "description": "The bom-ref to algorithm cryptographic asset."
+        }
+      }
+    },
+    "ikeV2Ke": {
+      "type": "object",
+      "title": "Key Exchange Method (KE)",
+      "description": "Object representing a key exchange method (KE).",
+      "additionalProperties": false,
+      "properties": {
+        "group": {
+          "type": "integer",
+          "title": "Group Identifier",
+          "description": "A group identifier for the key exchange algorithm."
+        },
+        "algorithm": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "Algorithm reference",
+          "description": "The bom-ref to algorithm cryptographic asset."
+        }
+      }
+    },
+    "ikeV2Auth": {
+      "type": "object",
+      "title": "IKEv2 Authentication method",
+      "description": "Object representing a IKEv2 Authentication method.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "A name for the authentication method."
+        },
+        "algorithm": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "Algorithm reference",
+          "description": "The bom-ref to algorithm cryptographic asset."
+        }
+      }
+    },
+    "cryptographicFunction": {
+      "type": "string",
+      "title": "Cryptographic Function",
+      "description": "A cryptographic function or usage.",
+      "enum": [
+        "generate",
+        "paramgen",
+        "paramver",
+        "keygen",
+        "keyver",
+        "encrypt",
+        "decrypt",
+        "digest",
+        "tag",
+        "keyderive",
+        "sign",
+        "verify",
+        "encapsulate",
+        "decapsulate",
+        "keyagree",
+        "wrap",
+        "unwrap",
+        "other",
+        "unknown"
+      ],
+      "meta:enum": {
+        "generate": "Generates random data, IVs, or nonces.",
+        "paramgen": "Generates cryptographic domain parameters.",
+        "paramver": "Verifies cryptographic domain parameters.",
+        "keygen": "Generates cryptographic keys.",
+        "keyver": "Verifies cryptographic keys.",
+        "encrypt": "Transforms plaintext into ciphertext.",
+        "decrypt": "Transforms ciphertext into plaintext.",
+        "digest": "Computes a hash value from input data.",
+        "tag": "Generates an authentication tag for data integrity.",
+        "keyderive": "Derives keys from another key or shared secret.",
+        "sign": "Creates a digital signature using a private key.",
+        "verify": "Verifies a digital signature using a public key.",
+        "encapsulate": "Encapsulates a secret using a public key (KEM).",
+        "decapsulate": "Decapsulates a secret using a private key (KEM).",
+        "keyagree": "Derives a shared secret between parties.",
+        "wrap": "Encrypts a key for secure storage or transport.",
+        "unwrap": "Decrypts a wrapped key to recover the original key.",
+        "other": "Another cryptographic function.",
+        "unknown": "The cryptographic function is not known."
+      }
+    },
+    "relatedCryptographicAssets": {
+      "type": "array",
+      "title": "Related Cryptographic Assets",
+      "description": "A list of cryptographic assets related to this component.",
+      "items": {
+        "$ref": "#/$defs/relatedCryptographicAsset"
+      }
+    },
+    "relatedCryptographicAsset": {
+      "type": "object",
+      "title": "Related Cryptographic Asset",
+      "description": "A cryptographic assets related to this component.",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "description": "Specifies the mechanism by which the cryptographic asset is secured by.",
+          "examples": [
+            "publicKey",
+            "privateKey",
+            "algorithm"
+          ]
+        },
+        "ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "Reference to cryptographic asset",
+          "description": "The bom-ref to cryptographic asset."
+        }
+      }
+    },
+    "securedBy": {
+      "type": "object",
+      "title": "Secured By",
+      "description": "Specifies the mechanism by which the cryptographic asset is secured by.",
+      "additionalProperties": false,
+      "properties": {
+        "mechanism": {
+          "type": "string",
+          "title": "Mechanism",
+          "description": "Specifies the mechanism by which the cryptographic asset is secured by.",
+          "examples": [
+            "HSM",
+            "TPM",
+            "SGX",
+            "Software",
+            "None"
+          ]
+        },
+        "algorithmRef": {
+          "type": "array",
+          "title": "References",
+          "description": "The bom-refs to the assets securing this asset (e.g., algorithms, hardware, keys).",
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-data-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-data-2.0.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-data-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Data Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "dataClassification": {
+      "type": "string",
+      "title": "Data Classification",
+      "description": "Data classification tags data according to its type, sensitivity, and value if altered, stolen, or destroyed."
+    },
+    "dataGovernance": {
+      "type": "object",
+      "title": "Data Governance",
+      "description": "Data governance captures information regarding data ownership, stewardship, and custodianship, providing insights into the individuals or entities responsible for managing, overseeing, and safeguarding the data throughout its lifecycle.",
+      "additionalProperties": false,
+      "properties": {
+        "custodians": {
+          "type": "array",
+          "title": "Data Custodians",
+          "description": "Data custodians are responsible for the safe custody, transport, and storage of data.",
+          "items": { "$ref": "#/$defs/dataGovernanceResponsibleParty" }
+        },
+        "stewards": {
+          "type": "array",
+          "title": "Data Stewards",
+          "description": "Data stewards are responsible for data content, context, and associated business rules.",
+          "items": { "$ref": "#/$defs/dataGovernanceResponsibleParty" }
+        },
+        "owners": {
+          "type": "array",
+          "title": "Data Owners",
+          "description": "Data owners are concerned with risk and appropriate access to data.",
+          "items": { "$ref": "#/$defs/dataGovernanceResponsibleParty" }
+        }
+      }
+    },
+    "dataGovernanceResponsibleParty": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "organization": {
+          "title": "Organization",
+          "description": "The organization that is responsible for specific data governance role(s).",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity"
+        },
+        "contact": {
+          "title": "Individual",
+          "description": "The individual that is responsible for specific data governance role(s).",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalContact"
+        }
+      },
+      "oneOf":[
+        {
+          "required": ["organization"]
+        },
+        {
+          "required": ["contact"]
+        }
+      ]
+    },
+    "dataFlowDirection": {
+      "type": "string",
+      "enum": [
+        "inbound",
+        "outbound",
+        "bi-directional",
+        "unknown"
+      ],
+      "meta:enum": {
+        "inbound": "Data that enters a service.",
+        "outbound": "Data that exits a service.",
+        "bi-directional": "Data flows in and out of the service.",
+        "unknown": "The directional flow of data is not known."
+      },
+      "title": "Data flow direction",
+      "description": "Specifies the flow direction of the data. Direction is relative to the service."
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-declaration-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-declaration-2.0.schema.json
@@ -1,0 +1,403 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-declaration-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Declaration Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "declarations": {
+      "type": "object",
+      "title": "Declarations",
+      "description": "The list of declarations which describe the conformance to standards. Each declaration may include attestations, claims, and evidence.",
+      "additionalProperties": false,
+      "properties": {
+        "assessors": {
+          "type": "array",
+          "title": "Assessors",
+          "description": "The list of assessors evaluating claims and determining conformance to requirements and confidence in that assessment.",
+          "items": {
+            "type": "object",
+            "title": "Assessor",
+            "description": "The assessor who evaluates claims and determines conformance to requirements and confidence in that assessment.",
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+                "title": "BOM Reference",
+                "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+              },
+              "thirdParty": {
+                "type": "boolean",
+                "title": "Third Party",
+                "description": "The boolean indicating if the assessor is outside the organization generating claims. A value of false indicates a self assessor."
+              },
+              "organization": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity",
+                "title": "Organization",
+                "description": "The entity issuing the assessment."
+              }
+            }
+          }
+        },
+        "attestations": {
+          "type": "array",
+          "title": "Attestations",
+          "description": "The list of attestations asserted by an assessor that maps requirements to claims.",
+          "items": {
+            "type": "object",
+            "title": "Attestation",
+            "additionalProperties": false,
+            "properties": {
+              "summary":  {
+                "type": "string",
+                "title": "Summary",
+                "description": "The short description explaining the main points of the attestation."
+              },
+              "assessor": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+                "title": "Assessor",
+                "description": "The `bom-ref` to the assessor asserting the attestation."
+              },
+              "map": {
+                "type": "array",
+                "title": "Map",
+                "description": "The grouping of requirements to claims and the attestors declared conformance and confidence thereof.",
+                "items": {
+                  "type": "object",
+                  "title": "Map",
+                  "additionalProperties": false,
+                  "properties": {
+                    "requirement": {
+                      "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+                      "title": "Requirement",
+                      "description": "The `bom-ref` to the requirement being attested to."
+                    },
+                    "claims": {
+                      "type": "array",
+                      "title": "Claims",
+                      "description": "The list of `bom-ref` to the claims being attested to.",
+                      "items": { "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType" }
+                    },
+                    "counterClaims": {
+                      "type": "array",
+                      "title": "Counter Claims",
+                      "description": "The list of  `bom-ref` to the counter claims being attested to.",
+                      "items": { "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType" }
+                    },
+                    "conformance": {
+                      "type": "object",
+                      "title": "Conformance",
+                      "description": "The conformance of the claim meeting a requirement.",
+                      "additionalProperties": false,
+                      "properties": {
+                        "score": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1,
+                          "title": "Score",
+                          "description": "The conformance of the claim between and inclusive of 0 and 1, where 1 is 100% conformance."
+                        },
+                        "rationale": {
+                          "type": "string",
+                          "title": "Rationale",
+                          "description": "The rationale for the conformance score."
+                        },
+                        "mitigationStrategies": {
+                          "type": "array",
+                          "title": "Mitigation Strategies",
+                          "description": "The list of  `bom-ref` to the evidence provided describing the mitigation strategies.",
+                          "items": { "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType" }
+                        }
+                      }
+                    },
+                    "confidence": {
+                      "type": "object",
+                      "title": "Confidence",
+                      "description": "The confidence of the claim meeting the requirement.",
+                      "additionalProperties": false,
+                      "properties": {
+                        "score": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1,
+                          "title": "Score",
+                          "description": "The confidence of the claim between and inclusive of 0 and 1, where 1 is 100% confidence."
+                        },
+                        "rationale": {
+                          "type": "string",
+                          "title": "Rationale",
+                          "description": "The rationale for the confidence score."
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "signature": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/signature",
+                "title": "Signature",
+                "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+              }
+            }
+          }
+        },
+        "claims": {
+          "type": "array",
+          "title": "Claims",
+          "description": "The list of claims.",
+          "items": {
+            "type": "object",
+            "title": "Claim",
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+                "title": "BOM Reference",
+                "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+              },
+              "target": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+                "title": "Target",
+                "description": "The `bom-ref` to a target representing a specific system, application, API, module, team, person, process, business unit, company, etc...  that this claim is being applied to."
+              },
+              "predicate": {
+                "type": "string",
+                "title": "Predicate",
+                "description": "The specific statement or assertion about the target."
+              },
+              "mitigationStrategies": {
+                "type": "array",
+                "title": "Mitigation Strategies",
+                "description": "The list of  `bom-ref` to the evidence provided describing the mitigation strategies. Each mitigation strategy should include an explanation of how any weaknesses in the evidence will be mitigated.",
+                "items": { "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType" }
+              },
+              "reasoning": {
+                "type": "string",
+                "title": "Reasoning",
+                "description": "The written explanation of why the evidence provided substantiates the claim."
+              },
+              "evidence": {
+                "type": "array",
+                "title": "Evidence",
+                "description": "The list of `bom-ref` to evidence that supports this claim.",
+                "items": { "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType" }
+              },
+              "counterEvidence": {
+                "type": "array",
+                "title": "Counter Evidence",
+                "description": "The list of `bom-ref` to counterEvidence that supports this claim.",
+                "items": { "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType" }
+              },
+              "externalReferences": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReferences"
+              },
+              "signature": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/signature",
+                "title": "Signature",
+                "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+              }
+            }
+          }
+        },
+        "evidence": {
+          "type": "array",
+          "title": "Evidence",
+          "description": "The list of evidence",
+          "items": {
+            "type": "object",
+            "title": "Evidence",
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+                "title": "BOM Reference",
+                "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+              },
+              "propertyName": {
+                "type": "string",
+                "title": "Property Name",
+                "description": "The reference to the property name as defined in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy/)."
+              },
+              "description": {
+                "type": "string",
+                "title": "Description",
+                "description": "The written description of what this evidence is and how it was created."
+              },
+              "data": {
+                "type": "array",
+                "title": "Data",
+                "description": "The output or analysis that supports claims.",
+                "items": {
+                  "type": "object",
+                  "title": "Data",
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "title": "Data Name",
+                      "description": "The name of the data.",
+                      "type": "string"
+                    },
+                    "contents": {
+                      "type": "object",
+                      "title": "Data Contents",
+                      "description": "The contents or references to the contents of the data being described.",
+                      "additionalProperties": false,
+                      "properties": {
+                        "attachment": {
+                          "title": "Data Attachment",
+                          "description": "A way to include textual or encoded data.",
+                          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/attachment"
+                        },
+                        "url": {
+                          "type": "string",
+                          "title": "Data URL",
+                          "description": "The URL to where the data can be retrieved.",
+                          "format": "iri-reference"
+                        }
+                      }
+                    },
+                    "classification": {
+                      "$ref": "cyclonedx-data-2.0.schema.json#/$defs/dataClassification"
+                    },
+                    "sensitiveData": {
+                      "type": "array",
+                      "title": "Sensitive Data",
+                      "description": "A description of any sensitive data included.",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "governance": {
+                      "title": "Data Governance",
+                      "$ref": "cyclonedx-data-2.0.schema.json#/$defs/dataGovernance"
+                    }
+                  }
+                }
+              },
+              "created": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Created",
+                "description": "The date and time (timestamp) when the evidence was created."
+              },
+              "expires": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Expires",
+                "description": "The date and time (timestamp) when the evidence is no longer valid."
+              },
+              "author": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalContact",
+                "title": "Author",
+                "description": "The author of the evidence."
+              },
+              "reviewer": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalContact",
+                "title": "Reviewer",
+                "description": "The reviewer of the evidence."
+              },
+              "signature": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/signature",
+                "title": "Signature",
+                "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+              }
+            }
+          }
+        },
+        "targets": {
+          "type": "object",
+          "title": "Targets",
+          "description": "The list of targets which claims are made against.",
+          "additionalProperties": false,
+          "properties": {
+            "organizations": {
+              "type": "array",
+              "title": "Organizations",
+              "description": "The list of organizations which claims are made against.",
+              "items": {"$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity"}
+            },
+            "components": {
+              "type": "array",
+              "title": "Components",
+              "description": "The list of components which claims are made against.",
+              "items": {"$ref": "cyclonedx-component-2.0.schema.json#/$defs/component"}
+            },
+            "services": {
+              "type": "array",
+              "title": "Services",
+              "description": "The list of services which claims are made against.",
+              "items": {"$ref": "cyclonedx-service-2.0.schema.json#/$defs/service"}
+            }
+          }
+        },
+        "affirmation": {
+          "type": "object",
+          "title": "Affirmation",
+          "description": "A concise statement affirmed by an individual regarding all declarations, often used for third-party auditor acceptance or recipient acknowledgment. It includes a list of authorized signatories who assert the validity of the document on behalf of the organization.",
+          "additionalProperties": false,
+          "properties": {
+            "statement": {
+              "type": "string",
+              "title": "Statement",
+              "description": "The brief statement affirmed by an individual regarding all declarations.\n*- Notes This could be an affirmation of acceptance by a third-party auditor or receiving individual of a file.",
+              "examples": [ "I certify, to the best of my knowledge, that all information is correct." ]
+            },
+            "signatories": {
+              "type": "array",
+              "title": "Signatories",
+              "description": "The list of signatories authorized on behalf of an organization to assert validity of this document.",
+              "items": {
+                "type": "object",
+                "title": "Signatory",
+                "additionalProperties": false,
+                "oneOf": [
+                  {
+                    "required": ["signature"]
+                  },
+                  {
+                    "required": ["externalReference", "organization"]
+                  }
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The signatory's name."
+                  },
+                  "role": {
+                    "type": "string",
+                    "title": "Role",
+                    "description": "The signatory's role within an organization."
+                  },
+                  "signature": {
+                    "$ref": "cyclonedx-common-2.0.schema.json#/$defs/signature",
+                    "title": "Signature",
+                    "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+                  },
+                  "organization": {
+                    "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity",
+                    "title": "Organization",
+                    "description": "The signatory's organization."
+                  },
+                  "externalReference": {
+                    "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReference"
+                  }
+                }
+              }
+            },
+            "signature": {
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/signature",
+              "title": "Signature",
+              "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+            }
+          }
+        },
+        "signature": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-definition-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-definition-2.0.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-definition-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Definition Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "definitions": {
+      "type": "object",
+      "title": "Definitions",
+      "description": "A collection of reusable objects that are defined and may be used elsewhere in the BOM.",
+      "additionalProperties": false,
+      "properties": {
+        "standards": {
+          "$ref": "cyclonedx-standard-2.0.schema.json#/$defs/standards"
+        },
+        "patents": {
+          "$ref": "cyclonedx-patent-2.0.schema.json#/$defs/patents"
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-dependency-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-dependency-2.0.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-dependency-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Dependency Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "dependencies": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/dependency"},
+      "uniqueItems": true,
+      "title": "Dependencies",
+      "description": "Provides the ability to document dependency relationships including provided & implemented components."
+    },
+    "dependency": {
+      "type": "object",
+      "title": "Dependency",
+      "description": "Defines the direct dependencies of a component, service, or the components provided/implemented by a given component. Components or services that do not have their own dependencies must be declared as empty elements within the graph. Components or services that are not represented in the dependency graph may have unknown dependencies. It is recommended that implementations assume this to be opaque and not an indicator of an object being dependency-free. It is recommended to leverage compositions to indicate unknown dependency graphs.",
+      "required": [
+        "ref"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "title": "Reference",
+          "description": "References a component or service by its bom-ref attribute"
+        },
+        "dependsOn": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "title": "Depends On",
+          "description": "The bom-ref identifiers of the components or services that are dependencies of this dependency object."
+        },
+        "provides": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          },
+          "title": "Provides",
+          "description": "The bom-ref identifiers of the components or services that define a given specification or standard, which are provided or implemented by this dependency object.\nFor example, a cryptographic library which implements a cryptographic algorithm. A component which implements another component does not imply that the implementation is in use."
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-formulation-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-formulation-2.0.schema.json
@@ -1,0 +1,927 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-formulation-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Formulation Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "formulation": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/formula"},
+      "uniqueItems": true,
+      "title": "Formulation",
+      "description": "Describes the formulation of any referencable object within the BOM, including components, services, metadata, declarations, or the BOM itself. This may encompass how the object was created, assembled, deployed, tested, certified, or otherwise brought into its present form. Common examples include software build pipelines, deployment processes, AI/ML model training, cryptographic key generation or certification, and third-party audits. Processes are modeled using declared and observed formulas, composed of workflows, tasks, and individual steps."
+    },
+    "formula": {
+      "title": "Formula",
+      "description": "Describes workflows and resources that captures rules and other aspects of how the associated BOM component or service was formed.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the formula elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "components": {
+          "title": "Components",
+          "description": "Transient components that are used in tasks that constitute one or more of this formula's workflows",
+          "type": "array",
+          "items": {
+            "$ref": "cyclonedx-component-2.0.schema.json#/$defs/component"
+          },
+          "uniqueItems": true
+        },
+        "services": {
+          "title": "Services",
+          "description": "Transient services that are used in tasks that constitute one or more of this formula's workflows",
+          "type": "array",
+          "items": {
+            "$ref": "cyclonedx-service-2.0.schema.json#/$defs/service"
+          },
+          "uniqueItems": true
+        },
+        "workflows": {
+          "title": "Workflows",
+          "description": "List of workflows that can be declared to accomplish specific orchestrated goals and independently triggered.",
+          "$comment": "Different workflows can be designed to work together to perform end-to-end CI/CD builds and deployments.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/workflow"
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "workflow": {
+      "title": "Workflow",
+      "description": "A specialized orchestration task.",
+      "$comment": "Workflow are as task themselves and can trigger other workflow tasks.  These relationships can be modeled in the taskDependencies graph.",
+      "type": "object",
+      "required": [
+        "bom-ref",
+        "uid",
+        "taskTypes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the workflow elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the resource instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the resource instance.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the resource instance.",
+          "type": "string"
+        },
+        "resourceReferences": {
+          "title": "Resource references",
+          "description": "References to component or service resources that are used to realize the resource instance.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/resourceReferenceChoice"
+          }
+        },
+        "tasks": {
+          "title": "Tasks",
+          "description": "The tasks that comprise the workflow.",
+          "$comment": "Note that tasks can appear more than once as different instances (by name or UID).",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/task"
+          }
+        },
+        "taskDependencies": {
+          "title": "Task dependency graph",
+          "description": "The graph of dependencies between tasks within the workflow.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-dependency-2.0.schema.json#/$defs/dependency"
+          }
+        },
+        "taskTypes": {
+          "title": "Task types",
+          "description": "Indicates the types of activities performed by the set of workflow tasks.",
+          "$comment": "Currently, these types reflect common CI/CD actions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/taskType"
+          }
+        },
+        "trigger": {
+          "title": "Trigger",
+          "description": "The trigger that initiated the task.",
+          "$ref": "#/$defs/trigger"
+        },
+        "steps": {
+          "title": "Steps",
+          "description": "The sequence of steps for the task.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/step"
+          },
+          "uniqueItems": true
+        },
+        "inputs": {
+          "title": "Inputs",
+          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
+          "examples": ["a `configuration` file which was declared as a local `component` or `externalReference`"],
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/inputType"
+          },
+          "uniqueItems": true
+        },
+        "outputs": {
+          "title": "Outputs",
+          "description": "Represents resources and data output from a task at runtime by executor or task commands",
+          "examples": ["a log file or metrics data produced by the task"],
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/outputType"
+          },
+          "uniqueItems": true
+        },
+        "timeStart": {
+          "title": "Time start",
+          "description": "The date and time (timestamp) when the task started.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "timeEnd": {
+          "title": "Time end",
+          "description": "The date and time (timestamp) when the task ended.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "workspaces": {
+          "title": "Workspaces",
+          "description": "A set of named filesystem or data resource shareable by workflow tasks.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/workspace"
+          }
+        },
+        "runtimeTopology": {
+          "title": "Runtime topology",
+          "description": "A graph of the component runtime topology for workflow's instance.",
+          "$comment": "A description of the runtime component and service topology.  This can describe a partial or complete topology used to host and execute the task (e.g., hardware, operating systems, configurations, etc.),",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "cyclonedx-dependency-2.0.schema.json#/$defs/dependency"
+          }
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "task": {
+      "title": "Task",
+      "description": "Describes the inputs, sequence of steps and resources used to accomplish a task and its output.",
+      "$comment": "Tasks are building blocks for constructing assemble CI/CD workflows or pipelines.",
+      "type": "object",
+      "required": [
+        "bom-ref",
+        "uid",
+        "taskTypes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the task elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the resource instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the resource instance.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the resource instance.",
+          "type": "string"
+        },
+        "resourceReferences": {
+          "title": "Resource references",
+          "description": "References to component or service resources that are used to realize the resource instance.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/resourceReferenceChoice"
+          }
+        },
+        "taskTypes": {
+          "title": "Task types",
+          "description": "Indicates the types of activities performed by the set of workflow tasks.",
+          "$comment": "Currently, these types reflect common CI/CD actions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/taskType"
+          }
+        },
+        "trigger": {
+          "title": "Trigger",
+          "description": "The trigger that initiated the task.",
+          "$ref": "#/$defs/trigger"
+        },
+        "steps": {
+          "title": "Steps",
+          "description": "The sequence of steps for the task.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/step"
+          },
+          "uniqueItems": true
+        },
+        "inputs": {
+          "title": "Inputs",
+          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
+          "examples": ["a `configuration` file which was declared as a local `component` or `externalReference`"],
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/inputType"
+          },
+          "uniqueItems": true
+        },
+        "outputs": {
+          "title": "Outputs",
+          "description": "Represents resources and data output from a task at runtime by executor or task commands",
+          "examples": ["a log file or metrics data produced by the task"],
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/outputType"
+          },
+          "uniqueItems": true
+        },
+        "timeStart": {
+          "title": "Time start",
+          "description": "The date and time (timestamp) when the task started.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "timeEnd": {
+          "title": "Time end",
+          "description": "The date and time (timestamp) when the task ended.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "workspaces": {
+          "title": "Workspaces",
+          "description": "A set of named filesystem or data resource shareable by workflow tasks.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/workspace"
+          },
+          "uniqueItems": true
+        },
+        "runtimeTopology": {
+          "title": "Runtime topology",
+          "description": "A graph of the component runtime topology for task's instance.",
+          "$comment": "A description of the runtime component and service topology.  This can describe a partial or complete topology used to host and execute the task (e.g., hardware, operating systems, configurations, etc.),",
+          "type": "array",
+          "items": {
+            "$ref": "cyclonedx-dependency-2.0.schema.json#/$defs/dependency"
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "step": {
+      "type": "object",
+      "description": "Executes specific commands or tools in order to accomplish its owning task as part of a sequence.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "A name for the step.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the step.",
+          "type": "string"
+        },
+        "commands": {
+          "title": "Commands",
+          "description": "Ordered list of commands or directives for the step",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/command"
+          }
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "executed": {
+          "title": "Executed",
+          "description": "A text representation of the executed command.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "workspace": {
+      "title": "Workspace",
+      "description": "A named filesystem or data resource shareable by workflow tasks.",
+      "type": "object",
+      "required": [
+        "bom-ref",
+        "uid"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the workspace elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the resource instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the resource instance.",
+          "type": "string"
+        },
+        "aliases": {
+          "title": "Aliases",
+          "description": "The names for the workspace as referenced by other workflow tasks. Effectively, a name mapping so other tasks can use their own local name in their steps.",
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the resource instance.",
+          "type": "string"
+        },
+        "resourceReferences": {
+          "title": "Resource references",
+          "description": "References to component or service resources that are used to realize the resource instance.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/resourceReferenceChoice"
+          }
+        },
+        "accessMode": {
+          "title": "Access mode",
+          "description": "Describes the read-write access control for the workspace relative to the owning resource instance.",
+          "type": "string",
+          "enum": [
+            "read-only",
+            "read-write",
+            "read-write-once",
+            "write-once",
+            "write-only"
+          ]
+        },
+        "mountPath": {
+          "title": "Mount path",
+          "description": "A path to a location on disk where the workspace will be available to the associated task's steps.",
+          "type": "string"
+        },
+        "managedDataType": {
+          "title": "Managed data type",
+          "description": "The name of a domain-specific data type the workspace represents.",
+          "$comment": "This property is for CI/CD frameworks that are able to provide access to structured, managed data at a more granular level than a filesystem.",
+          "examples": ["ConfigMap","Secret"],
+          "type": "string"
+        },
+        "volumeRequest": {
+          "title": "Volume request",
+          "description": "Identifies the reference to the request for a specific volume type and parameters.",
+          "examples": ["a kubernetes Persistent Volume Claim (PVC) name"],
+          "type": "string"
+        },
+        "volume": {
+          "title": "Volume",
+          "description": "Information about the actual volume instance allocated to the workspace.",
+          "$comment": "The actual volume allocated may be different than the request.",
+          "examples": ["see https://kubernetes.io/docs/concepts/storage/persistent-volumes/"],
+          "$ref": "#/$defs/volume"
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "volume": {
+      "title": "Volume",
+      "description": "An identifiable, logical unit of data storage tied to a physical device.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the volume instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the volume instance",
+          "type": "string"
+        },
+        "mode": {
+          "title": "Mode",
+          "description": "The mode for the volume instance.",
+          "type": "string",
+          "enum": [
+            "filesystem", "block"
+          ],
+          "default": "filesystem"
+        },
+        "path": {
+          "title": "Path",
+          "description": "The underlying path created from the actual volume.",
+          "type": "string"
+        },
+        "sizeAllocated": {
+          "title": "Size allocated",
+          "description": "The allocated size of the volume accessible to the associated workspace. This should include the scalar size as well as IEC standard unit in either decimal or binary form.",
+          "examples": ["10GB", "2Ti", "1Pi"],
+          "type": "string"
+        },
+        "persistent": {
+          "title": "Persistent",
+          "description": "Indicates if the volume persists beyond the life of the resource it is associated with.",
+          "type": "boolean"
+        },
+        "remote": {
+          "title": "Remote",
+          "description": "Indicates if the volume is remotely (i.e., network) attached.",
+          "type": "boolean"
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "trigger": {
+      "title": "Trigger",
+      "description": "Represents a resource that can conditionally activate (or fire) tasks based upon associated events and their data.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "bom-ref",
+        "uid"
+      ],
+      "properties": {
+        "bom-ref": {
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the trigger elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier for the resource instance within its deployment context.",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "description": "The name of the resource instance.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the resource instance.",
+          "type": "string"
+        },
+        "resourceReferences": {
+          "title": "Resource references",
+          "description": "References to component or service resources that are used to realize the resource instance.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/resourceReferenceChoice"
+          }
+        },
+        "type": {
+          "title": "Type",
+          "description": "The source type of event which caused the trigger to fire.",
+          "type": "string",
+          "enum": [
+            "manual",
+            "api",
+            "webhook",
+            "scheduled"
+          ]
+        },
+        "event": {
+          "title": "Event",
+          "description": "The event data that caused the associated trigger to activate.",
+          "$ref": "#/$defs/event"
+        },
+        "conditions": {
+          "type": "array",
+          "title": "Conditions",
+          "description": "A list of conditions used to determine if a trigger should be activated.",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/condition"
+          }
+        },
+        "timeActivated": {
+          "title": "Time activated",
+          "description": "The date and time (timestamp) when the trigger was activated.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "inputs": {
+          "title": "Inputs",
+          "description": "Represents resources and data brought into a task at runtime by executor or task commands",
+          "examples": ["a `configuration` file which was declared as a local `component` or `externalReference`"],
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/inputType"
+          },
+          "uniqueItems": true
+        },
+        "outputs": {
+          "title": "Outputs",
+          "description": "Represents resources and data output from a task at runtime by executor or task commands",
+          "examples": ["a log file or metrics data produced by the task"],
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/outputType"
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "event": {
+      "title": "Event",
+      "description": "Represents something that happened that may trigger a response.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "uid": {
+          "title": "Unique Identifier (UID)",
+          "description": "The unique identifier of the event.",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "description": "A description of the event.",
+          "type": "string"
+        },
+        "timeReceived": {
+          "title": "Time Received",
+          "description": "The date and time (timestamp) when the event was received.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "data": {
+          "title": "Data",
+          "description": "Encoding of the raw event data.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/attachment"
+        },
+        "source": {
+          "title": "Source",
+          "description": "References the component or service that was the source of the event",
+          "$ref": "#/$defs/resourceReferenceChoice"
+        },
+        "target": {
+          "title": "Target",
+          "description": "References the component or service that was the target of the event",
+          "$ref": "#/$defs/resourceReferenceChoice"
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "inputType": {
+      "title": "Input type",
+      "description": "Type that represents various input data types and formats.",
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "resource"
+          ]
+        },
+        {
+          "required": [
+            "parameters"
+          ]
+        },
+        {
+          "required": [
+            "environmentVars"
+          ]
+        },
+        {
+          "required": [
+            "data"
+          ]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "title": "Source",
+          "description": "A reference to the component or service that provided the input to the task (e.g., reference to a service with data flow value of `inbound`)",
+          "examples": [
+            "source code repository",
+            "database"
+          ],
+          "$ref": "#/$defs/resourceReferenceChoice"
+        },
+        "target": {
+          "title": "Target",
+          "description": "A reference to the component or service that received or stored the input if not the task itself (e.g., a local, named storage workspace)",
+          "examples": [
+            "workspace",
+            "directory"
+          ],
+          "$ref": "#/$defs/resourceReferenceChoice"
+        },
+        "resource": {
+          "title": "Resource",
+          "description": "A reference to an independent resource provided as an input to a task by the workflow runtime.",
+          "examples": [
+            "a reference to a configuration file in a repository (i.e., a bom-ref)",
+            "a reference to a scanning service used in a task (i.e., a bom-ref)"
+          ],
+          "$ref": "#/$defs/resourceReferenceChoice"
+        },
+        "parameters": {
+          "title": "Parameters",
+          "description": "Inputs that have the form of parameters with names and values.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/parameter"
+          }
+        },
+        "environmentVars": {
+          "title": "Environment variables",
+          "description": "Inputs that have the form of parameters with names and values.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/property"
+              },
+              {
+                "type": "string",
+                "title": "String-Based Environment Variables",
+                "description": "In addition to the more common key–value pair format, some environment variables may consist of a single string without an explicit value assignment. These string-based environment variables typically act as flags or signals to software, indicating that a feature should be enabled, a mode should be activated, or a specific condition is present. Their presence alone conveys meaning."
+              }
+            ]
+          }
+        },
+        "data": {
+          "title": "Data",
+          "description": "Inputs that have the form of data.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/attachment"
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "outputType": {
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "resource"
+          ]
+        },
+        {
+          "required": [
+            "environmentVars"
+          ]
+        },
+        {
+          "required": [
+            "data"
+          ]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Type",
+          "description": "Describes the type of data output.",
+          "type": "string",
+          "enum": [
+            "artifact",
+            "attestation",
+            "log",
+            "evidence",
+            "metrics",
+            "other"
+          ]
+        },
+        "source": {
+          "title": "Source",
+          "description": "Component or service that generated or provided the output from the task (e.g., a build tool)",
+          "$ref": "#/$defs/resourceReferenceChoice"
+        },
+        "target": {
+          "title": "Target",
+          "description": "Component or service that received the output from the task (e.g., reference to an artifactory service with data flow value of `outbound`)",
+          "examples": ["a log file described as an `externalReference` within its target domain."],
+          "$ref": "#/$defs/resourceReferenceChoice"
+        },
+        "resource": {
+          "title": "Resource",
+          "description": "A reference to an independent resource generated as output by the task.",
+          "examples": [
+            "configuration file",
+            "source code",
+            "scanning service"
+          ],
+          "$ref": "#/$defs/resourceReferenceChoice"
+        },
+        "data": {
+          "title": "Data",
+          "description": "Outputs that have the form of data.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/attachment"
+        },
+        "environmentVars": {
+          "title": "Environment variables",
+          "description": "Outputs that have the form of environment variables.",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/property"
+              },
+              {
+                "type": "string",
+                "title": "String-Based Environment Variables",
+                "description": "In addition to the more common key–value pair format, some environment variables may consist of a single string without an explicit value assignment. These string-based environment variables typically act as flags or signals to software, indicating that a feature should be enabled, a mode should be activated, or a specific condition is present. Their presence alone conveys meaning."
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "resourceReferenceChoice": {
+      "title": "Resource reference choice",
+      "description": "A reference to a locally defined resource (e.g., a bom-ref) or an externally accessible resource.",
+      "$comment": "Enables reference to a resource that participates in a workflow; using either internal (bom-ref) or external (externalReference) types.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ref": {
+          "title": "BOM Reference",
+          "description": "References an object by its bom-ref attribute",
+          "anyOf": [
+            {
+              "title": "Ref",
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+            },
+            {
+              "title": "BOM-Link Element",
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/bomLinkElementType"
+            }
+          ]
+        },
+        "externalReference": {
+          "title": "External reference",
+          "description": "Reference to an externally accessible resource.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReference"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "ref"
+          ]
+        },
+        {
+          "required": [
+            "externalReference"
+          ]
+        }
+      ]
+    },
+    "condition": {
+      "title": "Condition",
+      "description": "A condition that was used to determine a trigger should be activated.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "title": "Description",
+          "description": "Describes the set of conditions which cause the trigger to activate.",
+          "type": "string"
+        },
+        "expression": {
+          "title": "Expression",
+          "description": "The logical expression that was evaluated that determined the trigger should be fired.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "taskType": {
+      "type": "string",
+      "enum": [
+        "copy",
+        "clone",
+        "lint",
+        "scan",
+        "merge",
+        "build",
+        "test",
+        "deliver",
+        "deploy",
+        "release",
+        "clean",
+        "other"
+      ],
+      "meta:enum": {
+        "copy": "A task that copies software or data used to accomplish other tasks in the workflow.",
+        "clone": "A task that clones a software repository into the workflow in order to retrieve its source code or data for use in a build step.",
+        "lint": "A task that checks source code for programmatic and stylistic errors.",
+        "scan": "A task that performs a scan against source code, or built or deployed components and services. Scans are typically run to gather or test for security vulnerabilities or policy compliance.",
+        "merge": "A task that merges changes or fixes into source code prior to a build step in the workflow.",
+        "build": "A task that builds the source code, dependencies and/or data into an artifact that can be deployed to and executed on target systems.",
+        "test": "A task that verifies the functionality of a component or service.",
+        "deliver": "A task that delivers a built artifact to one or more target repositories or storage systems.",
+        "deploy": "A task that deploys a built artifact for execution on one or more target systems.",
+        "release": "A task that releases a built, versioned artifact to a target repository or distribution system.",
+        "clean": "A task that cleans unnecessary tools, build artifacts and/or data from workflow storage.",
+        "other": "A workflow task that does not match current task type definitions."
+      }
+    },
+    "parameter": {
+      "title": "Parameter",
+      "description": "A representation of a functional parameter.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "The name of the parameter.",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value",
+          "description": "The value of the parameter.",
+          "type": "string"
+        },
+        "dataType": {
+          "title": "Data type",
+          "description": "The data type of the parameter.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-license-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-license-2.0.schema.json
@@ -1,0 +1,329 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-license-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX License Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "licenseChoice": {
+      "title": "License Choice",
+      "description": "A list of SPDX licenses and/or named licenses and/or SPDX License Expression.",
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "License",
+            "required": [
+              "license"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "license": {
+                "$ref": "#/$defs/license"
+              }
+            }
+          },
+          {
+            "title": "License Expression",
+            "description": "Specifies the details and attributes related to a software license.\nIt must be a valid SPDX license expression, along with additional properties such as license acknowledgment.",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "expression"
+            ],
+            "properties": {
+              "expression": {
+                "type": "string",
+                "title": "SPDX License Expression",
+                "description": "A valid SPDX license expression.\nRefer to https://spdx.org/specifications for syntax requirements.",
+                "examples": [
+                  "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+                  "GPL-3.0-only WITH Classpath-exception-2.0"
+                ]
+              },
+              "expressionDetails": {
+                "title": "Expression Details",
+                "description": "Details for parts of the `expression`.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "description": "This document specifies the details and attributes related to a software license identifier. An SPDX expression may be a compound of license identifiers.\nThe `license_identifier` property serves as the key that identifies each record. Note that this key is not required to be unique, as the same license identifier could apply to multiple, different but similar license details, texts, etc.",
+                  "required": [
+                    "licenseIdentifier"
+                  ],
+                  "properties": {
+                    "licenseIdentifier": {
+                      "title": "License Identifier",
+                      "description": "The valid SPDX license identifier. Refer to https://spdx.org/specifications for syntax requirements.\nThis property serves as the primary key, which uniquely identifies each record.",
+                      "type": "string",
+                      "examples": [
+                        "Apache-2.0",
+                        "GPL-3.0-only WITH Classpath-exception-2.0",
+                        "LicenseRef-my-custom-license"
+                      ]
+                    },
+                    "bom-ref": {
+                      "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+                      "title": "BOM Reference",
+                      "description": "An identifier which can be used to reference the license elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+                    },
+                    "text": {
+                      "title": "License texts",
+                      "description": "A way to include the textual content of the license.",
+                      "$ref": "cyclonedx-common-2.0.schema.json#/$defs/attachment"
+                    },
+                    "url": {
+                      "type": "string",
+                      "title": "License URL",
+                      "description": "The URL to the license file. If specified, a 'license' externalReference should also be specified for completeness",
+                      "examples": [
+                        "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                      ],
+                      "format": "iri-reference"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "acknowledgement": {
+                "$ref": "#/$defs/licenseAcknowledgementEnumeration"
+              },
+              "bom-ref": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+                "title": "BOM Reference",
+                "description": "An identifier which can be used to reference the license elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+              },
+              "licensing": {
+                "$ref": "#/$defs/licensing"
+              },
+              "properties": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "license": {
+      "type": "object",
+      "title": "License",
+      "description": "Specifies the details and attributes related to a software license. It can either include a valid SPDX license identifier or a named license, along with additional properties such as license acknowledgment, comprehensive commercial licensing information, and the full text of the license.",
+      "oneOf": [
+        {
+          "required": ["id"]
+        },
+        {
+          "required": ["name"]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the license elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "id": {
+          "$ref": "../spdx.schema.json",
+          "title": "License ID (SPDX)",
+          "description": "A valid SPDX license identifier. If specified, this value must be one of the enumeration of valid SPDX license identifiers defined in the spdx.schema.json (or spdx.xml) subschema which is synchronized with the official SPDX license list.",
+          "examples": ["Apache-2.0"]
+        },
+        "name": {
+          "type": "string",
+          "title": "License Name",
+          "description": "The name of the license. This may include the name of a commercial or proprietary license or an open source license that may not be defined by SPDX.",
+          "examples": ["Acme Software License"]
+        },
+        "acknowledgement": {
+          "$ref": "#/$defs/licenseAcknowledgementEnumeration"
+        },
+        "text": {
+          "title": "License text",
+          "description": "A way to include the textual content of a license.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/attachment"
+        },
+        "url": {
+          "type": "string",
+          "title": "License URL",
+          "description": "The URL to the license file. If specified, a 'license' externalReference should also be specified for completeness",
+          "examples": ["https://www.apache.org/licenses/LICENSE-2.0.txt"],
+          "format": "iri-reference"
+        },
+        "licensing": {"$ref": "#/$defs/licensing"},
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "licenseAcknowledgementEnumeration": {
+      "title": "License Acknowledgement",
+      "description": "Declared licenses and concluded licenses represent two different stages in the licensing process within software development. Declared licenses refer to the initial intention of the software authors regarding the licensing terms under which their code is released. On the other hand, concluded licenses are the result of a comprehensive analysis of the project's codebase to identify and confirm the actual licenses of the components used, which may differ from the initially declared licenses. While declared licenses provide an upfront indication of the licensing intentions, concluded licenses offer a more thorough understanding of the actual licensing within a project, facilitating proper compliance and risk management. Observed licenses are defined in `@.evidence.licenses`. Observed licenses form the evidence necessary to substantiate a concluded license.",
+      "type": "string",
+      "enum": [
+        "declared",
+        "concluded"
+      ],
+      "meta:enum": {
+        "declared": "Declared licenses represent the initial intentions of authors regarding the licensing terms of their code.",
+        "concluded": "Concluded licenses are verified and confirmed."
+      }
+    },
+    "licensing": {
+      "type": "object",
+      "title": "Licensing information",
+      "description": "Licensing details describing the licensor/licensee, license type, renewal and expiration dates, and other important metadata",
+      "additionalProperties": false,
+      "properties": {
+        "altIds": {
+          "type": "array",
+          "title": "Alternate License Identifiers",
+          "description": "License identifiers that may be used to manage licenses and their lifecycle",
+          "items": {
+            "type": "string"
+          }
+        },
+        "licensor": {
+          "title": "Licensor",
+          "description": "The individual or organization that grants a license to another individual or organization",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "organization": {
+              "title": "Licensor (Organization)",
+              "description": "The organization that granted the license",
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity"
+            },
+            "individual": {
+              "title": "Licensor (Individual)",
+              "description": "The individual, not associated with an organization, that granted the license",
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalContact"
+            }
+          },
+          "oneOf":[
+            {
+              "required": ["organization"]
+            },
+            {
+              "required": ["individual"]
+            }
+          ]
+        },
+        "licensee": {
+          "title": "Licensee",
+          "description": "The individual or organization for which a license was granted to",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "organization": {
+              "title": "Licensee (Organization)",
+              "description": "The organization that was granted the license",
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity"
+            },
+            "individual": {
+              "title": "Licensee (Individual)",
+              "description": "The individual, not associated with an organization, that was granted the license",
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalContact"
+            }
+          },
+          "oneOf":[
+            {
+              "required": ["organization"]
+            },
+            {
+              "required": ["individual"]
+            }
+          ]
+        },
+        "purchaser": {
+          "title": "Purchaser",
+          "description": "The individual or organization that purchased the license",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "organization": {
+              "title": "Purchaser (Organization)",
+              "description": "The organization that purchased the license",
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity"
+            },
+            "individual": {
+              "title": "Purchaser (Individual)",
+              "description": "The individual, not associated with an organization, that purchased the license",
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalContact"
+            }
+          },
+          "oneOf":[
+            {
+              "required": ["organization"]
+            },
+            {
+              "required": ["individual"]
+            }
+          ]
+        },
+        "purchaseOrder": {
+          "type": "string",
+          "title": "Purchase Order",
+          "description": "The purchase order identifier the purchaser sent to a supplier or vendor to authorize a purchase"
+        },
+        "licenseTypes": {
+          "type": "array",
+          "title": "License Type",
+          "description": "The type of license(s) that was granted to the licensee.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "academic",
+              "appliance",
+              "client-access",
+              "concurrent-user",
+              "core-points",
+              "custom-metric",
+              "device",
+              "evaluation",
+              "named-user",
+              "node-locked",
+              "oem",
+              "perpetual",
+              "processor-points",
+              "subscription",
+              "user",
+              "other"
+            ],
+            "meta:enum": {
+              "academic": "A license that grants use of software solely for the purpose of education or research.",
+              "appliance": "A license covering use of software embedded in a specific piece of hardware.",
+              "client-access": "A Client Access License (CAL) allows client computers to access services provided by server software.",
+              "concurrent-user": "A Concurrent User license (aka floating license) limits the number of licenses for a software application and licenses are shared among a larger number of users.",
+              "core-points": "A license where the core of a computer's processor is assigned a specific number of points.",
+              "custom-metric": "A license for which consumption is measured by non-standard metrics.",
+              "device": "A license that covers a defined number of installations on computers and other types of devices.",
+              "evaluation": "A license that grants permission to install and use software for trial purposes.",
+              "named-user": "A license that grants access to the software to one or more pre-defined users.",
+              "node-locked": "A license that grants access to the software on one or more pre-defined computers or devices.",
+              "oem": "An Original Equipment Manufacturer license that is delivered with hardware, cannot be transferred to other hardware, and is valid for the life of the hardware.",
+              "perpetual": "A license where the software is sold on a one-time basis and the licensee can use a copy of the software indefinitely.",
+              "processor-points": "A license where each installation consumes points per processor.",
+              "subscription": "A license where the licensee pays a fee to use the software or service.",
+              "user": "A license that grants access to the software or service by a specified number of users.",
+              "other": "Another license type."
+            }
+          }
+        },
+        "lastRenewal": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Last Renewal",
+          "description": "The timestamp indicating when the license was last renewed. For new purchases, this is often the purchase or acquisition date. For non-perpetual licenses or subscriptions, this is the timestamp of when the license was last renewed."
+        },
+        "expiration": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Expiration",
+          "description": "The timestamp indicating when the current license expires (if applicable)."
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-metadata-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-metadata-2.0.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-metadata-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Metadata Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "metadata": {
+      "type": "object",
+      "title": "BOM Metadata",
+      "description": "Provides additional information about a BOM.",
+      "additionalProperties": false,
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The date and time (timestamp) when the BOM was created."
+        },
+        "lifecycles": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/lifecycles"
+        },
+        "tools": {
+          "type": "object",
+          "title": "Tools",
+          "description": "The tool(s) used in the creation, enrichment, and validation of the BOM.",
+          "additionalProperties": false,
+          "properties": {
+            "components": {
+              "$ref": "cyclonedx-component-2.0.schema.json#/$defs/components",
+              "description": "A list of software and hardware components used as tools."
+            },
+            "services": {
+              "$ref": "cyclonedx-service-2.0.schema.json#/$defs/services",
+              "description": "A list of services used as tools. This may include microservices, function-as-a-service, and other types of network or intra-process services."
+            }
+          }
+        },
+        "manufacturer": {
+          "title": "BOM Manufacturer",
+          "description": "The organization that created the BOM.\nManufacturer is common in BOMs created through automated processes. BOMs created through manual means may have `@.authors` instead.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity"
+        },
+        "authors": {
+          "type": "array",
+          "title": "BOM Authors",
+          "description": "The person(s) who created the BOM.\nAuthors are common in BOMs created through manual processes. BOMs created through automated means may have `@.manufacturer` instead.",
+          "items": {"$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalContact"}
+        },
+        "component": {
+          "description": "The component that the BOM describes.",
+          "$ref": "cyclonedx-component-2.0.schema.json#/$defs/component"
+        },
+        "supplier": {
+          "title": "Supplier",
+          "description": " The organization that supplied the component that the BOM describes. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity"
+        },
+        "licenses": {
+          "title": "BOM License(s)",
+          "description": "The license information for the BOM document.\nThis may be different from the license(s) of the component(s) that the BOM describes.",
+          "$ref": "cyclonedx-license-2.0.schema.json#/$defs/licenseChoice"
+        },
+        "distributionConstraints": {
+          "$ref": "#/$defs/distributionConstraints"
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "distributionConstraints": {
+      "title": "Distribution Constraints",
+      "description": "Conditions and constraints governing the sharing and distribution of the data or components described by this BOM.",
+      "type": "object",
+      "properties": {
+        "tlp": {
+          "$ref": "#/$defs/tlpClassification",
+          "description": "The Traffic Light Protocol (TLP) classification that controls the sharing and distribution of the data that the BOM describes."
+        }
+      }
+    },
+    "tlpClassification": {
+      "title": "Traffic Light Protocol (TLP) Classification",
+      "description": "Traffic Light Protocol (TLP) is a classification system for identifying the potential risk associated with artefact, including whether it is subject to certain types of legal, financial, or technical threats. Refer to [https://www.first.org/tlp/](https://www.first.org/tlp/) for further information.\nThe default classification is \"CLEAR\"",
+      "type" : "string",
+      "default": "CLEAR",
+      "enum": [
+        "CLEAR",
+        "GREEN",
+        "AMBER",
+        "AMBER_AND_STRICT",
+        "RED"
+      ],
+      "meta:enum": {
+        "CLEAR": "The information is not subject to any restrictions as regards the sharing.",
+        "GREEN": "The information is subject to limited disclosure, and recipients can share it within their community but not via publicly accessible channels.",
+        "AMBER": "The information is subject to limited disclosure, and recipients can only share it on a need-to-know basis within their organization and with clients.",
+        "AMBER_AND_STRICT": "The information is subject to limited disclosure, and recipients can only share it on a need-to-know basis within their organization.",
+        "RED": "The information is subject to restricted distribution to individual recipients only and must not be shared."
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-patent-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-patent-2.0.schema.json
@@ -1,0 +1,286 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-patent-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Patent Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "patents": {
+      "type": "array",
+      "title": "Patents",
+      "description": "The list of either individual patents or patent families.",
+      "items": {
+        "anyOf": [
+          { "$ref": "#/$defs/patent" },
+          { "$ref": "#/$defs/patentFamily" }
+        ]
+      }
+    },
+    "patent": {
+      "type": "object",
+      "title": "Patent",
+      "description": "A patent is a legal instrument, granted by an authority, that confers certain rights over an invention for a specified period, contingent on public disclosure and adherence to relevant legal requirements. The summary information in this object is aligned with [WIPO ST.96](https://www.wipo.int/standards/en/st96/) principles where applicable.",
+      "required": ["patentNumber", "jurisdiction", "patentLegalStatus"],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+        },
+        "patentNumber": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9\\-/.()\\s]{0,28}[A-Za-z0-9]$",
+          "title": "Patent Number",
+          "description": "The unique number assigned to the granted patent by the issuing authority. Aligned with `PatentNumber` in WIPO ST.96. Refer to [PatentNumber in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/PatentNumber.xsd).",
+          "examples": ["US987654321", "EP1234567B1"]
+        },
+        "applicationNumber": {
+          "$ref": "#/$defs/patentApplicationNumber"
+        },
+        "jurisdiction": {
+          "$ref": "#/$defs/patentJurisdiction"
+        },
+        "priorityApplication": {
+          "$ref": "#/$defs/priorityApplication"
+        },
+        "publicationNumber": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9\\-/.()\\s]{0,28}[A-Za-z0-9]$",
+          "title": "Patent Publication Number",
+          "description": "This is the number assigned to a patent application once it is published. Patent applications are generally published 18 months after filing (unless an applicant requests non-publication). This number is distinct from the application number. \n\nPurpose: Identifies the publicly available version of the application. \n\nFormat: Varies by jurisdiction, often similar to application numbers but includes an additional suffix indicating publication. \n\nExample:\n - US: US20240000123A1 (indicates the first publication of application US20240000123) \n - Europe: EP23123456A1 (first publication of European application EP23123456). \n\nWIPO ST.96 v8.0: \n - Publication Number field: https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/PublicationNumber.xsd"
+        },
+        "title": {
+          "type": "string",
+          "title": "Patent Title",
+          "description": "The title of the patent, summarising the invention it protects. Aligned with `InventionTitle` in WIPO ST.96. Refer to [InventionTitle in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/InventionTitle.xsd)."
+        },
+        "abstract": {
+          "type": "string",
+          "title": "Patent Abstract",
+          "description": "A brief summary of the invention described in the patent. Aligned with `Abstract` and `P` in WIPO ST.96. Refer to [Abstract in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/Abstract.xsd)."
+        },
+        "filingDate": {
+          "type": "string",
+          "format": "date",
+          "title": "Filing Date",
+          "description": "The date the patent application was filed with the jurisdiction. Aligned with `FilingDate` in WIPO ST.96. Refer to [FilingDate in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/FilingDate.xsd)."
+        },
+        "grantDate": {
+          "type": "string",
+          "format": "date",
+          "title": "Grant Date",
+          "description": "The date the patent was granted by the jurisdiction. Aligned with `GrantDate` in WIPO ST.96. Refer to [GrantDate in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/GrantDate.xsd)."
+        },
+        "patentExpirationDate": {
+          "type": "string",
+          "format": "date",
+          "title": "Expiration Date",
+          "description": "The date the patent expires. Derived from grant or filing date according to jurisdiction-specific rules."
+        },
+        "patentLegalStatus": {
+          "type": "string",
+          "title": "Legal Status",
+          "description": "Indicates the current legal status of the patent or patent application, based on the WIPO ST.27 standard. This status reflects administrative, procedural, or legal events. Values include both active and inactive states and are useful for determining enforceability, procedural history, and maintenance status.",
+          "enum": [
+            "pending",
+            "granted",
+            "revoked",
+            "expired",
+            "lapsed",
+            "withdrawn",
+            "abandoned",
+            "suspended",
+            "reinstated",
+            "opposed",
+            "terminated",
+            "invalidated",
+            "in-force"
+          ],
+          "meta:enum": {
+            "pending": "The patent application has been filed but not yet examined or granted.",
+            "granted": "The patent application has been examined and a patent has been issued.",
+            "revoked": "The patent has been declared invalid through a legal or administrative process.",
+            "expired": "The patent has reached the end of its enforceable term.",
+            "lapsed": "The patent is no longer in force due to non-payment of maintenance fees or other requirements.",
+            "withdrawn": "The patent application was voluntarily withdrawn by the applicant.",
+            "abandoned": "The patent application was abandoned, often due to lack of action or response.",
+            "suspended": "Processing of the patent application has been temporarily halted.",
+            "reinstated": "A previously abandoned or lapsed patent has been reinstated.",
+            "opposed": "The patent application or granted patent is under formal opposition proceedings.",
+            "terminated": "The patent or application has been officially terminated.",
+            "invalidated": "The patent has been invalidated, either in part or in full.",
+            "in-force": "The granted patent is active and enforceable."
+          }
+        },
+        "patentAssignee": {
+          "type": "array",
+          "title": "Patent Assignees",
+          "description": "A collection of organisations or individuals to whom the patent rights are assigned. This supports joint ownership and allows for flexible representation of both corporate entities and individual inventors.",
+          "items": {
+            "oneOf": [
+              {
+                "title": "Person",
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalContact"
+              },
+              {
+                "title": "Organizational Entity",
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity"
+              }
+            ]
+          }
+        },
+        "externalReferences": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReferences"
+        }
+      }
+    },
+    "patentFamily": {
+      "type": "object",
+      "title": "Patent Family",
+      "description": "A patent family is a group of related patent applications or granted patents that cover the same or similar invention. These patents are filed in multiple jurisdictions to protect the invention across different regions or countries. A patent family typically includes patents that share a common priority date, originating from the same initial application, and may vary slightly in scope or claims to comply with regional legal frameworks. Fields align with WIPO ST.96 standards where applicable.",
+      "required": ["familyId"],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM. \n\nFor a patent, it might be a good idea to use a patent number as the BOM reference ID."
+        },
+        "familyId": {
+          "type": "string",
+          "title": "Patent Family ID",
+          "description": "The unique identifier for the patent family, aligned with the `id` attribute in WIPO ST.96 v8.0's `PatentFamilyType`. Refer to [PatentFamilyType in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/PatentFamilyType.xsd)."
+        },
+        "priorityApplication": {
+          "$ref": "#/$defs/priorityApplication"
+        },
+        "members": {
+          "type": "array",
+          "title": "Family Members",
+          "description": "A collection of patents or applications that belong to this family, each identified by a `bom-ref` pointing to a patent object defined elsewhere in the BOM.",
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+            "title": "BOM Reference",
+            "description": "A `bom-ref` linking to a patent or application object within the BOM."
+          }
+        },
+        "externalReferences": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReferences"
+        }
+      }
+    },
+    "patentAssertions": {
+      "type": "array",
+      "title": "Patent Assertions",
+      "description": "A list of assertions made regarding patents associated with this component or service. Assertions distinguish between ownership, licensing, and other relevant interactions with patents.",
+      "items": {
+        "type": "object",
+        "title": "Patent Assertion",
+        "description": "An assertion linking a patent or patent family to this component or service.",
+        "required": ["assertionType", "asserter"],
+        "additionalProperties": false,
+        "properties": {
+          "bom-ref": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+            "title": "BOM Reference",
+            "description": "A reference to the patent or patent family object within the BOM. This must match the `bom-ref` of a `patent` or `patentFamily` object."
+          },
+          "assertionType": {
+            "type": "string",
+            "title": "Assertion Type",
+            "description": "The type of assertion being made about the patent or patent family. Examples include ownership, licensing, and standards inclusion.",
+            "enum": [
+              "ownership",
+              "license",
+              "third-party-claim",
+              "standards-inclusion",
+              "prior-art",
+              "exclusive-rights",
+              "non-assertion",
+              "research-or-evaluation"
+            ],
+            "meta:enum": {
+              "ownership": "The manufacturer asserts ownership of the patent or patent family.",
+              "license": "The manufacturer asserts they have a license to use the patent or patent family.",
+              "third-party-claim": "A third party has asserted a claim or potential infringement against the manufacturer’s component or service.",
+              "standards-inclusion": "The patent is part of a standard essential patent (SEP) portfolio relevant to the component or service.",
+              "prior-art": "The manufacturer asserts the patent or patent family as prior art that invalidates another patent or claim.",
+              "exclusive-rights": "The manufacturer asserts exclusive rights granted through a licensing agreement.",
+              "non-assertion": "The manufacturer asserts they will not enforce the patent or patent family against certain uses or users.",
+              "research-or-evaluation": "The patent or patent family is being used under a research or evaluation license."
+            }
+          },
+          "patentRefs": {
+            "type": "array",
+            "title": "Patent References",
+            "description": "A list of BOM references (`bom-ref`) linking to patents or patent families associated with this assertion.",
+            "items": {
+              "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+            }
+          },
+          "asserter": {
+            "oneOf": [
+              {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity",
+                "title": "Organizational Entity"
+              },
+              {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalContact",
+                "title": "Person"
+              },
+              {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+                "title": "Reference",
+                "description": "A reference to a previously defined `organizationalContact` or `organizationalEntity` object in the BOM. The value must be a valid `bom-ref` pointing to one of these objects."
+              }
+            ]
+          },
+          "notes": {
+            "type": "string",
+            "title": "Notes",
+            "description": "Additional notes or clarifications regarding the assertion, if necessary. For example, geographical restrictions, duration, or limitations of a license."
+          }
+        }
+      }
+    },
+    "patentApplicationNumber": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9\\-/.()\\s]{0,28}[A-Za-z0-9]$",
+      "title": "Patent Application Number",
+      "description": "The unique number assigned to a patent application when it is filed with a patent office. It is used to identify the specific application and track its progress through the examination process. Aligned with `ApplicationNumber` in ST.96. Refer to [ApplicationIdentificationType in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/ApplicationIdentificationType.xsd).",
+      "examples": ["US20240000123", "EP23123456"]
+    },
+    "patentJurisdiction": {
+      "type": "string",
+      "title": "Jurisdiction",
+      "description": "The jurisdiction or patent office where the priority application was filed, specified using WIPO ST.3 codes. Aligned with `IPOfficeCode` in ST.96. Refer to [IPOfficeCode in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Common/IPOfficeCode.xsd).",
+      "pattern": "^[A-Z]{2}$",
+      "examples": ["US", "EP", "JP"]
+    },
+    "patentFilingDate": {
+      "type": "string",
+      "format": "date",
+      "title": "Filing Date",
+      "description": "The date the priority application was filed, aligned with `FilingDate` in ST.96. Refer to [FilingDate in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/FilingDate.xsd)."
+    },
+    "priorityApplication": {
+      "type": "object",
+      "title": "Priority Application",
+      "description": "The priorityApplication contains the essential data necessary to identify and reference an earlier patent filing for priority rights. In line with WIPO ST.96 guidelines, it includes the jurisdiction (office code), application number, and filing date-the three key elements that uniquely specify the priority application in a global patent context.",
+      "required": ["applicationNumber", "jurisdiction", "filingDate"],
+      "additionalProperties": false,
+      "properties": {
+        "applicationNumber": {
+          "$ref": "#/$defs/patentApplicationNumber"
+        },
+        "jurisdiction": {
+          "$ref": "#/$defs/patentJurisdiction"
+        },
+        "filingDate": {
+          "$ref": "#/$defs/patentFilingDate"
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-perspective-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-perspective-2.0.schema.json
@@ -1,0 +1,342 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-perspective-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Perspective Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "perspectives": {
+      "type": "array",
+      "title": "Perspectives",
+      "description": "Defines domain-specific views into the document, enabling different audiences to interpret and navigate the data through their own conceptual lens. Each perspective identifies relevant data types and may provide domain-specific terminology mappings.",
+      "items": {
+        "$ref": "#/$defs/perspective"
+      }
+    },
+    "perspective": {
+      "type": "object",
+      "title": "Perspective",
+      "description": "A domain-specific view that identifies the types of data relevant to a particular audience and provides optional terminology mappings to facilitate interpretation. Perspectives enable tooling to generate filtered views, translate terminology, and validate document completeness against audience-specific requirements.",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "mappings"
+      ],
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType"
+        },
+        "name": {
+          "type": "string",
+          "title": "Perspective Name",
+          "description": "The name of the perspective, typically indicating the target audience or domain.",
+          "examples": [
+            "AI/ML Transparency",
+            "Device Manufacturing Regulatory Compliance",
+            "Minimum Elements of an SBOM"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the perspective, its intended audience, and the use cases it supports."
+        },
+        "domains": {
+          "type": "array",
+          "title": "Domains",
+          "description": "The domains or disciplines to which this perspective applies. Allows selection of multiple pre-defined domains, custom domains, or a combination of both.",
+          "items": {
+            "$ref": "#/$defs/perspectiveDomainChoice"
+          }
+        },
+        "mappings": {
+          "type": "array",
+          "title": "Data Type Mappings",
+          "description": "An array of mappings that identify the types of data relevant to this perspective using JSON path expressions. Each mapping may include domain-specific terminology.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/perspectiveMapping"
+          }
+        },
+        "externalReferences": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReferences"
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "perspectiveMapping": {
+      "type": "object",
+      "title": "Perspective Mapping",
+      "description": "Maps a JSON path expression to domain-specific terminology, enabling audiences to interpret CycloneDX data using familiar nomenclature. Each mapping identifies a data type within the document structure and may provide alternative names and descriptions used by the target audience.",
+      "additionalProperties": false,
+      "required": [
+        "expression"
+      ],
+      "properties": {
+        "expression": {
+          "type": "string",
+          "title": "Path Expression",
+          "description": "A [JSONPath](https://datatracker.ietf.org/doc/html/rfc9535) expression that identifies the types of data relevant to this perspective.",
+          "examples": [
+            "$.components[*].pedigree",
+            "$.components[?(@.type=='machine-learning-model')].modelCard",
+            "$.components[?(@.type=='cryptographic-asset')]",
+            "$.vulnerabilities"
+          ]
+        },
+        "nativeName": {
+          "type": "string",
+          "title": "Native Name",
+          "description": "The domain-specific term used by the target audience to describe the data identified by the expression.",
+          "examples": [
+            "Foundation Models",
+            "Training Corpus",
+            "Cryptographic Inventory",
+            "Component Provenance"
+          ]
+        },
+        "nativeDescription": {
+          "type": "string",
+          "title": "Native Description",
+          "description": "A domain-specific description of the data type, explaining its significance within the context of the perspective."
+        },
+        "relevance": {
+          "$ref": "#/$defs/perspectiveRelevance"
+        },
+        "weight": {
+          "type": "number",
+          "title": "Weight",
+          "description": "Describes the importance of a field in relation to other fields. Values shall be between 0.0 and 1.0. This allows for relative ranking of mappings, where higher values indicate greater importance.",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "rationale": {
+          "type": "string",
+          "title": "Rationale",
+          "description": "Explains why this data type is relevant to the perspective and how it should be interpreted or used."
+        }
+      }
+    },
+    "perspectiveRelevance": {
+      "type": "string",
+      "title": "Perspective Relevance",
+      "description": "Indicates the importance of a data type to a perspective.",
+      "enum": [
+        "required",
+        "recommended",
+        "optional",
+        "informative"
+      ],
+      "meta:enum": {
+        "required": "This data type is essential for the perspective and should always be present.",
+        "recommended": "This data type is highly relevant and should be included when available.",
+        "optional": "This data type provides supplementary information that may be useful.",
+        "informative": "This data type provides background context but is not directly actionable."
+      }
+    },
+    "perspectiveDomainChoice": {
+      "title": "Perspective Domain Choice",
+      "description": "Allows selection of a pre-defined domain or specification of a custom domain.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/preDefinedPerspectiveDomain"
+        },
+        {
+          "type": "object",
+          "title": "Custom Domain",
+          "required": [
+            "name"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Domain Name",
+              "description": "The name of the custom domain."
+            },
+            "description": {
+              "type": "string",
+              "title": "Domain Description",
+              "description": "A description of the custom domain, its scope, and the concerns it addresses."
+            }
+          }
+        }
+      ]
+    },
+    "preDefinedPerspectiveDomain": {
+      "type": "string",
+      "title": "Pre-Defined Perspective Domain",
+      "description": "A pre-defined domain or discipline to which a perspective applies. Domains span security disciplines, safety engineering, industry verticals, technology areas, compliance frameworks, and cross-cutting concerns.",
+      "enum": [
+        "application-security",
+        "cloud-security",
+        "container-security",
+        "cryptographic-security",
+        "cyber-security",
+        "data-security",
+        "endpoint-security",
+        "firmware-security",
+        "hardware-security",
+        "identity-access-management",
+        "network-security",
+        "operational-security",
+        "physical-security",
+        "supply-chain-security",
+        "web-security",
+        "automotive-safety",
+        "aviation-safety",
+        "environmental-safety",
+        "functional-safety",
+        "machinery-safety",
+        "maritime-safety",
+        "nuclear-safety",
+        "patient-safety",
+        "process-safety",
+        "railway-safety",
+        "aerospace-defense",
+        "automotive",
+        "building-automation",
+        "consumer-electronics",
+        "critical-infrastructure",
+        "education",
+        "energy-utilities",
+        "financial-services",
+        "government",
+        "healthcare",
+        "insurance",
+        "legal",
+        "manufacturing",
+        "media-entertainment",
+        "pharmaceuticals",
+        "retail",
+        "telecommunications",
+        "transportation",
+        "artificial-intelligence",
+        "edge-computing",
+        "embedded-systems",
+        "industrial-control-systems",
+        "industrial-iot",
+        "internet-of-things",
+        "machine-learning",
+        "medical-devices",
+        "mobile",
+        "operational-technology",
+        "robotics",
+        "scada",
+        "smart-grid",
+        "data-protection",
+        "export-control",
+        "intellectual-property",
+        "legal-compliance",
+        "licensing",
+        "privacy",
+        "regulatory-compliance",
+        "maintainability",
+        "performance",
+        "quality-assurance",
+        "reliability",
+        "testability",
+        "incident-response",
+        "penetration-testing",
+        "red-team",
+        "risk-management",
+        "threat-intelligence",
+        "threat-modeling",
+        "vulnerability-management",
+        "accessibility",
+        "ethics",
+        "human-factors",
+        "interoperability",
+        "resilience",
+        "sustainability",
+        "transparency"
+      ],
+      "meta:enum": {
+        "application-security": "Security concerns related to software applications, including vulnerabilities, secure coding practices, input validation, and dependency management.",
+        "cloud-security": "Security concerns specific to cloud computing environments, including configuration, identity management, data protection, and shared responsibility models.",
+        "container-security": "Security concerns related to containerised applications, including image provenance, runtime protection, orchestration security, and supply chain integrity.",
+        "cryptographic-security": "Concerns related to cryptographic implementations, algorithm selection, key management, certificate handling, and post-quantum cryptography readiness.",
+        "cyber-security": "Broad security concerns encompassing threat detection, incident response, security operations, and defence-in-depth strategies.",
+        "data-security": "Concerns related to protecting data at rest, in transit, and in use, including encryption, access controls, and data loss prevention.",
+        "endpoint-security": "Security concerns for end-user devices including workstations, mobile devices, and peripherals, encompassing malware protection and device management.",
+        "firmware-security": "Security concerns specific to firmware, including secure boot, firmware updates, integrity verification, and protection against persistent threats.",
+        "hardware-security": "Security concerns related to physical hardware, including trusted platform modules, hardware security modules, side-channel attacks, and tamper resistance.",
+        "identity-access-management": "Concerns related to authentication, authorisation, identity lifecycle management, privileged access, and zero-trust architectures.",
+        "network-security": "Security concerns related to network infrastructure, including firewalls, intrusion detection, segmentation, and secure communications.",
+        "operational-security": "Security concerns related to the deployment, configuration, and day-to-day operation of systems in production environments.",
+        "physical-security": "Security concerns related to physical access controls, environmental protections, surveillance, and tamper evidence.",
+        "supply-chain-security": "Concerns related to the security, integrity, and trustworthiness of components, vendors, and processes throughout the supply chain.",
+        "web-security": "Security concerns specific to web applications and services, including OWASP Top 10 vulnerabilities, API security, and client-side protections.",
+        "automotive-safety": "Safety concerns for automotive systems aligned with ISO 26262, including hazard analysis, functional safety requirements, and ASIL classifications.",
+        "aviation-safety": "Safety concerns for aviation systems aligned with DO-178C, DO-254, and DO-326A, including design assurance levels and airworthiness requirements.",
+        "environmental-safety": "Concerns related to environmental protection, hazardous materials handling, emissions, and ecological impact assessment.",
+        "functional-safety": "Safety concerns aligned with IEC 61508 and derivative standards, focusing on systematic failures, safety integrity levels, and risk reduction.",
+        "machinery-safety": "Safety concerns for industrial machinery aligned with ISO 12100 and IEC 62443, including safeguarding, emergency stops, and risk assessment.",
+        "maritime-safety": "Safety concerns for maritime and offshore systems, including vessel automation, navigation systems, and compliance with maritime regulations.",
+        "nuclear-safety": "Safety concerns for nuclear facilities and systems, including defence-in-depth, safety classification, and regulatory compliance with nuclear standards.",
+        "patient-safety": "Safety concerns for medical devices and healthcare systems focusing on preventing harm to patients, including adverse event prevention and clinical risk management.",
+        "process-safety": "Safety concerns for industrial processes involving hazardous materials, including process hazard analysis, safety instrumented systems, and layers of protection.",
+        "railway-safety": "Safety concerns for railway systems aligned with EN 50126, EN 50128, and EN 50129, including signalling, train control, and safety cases.",
+        "aerospace-defense": "Concerns specific to aerospace and defence industries, including mission-critical systems, military standards, and classified information handling.",
+        "automotive": "Industry-specific concerns for automotive manufacturers and suppliers, including ISO/SAE 21434 cyber security and vehicle type approval.",
+        "building-automation": "Concerns related to building management systems, HVAC controls, access systems, and smart building infrastructure.",
+        "consumer-electronics": "Concerns specific to consumer electronic devices, including product safety, electromagnetic compatibility, and consumer protection regulations.",
+        "critical-infrastructure": "Concerns related to systems designated as critical infrastructure, including sector-specific requirements and national security considerations.",
+        "education": "Concerns specific to educational institutions and EdTech, including student data protection, FERPA compliance, and academic integrity.",
+        "energy-utilities": "Concerns specific to energy and utility sectors, including NERC CIP compliance, grid security, and operational continuity.",
+        "financial-services": "Concerns specific to financial institutions, including PCI DSS, SOX compliance, fraud prevention, and transaction integrity.",
+        "government": "Concerns specific to government agencies and contractors, including FedRAMP, FISMA, and public sector procurement requirements.",
+        "healthcare": "Concerns specific to healthcare organisations, including HIPAA compliance, electronic health records, and healthcare interoperability.",
+        "insurance": "Concerns specific to insurance industry, including actuarial data integrity, claims processing security, and regulatory compliance.",
+        "legal": "Concerns specific to legal industry, including attorney-client privilege, e-discovery, and legal hold requirements.",
+        "manufacturing": "Concerns specific to manufacturing environments, including production systems, quality management, and shop floor security.",
+        "media-entertainment": "Concerns specific to media and entertainment, including digital rights management, content protection, and broadcast systems.",
+        "pharmaceuticals": "Concerns specific to pharmaceutical industry, including FDA 21 CFR Part 11, GxP compliance, and drug safety systems.",
+        "retail": "Concerns specific to retail industry, including point-of-sale security, e-commerce platforms, and customer data protection.",
+        "telecommunications": "Concerns specific to telecommunications providers, including network infrastructure, subscriber data, and regulatory compliance.",
+        "transportation": "Concerns related to transportation systems beyond automotive and rail, including logistics, fleet management, and traffic control systems.",
+        "artificial-intelligence": "Concerns related to AI systems, including model transparency, algorithmic bias, explainability, and ethical considerations.",
+        "edge-computing": "Concerns specific to edge computing deployments, including distributed processing, local data handling, and remote device management.",
+        "embedded-systems": "Concerns specific to embedded systems development, including real-time constraints, resource limitations, and hardware-software integration.",
+        "industrial-control-systems": "Concerns specific to ICS environments, including PLCs, DCS, and industrial automation security aligned with IEC 62443.",
+        "industrial-iot": "Concerns specific to Industrial Internet of Things deployments, combining IT security with OT requirements and industrial protocols.",
+        "internet-of-things": "Concerns related to IoT devices and ecosystems, including device security, communication protocols, and fleet management.",
+        "machine-learning": "Concerns specific to ML models, including training data provenance, model lineage, performance metrics, and reproducibility.",
+        "medical-devices": "Concerns specific to medical device development aligned with IEC 62304, FDA guidance, and MDR/IVDR requirements.",
+        "mobile": "Concerns specific to mobile applications and devices, including app store requirements, mobile-specific vulnerabilities, and device management.",
+        "operational-technology": "Concerns specific to OT environments, bridging IT and industrial systems with focus on availability, safety, and legacy system integration.",
+        "robotics": "Concerns specific to robotic systems, including autonomous operation, human-robot interaction safety, and motion control security.",
+        "scada": "Concerns specific to Supervisory Control and Data Acquisition systems, including remote monitoring, control system security, and protocol vulnerabilities.",
+        "smart-grid": "Concerns specific to smart grid infrastructure, including advanced metering, grid automation, and distributed energy resource management.",
+        "data-protection": "Concerns related to data protection regulations such as GDPR, CCPA, and cross-border data transfer requirements.",
+        "export-control": "Concerns related to export control regulations, including EAR, ITAR, and dual-use technology restrictions.",
+        "intellectual-property": "Concerns related to patents, trade secrets, copyright, and other intellectual property rights and protections.",
+        "legal-compliance": "Regulatory and legal requirements, including contractual obligations, liability considerations, and legal holds.",
+        "licensing": "Concerns related to software licensing, licence compatibility, open source obligations, and commercial licensing terms.",
+        "privacy": "Concerns related to personal data protection, privacy by design, consent management, and individual rights.",
+        "regulatory-compliance": "Concerns related to compliance with industry-specific regulations, standards, and certification requirements.",
+        "maintainability": "Concerns related to the ease of maintaining, updating, and supporting software and systems over their lifecycle.",
+        "performance": "Concerns related to system performance, scalability, response times, and resource utilisation.",
+        "quality-assurance": "Concerns related to testing, validation, verification, and overall quality metrics and processes.",
+        "reliability": "Concerns related to system reliability, fault tolerance, mean time between failures, and degradation modes.",
+        "testability": "Concerns related to the ability to test components and systems, including test coverage, test automation, and test data management.",
+        "incident-response": "Concerns related to detecting, responding to, and recovering from security incidents and breaches.",
+        "penetration-testing": "Concerns related to authorised security testing, vulnerability assessment, and security validation activities.",
+        "red-team": "Concerns related to adversarial simulation, attack path analysis, and security control effectiveness testing.",
+        "risk-management": "Concerns related to risk identification, assessment, treatment, and ongoing risk monitoring.",
+        "threat-intelligence": "Concerns related to threat actor analysis, indicators of compromise, and proactive threat hunting.",
+        "threat-modeling": "Concerns related to identifying weaknesses, threats, countermeasures, attack surfaces, and trust boundaries.",
+        "vulnerability-management": "Concerns related to vulnerability identification, prioritisation, remediation tracking, and disclosure processes.",
+        "accessibility": "Concerns related to ensuring systems are usable by people with disabilities, including WCAG compliance.",
+        "ethics": "Concerns related to ethical considerations in technology development, including algorithmic fairness and responsible innovation.",
+        "human-factors": "Concerns related to human-system interaction, usability, operator error prevention, and ergonomic design.",
+        "interoperability": "Concerns related to the ability of systems to exchange and use information effectively across boundaries.",
+        "resilience": "Concerns related to system resilience, business continuity, disaster recovery, and graceful degradation.",
+        "sustainability": "Concerns related to environmental sustainability, energy efficiency, and responsible resource consumption.",
+        "transparency": "Concerns related to openness, auditability, and the ability for stakeholders to understand system behaviour and composition."
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-release-notes-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-release-notes-2.0.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-release-notes-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Release Notes Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "releaseNotes": {
+      "type": "object",
+      "title": "Release notes",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/releaseType",
+          "title": "Type",
+          "description": "The software versioning type the release note describes."
+        },
+        "title": {
+          "type": "string",
+          "title": "Title",
+          "description": "The title of the release."
+        },
+        "featuredImage": {
+          "type": "string",
+          "format": "iri-reference",
+          "title": "Featured image",
+          "description": "The URL to an image that may be prominently displayed with the release note."
+        },
+        "socialImage": {
+          "type": "string",
+          "format": "iri-reference",
+          "title": "Social image",
+          "description": "The URL to an image that may be used in messaging on social media platforms."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A short description of the release."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The date and time (timestamp) when the release note was created."
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Aliases",
+          "description": "One or more alternate names the release may be referred to. This may include unofficial terms used by development and marketing teams (e.g. code names)."
+        },
+        "tags": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/tags",
+          "title": "Tags"
+        },
+        "resolves": {
+          "type": "array",
+          "items": {"$ref": "cyclonedx-common-2.0.schema.json#/$defs/issue"},
+          "title": "Resolves",
+          "description": "A collection of issues that have been resolved."
+        },
+        "notes": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/note"},
+          "title": "Notes",
+          "description": "Zero or more release notes containing the locale and content. Multiple note objects may be specified to support release notes in a wide variety of languages."
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {"$ref": "cyclonedx-common-2.0.schema.json#/$defs/property"}
+        }
+      }
+    },
+    "releaseType": {
+      "type": "string",
+      "examples": [
+        "major",
+        "minor",
+        "patch",
+        "pre-release",
+        "internal"
+      ],
+      "description": "The software versioning type. It is recommended that the release type use one of 'major', 'minor', 'patch', 'pre-release', or 'internal'. Representing all possible software release types is not practical, so standardizing on the recommended values, whenever possible, is strongly encouraged.\n\n* __major__ = A major release may contain significant changes or may introduce breaking changes.\n* __minor__ = A minor release, also known as an update, may contain a smaller number of changes than major releases.\n* __patch__ = Patch releases are typically unplanned and may resolve defects or important security issues.\n* __pre-release__ = A pre-release may include alpha, beta, or release candidates and typically have limited support. They provide the ability to preview a release prior to its general availability.\n* __internal__ = Internal releases are not for public consumption and are intended to be used exclusively by the project or manufacturer that produced it."
+    },
+    "note": {
+      "type": "object",
+      "title": "Note",
+      "description": "A note containing the locale and content.",
+      "required": [
+        "text"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "locale": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/locale",
+          "title": "Locale",
+          "description": "The ISO-639 (or higher) language code and optional ISO-3166 (or higher) country code. Examples include: \"en\", \"en-US\", \"fr\" and \"fr-CA\""
+        },
+        "text": {
+          "title": "Release note content",
+          "description": "Specifies the full content of the release note.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/attachment"
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-service-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-service-2.0.schema.json
@@ -1,0 +1,198 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-service-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Service Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "services": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/service"},
+      "uniqueItems": true,
+      "title": "Services"
+    },
+    "service": {
+      "type": "object",
+      "title": "Service",
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the service elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "provider": {
+          "title": "Provider",
+          "description": "The organization that provides the service.",
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity"
+        },
+        "group": {
+          "type": "string",
+          "title": "Service Group",
+          "description": "The grouping name, namespace, or identifier. This will often be a shortened, single name of the company or project that produced the service or domain name. Whitespace and special characters should be avoided.",
+          "examples": ["com.acme"]
+        },
+        "name": {
+          "type": "string",
+          "title": "Service Name",
+          "description": "The name of the service. This will often be a shortened, single name of the service.",
+          "examples": ["ticker-service"]
+        },
+        "version": {
+          "$ref": "cyclonedx-component-2.0.schema.json#/$defs/version",
+          "title": "Service Version",
+          "description": "The service version."
+        },
+        "description": {
+          "type": "string",
+          "title": "Service Description",
+          "description": "Specifies a description for the service"
+        },
+        "endpoints": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "iri-reference"
+          },
+          "title": "Endpoints",
+          "description": "The endpoint URIs of the service. Multiple endpoints are allowed.",
+          "examples": ["https://example.com/api/v1/ticker"]
+        },
+        "authenticated": {
+          "type": "boolean",
+          "title": "Authentication Required",
+          "description": "A boolean value indicating if the service requires authentication. A value of true indicates the service requires authentication prior to use. A value of false indicates the service does not require authentication."
+        },
+        "x-trust-boundary": {
+          "type": "boolean",
+          "title": "Crosses Trust Boundary",
+          "description": "A boolean value indicating if use of the service crosses a trust zone or boundary. A value of true indicates that by using the service, a trust boundary is crossed. A value of false indicates that by using the service, a trust boundary is not crossed."
+        },
+        "trustZone": {
+          "type": "string",
+          "title": "Trust Zone",
+          "description": "The name of the trust zone the service resides in."
+        },
+        "data": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/serviceData"},
+          "title": "Data",
+          "description": "Specifies information about the data including the directional flow of data and the data classification."
+        },
+        "licenses": {
+          "$ref": "cyclonedx-license-2.0.schema.json#/$defs/licenseChoice",
+          "title": "Service License(s)"
+        },
+        "patentAssertions": {
+          "$ref": "cyclonedx-patent-2.0.schema.json#/$defs/patentAssertions",
+          "title": "Service Patent(s)"
+        },
+        "externalReferences": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReferences"
+        },
+        "services": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/service"},
+          "uniqueItems": true,
+          "title": "Services",
+          "description": "A list of services included or deployed behind the parent service. This is not a dependency tree. It provides a way to specify a hierarchical representation of service assemblies."
+        },
+        "releaseNotes": {
+          "$ref": "cyclonedx-release-notes-2.0.schema.json#/$defs/releaseNotes",
+          "title": "Release notes",
+          "description": "Specifies release notes."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        },
+        "tags": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/tags",
+          "title": "Tags"
+        },
+        "signature": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
+    },
+    "serviceData": {
+      "type": "object",
+      "title": "Hash Objects",
+      "required": [
+        "flow",
+        "classification"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "flow": {
+          "$ref": "cyclonedx-data-2.0.schema.json#/$defs/dataFlowDirection",
+          "title": "Directional Flow",
+          "description": "Specifies the flow direction of the data. Direction is relative to the service. Inbound flow states that data enters the service. Outbound flow states that data leaves the service. Bi-directional states that data flows both ways and unknown states that the direction is not known."
+        },
+        "classification": {
+          "$ref": "cyclonedx-data-2.0.schema.json#/$defs/dataClassification"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Name for the defined data",
+          "examples": [
+            "Credit card reporting"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Short description of the data content and usage",
+          "examples": [
+            "Credit card information being exchanged in between the web app and the database"
+          ]
+        },
+        "governance": {
+          "title": "Data Governance",
+          "$ref": "cyclonedx-data-2.0.schema.json#/$defs/dataGovernance"
+        },
+        "source": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "title": "URL",
+                "type": "string",
+                "format": "iri-reference"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "Source",
+          "description": "The URI, URL, or BOM-Link of the components or services the data came in from"
+        },
+        "destination": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "title": "URL",
+                "type": "string",
+                "format": "iri-reference"
+              },
+              {
+                "title": "BOM-Link Element",
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/bomLinkElementType"
+              }
+            ]
+          },
+          "title": "Destination",
+          "description": "The URI, URL, or BOM-Link of the components or services the data is sent to"
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-standard-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-standard-2.0.schema.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-standard-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Standard Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "standards": {
+      "type": "array",
+      "title": "Standards",
+      "description": "The list of standards which may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to.",
+      "items": {
+        "$ref": "#/$defs/standard"
+      }
+    },
+    "standard": {
+      "type": "object",
+      "title": "Standard",
+      "description": "A standard may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the standard. This will often be a shortened, single name of the standard."
+        },
+        "version": {
+          "type": "string",
+          "title": "Version",
+          "description": "The version of the standard."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "The description of the standard."
+        },
+        "owner": {
+          "type": "string",
+          "title": "Owner",
+          "description": "The owner of the standard, often the entity responsible for its release."
+        },
+        "requirements": {
+          "$ref": "#/$defs/requirements"
+        },
+        "levels": {
+          "$ref": "#/$defs/levels"
+        },
+        "externalReferences": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReferences"
+        },
+        "signature": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/signature",
+          "title": "Signature",
+          "description": "Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)."
+        }
+      }
+    },
+    "requirements": {
+      "type": "array",
+      "title": "Requirements",
+      "description": "The list of requirements comprising the standard.",
+      "items": {
+        "$ref": "#/$defs/requirement"
+      }
+    },
+    "requirement": {
+      "type": "object",
+      "title": "Requirement",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+        },
+        "identifier": {
+          "type": "string",
+          "title": "Identifier",
+          "description": "The unique identifier used in the standard to identify a specific requirement. This should match what is in the standard and should not be the requirements bom-ref."
+        },
+        "title": {
+          "type": "string",
+          "title": "Title",
+          "description": "The title of the requirement."
+        },
+        "text": {
+          "type": "string",
+          "title": "Text",
+          "description": "The textual content of the requirement."
+        },
+        "descriptions": {
+          "type": "array",
+          "title": "Descriptions",
+          "description": "The supplemental text that provides additional guidance or context to the requirement, but is not directly part of the requirement.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "openCre": {
+          "type": "array",
+          "title": "OWASP OpenCRE Identifier(s)",
+          "description": "The Common Requirements Enumeration (CRE) identifier(s). CRE is a structured and standardized framework for uniting security standards and guidelines. CRE links each section of a resource to a shared topic identifier (a Common Requirement). Through this shared topic link, all resources map to each other. Use of CRE promotes clear and unambiguous communication among stakeholders.",
+          "items": {
+            "type": "string",
+            "pattern": "^CRE:[0-9]+-[0-9]+$",
+            "examples": [
+              "CRE:764-507"
+            ]
+          }
+        },
+        "parent": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType",
+          "title": "Parent BOM Reference",
+          "description": "The `bom-ref` to a parent requirement. This establishes a hierarchy of requirements. Top-level requirements must not define a parent. Only child requirements should define parents."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        },
+        "externalReferences": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/externalReferences"
+        }
+      }
+    },
+    "levels": {
+      "type": "array",
+      "title": "Levels",
+      "description": "The list of levels associated with the standard. Some standards have different levels of compliance.",
+      "items": {
+        "$ref": "#/$defs/level"
+      }
+    },
+    "level": {
+      "type": "object",
+      "title": "Level",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+        },
+        "identifier": {
+          "type": "string",
+          "title": "Identifier",
+          "description": "The identifier used in the standard to identify a specific level."
+        },
+        "title": {
+          "type": "string",
+          "title": "Title",
+          "description": "The title of the level."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "The description of the level."
+        },
+        "requirements": {
+          "type": "array",
+          "title": "Requirements",
+          "description": "The list of requirement `bom-ref`s that comprise the level.",
+          "items": {
+            "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-vulnerability-2.0.schema.json
+++ b/.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-vulnerability-2.0.schema.json
@@ -1,0 +1,526 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/model/cyclonedx-vulnerability-2.0.schema.json",
+  "type": "null",
+  "title": "CycloneDX Vulnerability Model",
+  "$comment" : "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "$defs": {
+    "vulnerabilities": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/vulnerability"},
+      "uniqueItems": true,
+      "title": "Vulnerabilities",
+      "description": "Vulnerabilities identified in components or services."
+    },
+    "vulnerability": {
+      "type": "object",
+      "title": "Vulnerability",
+      "description": "Defines a weakness in a component or service that could be exploited or triggered by a threat source.",
+      "additionalProperties": false,
+      "properties": {
+        "bom-ref": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refType",
+          "title": "BOM Reference",
+          "description": "An identifier which can be used to reference the vulnerability elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+        },
+        "id": {
+          "type": "string",
+          "title": "ID",
+          "description": "The identifier that uniquely identifies the vulnerability.",
+          "examples": [
+            "CVE-2021-39182",
+            "GHSA-35m5-8cvj-8783",
+            "SNYK-PYTHON-ENROCRYPT-1912876"
+          ]
+        },
+        "source": {
+          "$ref": "#/$defs/vulnerabilitySource",
+          "description": "The source that published the vulnerability."
+        },
+        "references": {
+          "type": "array",
+          "title": "References",
+          "description": "Zero or more pointers to vulnerabilities that are the equivalent of the vulnerability specified. Often times, the same vulnerability may exist in multiple sources of vulnerability intelligence, but have different identifiers. References provide a way to correlate vulnerabilities across multiple sources of vulnerability intelligence.",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "source"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "title": "ID",
+                "description": "An identifier that uniquely identifies the vulnerability.",
+                "examples": [
+                  "CVE-2021-39182",
+                  "GHSA-35m5-8cvj-8783",
+                  "SNYK-PYTHON-ENROCRYPT-1912876"
+                ]
+              },
+              "source": {
+                "$ref": "#/$defs/vulnerabilitySource",
+                "description": "The source that published the vulnerability."
+              }
+            }
+          }
+        },
+        "ratings": {
+          "type": "array",
+          "title": "Ratings",
+          "description": "List of vulnerability ratings. Consumers should consider ratings in prioritization decisions; source ratings may differ and aid prioritization.",
+          "items": {
+            "$ref": "#/$defs/rating"
+          }
+        },
+        "cwes": {
+          "type": "array",
+          "title": "CWEs",
+          "description": "List of Common Weaknesses Enumerations (CWEs) codes that describes this vulnerability.",
+          "examples": [399],
+          "items": {
+            "$ref": "#/$defs/cwe"
+          }
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the vulnerability as provided by the source."
+        },
+        "detail": {
+          "type": "string",
+          "title": "Details",
+          "description": "If available, an in-depth description of the vulnerability as provided by the source organization. Details often include information useful in understanding root cause."
+        },
+        "recommendation": {
+          "type": "string",
+          "title": "Recommendation",
+          "description": "Recommendations of how the vulnerability can be remediated or mitigated."
+        },
+        "workaround": {
+          "type": "string",
+          "title": "Workarounds",
+          "description": "A bypass, usually temporary, of the vulnerability that reduces its likelihood and/or impact. Workarounds often involve changes to configuration or deployments."
+        },
+        "proofOfConcept": {
+          "type": "object",
+          "title": "Proof of Concept",
+          "description": "Evidence used to reproduce the vulnerability.",
+          "properties": {
+            "reproductionSteps": {
+              "type": "string",
+              "title": "Steps to Reproduce",
+              "description": "Precise steps to reproduce the vulnerability."
+            },
+            "environment": {
+              "type": "string",
+              "title": "Environment",
+              "description": "A description of the environment in which reproduction was possible."
+            },
+            "supportingMaterial": {
+              "type": "array",
+              "title": "Supporting Material",
+              "description": "Supporting material that helps in reproducing or understanding how reproduction is possible. This may include screenshots, payloads, and PoC exploit code.",
+              "items": { "$ref": "cyclonedx-common-2.0.schema.json#/$defs/attachment" }
+            }
+          }
+        },
+        "advisories": {
+          "type": "array",
+          "title": "Advisories",
+          "description": "Published advisories of the vulnerability if provided.",
+          "items": {
+            "$ref": "#/$defs/advisory"
+          }
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Created",
+          "description": "The date and time (timestamp) when the vulnerability record was created in the vulnerability database."
+        },
+        "published": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Published",
+          "description": "The date and time (timestamp) when the vulnerability record was first published."
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Updated",
+          "description": "The date and time (timestamp) when the vulnerability record was last updated."
+        },
+        "rejected": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Rejected",
+          "description": "The date and time (timestamp) when the vulnerability record was rejected (if applicable)."
+        },
+        "credits": {
+          "type": "object",
+          "title": "Credits",
+          "description": "Individuals or organizations credited with the discovery of the vulnerability.",
+          "additionalProperties": false,
+          "properties": {
+            "organizations": {
+              "type": "array",
+              "title": "Organizations",
+              "description": "The organizations credited with vulnerability discovery.",
+              "items": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalEntity"
+              }
+            },
+            "individuals": {
+              "type": "array",
+              "title": "Individuals",
+              "description": "The individuals, not associated with organizations, that are credited with vulnerability discovery.",
+              "items": {
+                "$ref": "cyclonedx-common-2.0.schema.json#/$defs/organizationalContact"
+              }
+            }
+          }
+        },
+        "tools": {
+          "type": "object",
+          "title": "Tools",
+          "description": "The tool(s) used to identify, confirm, or score the vulnerability.",
+          "additionalProperties": false,
+          "properties": {
+            "components": {
+              "type": "array",
+              "items": {"$ref": "cyclonedx-component-2.0.schema.json#/$defs/component"},
+              "uniqueItems": true,
+              "title": "Components",
+              "description": "A list of software and hardware components used as tools."
+            },
+            "services": {
+              "type": "array",
+              "items": {"$ref": "cyclonedx-service-2.0.schema.json#/$defs/service"},
+              "uniqueItems": true,
+              "title": "Services",
+              "description": "A list of services used as tools. This may include microservices, function-as-a-service, and other types of network or intra-process services."
+            }
+          }
+        },
+        "analysis": {
+          "type": "object",
+          "title": "Impact Analysis",
+          "description": "An assessment of the impact and exploitability of the vulnerability.",
+          "additionalProperties": false,
+          "properties": {
+            "state": {
+              "$ref": "#/$defs/impactAnalysisState"
+            },
+            "justification": {
+              "$ref": "#/$defs/impactAnalysisJustification"
+            },
+            "response": {
+              "type": "array",
+              "title": "Response",
+              "description": "A response to the vulnerability by the manufacturer, supplier, or project responsible for the affected component or service. More than one response is allowed. Responses are strongly encouraged for vulnerabilities where the analysis state is exploitable.",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "can_not_fix",
+                  "will_not_fix",
+                  "update",
+                  "rollback",
+                  "workaround_available"
+                ],
+                "meta:enum": {
+                  "can_not_fix": "Can not fix",
+                  "will_not_fix": "Will not fix",
+                  "update": "Update to a different revision or release",
+                  "rollback": "Revert to a previous revision or release",
+                  "workaround_available": "There is a workaround available"
+                }
+              }
+            },
+            "detail": {
+              "type": "string",
+              "title": "Detail",
+              "description": "Detailed description of the impact including methods used during assessment. If a vulnerability is not exploitable, this field should include specific details on why the component or service is not impacted by this vulnerability."
+            },
+            "firstIssued": {
+              "type": "string",
+              "format": "date-time",
+              "title": "First Issued",
+              "description": "The date and time (timestamp) when the analysis was first issued."
+            },
+            "lastUpdated": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Last Updated",
+              "description": "The date and time (timestamp) when the analysis was last updated."
+            }
+          }
+        },
+        "affects": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "required": [
+              "ref"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "ref": {
+                "anyOf": [
+                  {
+                    "title": "Ref",
+                    "$ref": "cyclonedx-common-2.0.schema.json#/$defs/refLinkType"
+                  },
+                  {
+                    "title": "BOM-Link Element",
+                    "$ref": "cyclonedx-common-2.0.schema.json#/$defs/bomLinkElementType"
+                  }
+                ],
+                "title": "Reference",
+                "description": "References a component or service by the objects bom-ref"
+              },
+              "versions": {
+                "type": "array",
+                "title": "Versions",
+                "description": "Zero or more individual versions or range of versions.",
+                "items": {
+                  "type": "object",
+                  "oneOf": [
+                    {
+                      "required": ["version"]
+                    },
+                    {
+                      "required": ["range"]
+                    }
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "version": {
+                      "title": "Version",
+                      "description": "A single version of a component or service.",
+                      "$ref": "cyclonedx-component-2.0.schema.json#/$defs/version"
+                    },
+                    "range": {
+                      "title": "Version Range",
+                      "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec",
+                      "$ref": "cyclonedx-component-2.0.schema.json#/$defs/versionRange"
+                    },
+                    "status": {
+                      "title": "Status",
+                      "description": "The vulnerability status for the version or range of versions.",
+                      "$ref": "#/$defs/affectedStatus",
+                      "default": "affected"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "title": "Affects",
+          "description": "The components or services that are affected by the vulnerability."
+        },
+        "properties": {
+          "$ref": "cyclonedx-common-2.0.schema.json#/$defs/properties"
+        }
+      }
+    },
+    "advisory": {
+      "type": "object",
+      "title": "Advisory",
+      "description": "Title and location where advisory information can be obtained. An advisory is a notification of a threat to a component, service, or system.",
+      "required": ["url"],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string",
+          "title": "Title",
+          "description": "A name of the advisory."
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "format": "iri-reference",
+          "description": "Location where the advisory can be obtained."
+        }
+      }
+    },
+    "cwe": {
+      "type": "integer",
+      "minimum": 1,
+      "title": "CWE",
+      "description": "Integer representation of a Common Weaknesses Enumerations (CWE). For example 399 (of https://cwe.mitre.org/data/definitions/399.html)"
+    },
+    "severity": {
+      "type": "string",
+      "title": "Severity",
+      "description": "Textual representation of the severity of the vulnerability adopted by the analysis method. If the analysis method uses values other than what is provided, the user is expected to translate appropriately.",
+      "enum": [
+        "critical",
+        "high",
+        "medium",
+        "low",
+        "info",
+        "none",
+        "unknown"
+      ],
+      "meta:enum": {
+        "critical": "Critical severity",
+        "high": "High severity",
+        "medium": "Medium severity",
+        "low": "Low severity",
+        "info": "Informational warning.",
+        "none": "None",
+        "unknown": "The severity is not known"
+      }
+    },
+    "scoreMethod": {
+      "type": "string",
+      "title": "Method",
+      "description": "Specifies the severity or risk scoring methodology or standard used.",
+      "enum": [
+        "CVSSv2",
+        "CVSSv3",
+        "CVSSv31",
+        "CVSSv4",
+        "OWASP",
+        "SSVC",
+        "other"
+      ],
+      "meta:enum": {
+        "CVSSv2": "Common Vulnerability Scoring System v2.0",
+        "CVSSv3": "Common Vulnerability Scoring System v3.0",
+        "CVSSv31": "Common Vulnerability Scoring System v3.1",
+        "CVSSv4": "Common Vulnerability Scoring System v4.0",
+        "OWASP": "OWASP Risk Rating Methodology",
+        "SSVC": "Stakeholder Specific Vulnerability Categorization",
+        "other": "Another severity or risk scoring methodology"
+      }
+    },
+    "impactAnalysisState": {
+      "type": "string",
+      "title": "Impact Analysis State",
+      "description": "Declares the current state of an occurrence of a vulnerability, after automated or manual analysis.",
+      "enum": [
+        "resolved",
+        "resolved_with_pedigree",
+        "exploitable",
+        "in_triage",
+        "false_positive",
+        "not_affected"
+      ],
+      "meta:enum": {
+        "resolved": "The vulnerability has been remediated.",
+        "resolved_with_pedigree": "The vulnerability has been remediated and evidence of the changes are provided in the affected components pedigree containing verifiable commit history and/or diff(s).",
+        "exploitable": "The vulnerability may be directly or indirectly exploitable.",
+        "in_triage": "The vulnerability is being investigated.",
+        "false_positive": "The vulnerability is not specific to the component or service and was falsely identified or associated.",
+        "not_affected": "The component or service is not affected by the vulnerability. Justification should be specified for all not_affected cases."
+      }
+    },
+    "impactAnalysisJustification": {
+      "type": "string",
+      "title": "Impact Analysis Justification",
+      "description": "The rationale of why the impact analysis state was asserted.",
+      "enum": [
+        "code_not_present",
+        "code_not_reachable",
+        "requires_configuration",
+        "requires_dependency",
+        "requires_environment",
+        "protected_by_compiler",
+        "protected_at_runtime",
+        "protected_at_perimeter",
+        "protected_by_mitigating_control"
+      ],
+      "meta:enum": {
+        "code_not_present": "The code has been removed or tree-shaked.",
+        "code_not_reachable": "The vulnerable code is not invoked at runtime.",
+        "requires_configuration": "Exploitability requires a configurable option to be set/unset.",
+        "requires_dependency": "Exploitability requires a dependency that is not present.",
+        "requires_environment": "Exploitability requires a certain environment which is not present.",
+        "protected_by_compiler": "Exploitability requires a compiler flag to be set/unset.",
+        "protected_at_runtime": "Exploits are prevented at runtime.",
+        "protected_at_perimeter": "Attacks are blocked at physical, logical, or network perimeter.",
+        "protected_by_mitigating_control": "Preventative measures have been implemented that reduce the likelihood and/or impact of the vulnerability."
+      }
+    },
+    "rating": {
+      "type": "object",
+      "title": "Rating",
+      "description": "Defines the severity or risk ratings of a vulnerability.",
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "$ref": "#/$defs/vulnerabilitySource",
+          "description": "The source that calculated the severity or risk rating of the vulnerability."
+        },
+        "score": {
+          "type": "number",
+          "title": "Score",
+          "description": "The numerical score of the rating."
+        },
+        "severity": {
+          "$ref": "#/$defs/severity",
+          "description": "Textual representation of the severity that corresponds to the numerical score of the rating."
+        },
+        "method": {
+          "$ref": "#/$defs/scoreMethod"
+        },
+        "vector": {
+          "type": "string",
+          "title": "Vector",
+          "description": "Textual representation of the metric values used to score the vulnerability"
+        },
+        "justification": {
+          "type": "string",
+          "title": "Justification",
+          "description": "A reason for rating the vulnerability as it was"
+        }
+      }
+    },
+    "vulnerabilitySource": {
+      "type": "object",
+      "title": "Source",
+      "description": "The source of vulnerability information. This is often the organization that published the vulnerability.",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "The url of the vulnerability documentation as provided by the source.",
+          "examples": [
+            "https://nvd.nist.gov/vuln/detail/CVE-2021-39182"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the source.",
+          "examples": [
+            "NVD",
+            "National Vulnerability Database",
+            "OSS Index",
+            "VulnDB",
+            "GitHub Advisories"
+          ]
+        }
+      }
+    },
+    "affectedStatus": {
+      "description": "The vulnerability status of a given version or range of versions of a product. The statuses 'affected' and 'unaffected' indicate that the version is affected or unaffected by the vulnerability. The status 'unknown' indicates that it is unknown or unspecified whether the given version is affected. There can be many reasons for an 'unknown' status, including that an investigation has not been undertaken or that a vendor has not disclosed the status.",
+      "type": "string",
+      "enum": [
+        "affected",
+        "unaffected",
+        "unknown"
+      ],
+      "meta:enum": {
+        "affected": "The version is affected by the vulnerability.",
+        "unaffected": "The version is not affected by the vulnerability.",
+        "unknown": "It is unknown (or unspecified) whether the given version is affected."
+      }
+    }
+  }
+}

--- a/.bob/skills/cyclonedx/skill.md
+++ b/.bob/skills/cyclonedx/skill.md
@@ -1,6 +1,6 @@
 ---
 name: cyclonedx-v1-7-bom-expert
-description: "OWASP CycloneDX v1.7 BOM & AI/ML-BOM authoring and validation expert"
+description: "OWASP CycloneDX v1.7 BOM & AI/ML-BOM authoring and validation expert; includes v2.0 pre-release schema findings"
 version: "1.0.0"
 author: ""
 tags:
@@ -228,3 +228,66 @@ _Boolean value_ are `true` or `false`; case sensitive.
 | `cdx:poetry` | Namespace for properties specific to the Python Poetry ecosystem. | [CycloneDX Python Maintainers] | [cdx:poetry taxonomy](cdx/poetry.md) |
 | `cdx:python` | Namespace for properties specific to the Python general packaging. | [CycloneDX Python Maintainers] | [cdx:python taxonomy](cdx/python.md) |
 | `cdx:rustc` | Namespace for properties specific to the Rust compiler, `rustc`. | [CycloneDX Rust Maintainers] | [cdx:rustc taxonomy](cdx/rustc.md) |
+
+---
+
+## CycloneDX v2.0 Pre-Release Schema Findings
+
+> These findings apply to the **bundled schema** used by sbom-utility:
+> `resources/schema/cyclonedx/2.0/cyclonedx-2.0-bundled.schema.json`
+> (`$id`: `https://cyclonedx.org/schema/2.0/cyclonedx-2.0.schema.json`)
+
+### Breaking Change: Component-level supplier / manufacturer / publisher removed
+
+In the **skill reference schema** (`.bob/skills/cyclonedx/cdx/schema/2.0/model/2.0-dev/cyclonedx-component-2.0.schema.json`) — an earlier draft — the `component` object retains `supplier`, `manufacturer`, and `publisher` as direct properties (using `organizationalEntity`).
+
+In the **bundled schema** used by the tool (a later draft), those three properties were **removed** from the `component` object. The `component` definition has `"additionalProperties": false`, so passing them causes validation errors:
+
+```
+Additional property manufacturer is not allowed
+Additional property supplier is not allowed
+Additional property publisher is not allowed
+```
+
+**v2.0 replacement:** organisational attribution on a component is now expressed via the `parties` array (new in v2.0), where each party carries a `roles` array using predefined role values including `"manufacturer"`, `"supplier"`, and `"publisher"`.
+
+```json
+"parties": [
+  {
+    "bom-ref": "party-acme",
+    "roles": [ { "role": "supplier" } ],
+    "organization": { "name": "Acme Corp" }
+  }
+]
+```
+
+**`metadata` is unaffected:** `metadata.supplier` and `metadata.manufacturer` still use `organizationalEntity` (plain `url` array of strings) in both schema variants.
+
+### Top-level field rename
+
+| v1.x | v2.0 |
+|---|---|
+| `bomFormat: "CycloneDX"` | `specFormat: "CycloneDX"` |
+| `specVersion: "1.x"` | `specVersion: "2.0"` |
+
+### Primary component placement
+
+In v1.x the subject component of the BOM lives at `metadata.component`.
+This is **unchanged in v2.0** — the `components[]` array is for dependency inventory; `metadata.component` is for the subject being described.
+
+### v2.0 purl / cpe in identifiers
+
+The `purl` and `cpe` top-level fields on `component` are replaced by `identifiers[].identities[]` with `scheme` + `value`:
+
+```json
+"identifiers": [
+  {
+    "bom-ref": "ident-1",
+    "party": "<bom-ref of asserting party>",
+    "identities": [
+      { "scheme": "purl", "value": "pkg:npm/acme/lib@1.0.0" },
+      { "scheme": "cpe",  "value": "cpe:2.3:a:acme:lib:1.0.0:*:*:*:*:*:*:*" }
+    ]
+  }
+]
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![License](https://img.shields.io/badge/CycloneDX-v1.2,1.3,1.4,1.5,1.6,1.7-darkcyan.svg)](https://github.com/CycloneDX/specification)
+[![License](https://img.shields.io/badge/CycloneDX-v1.2,1.3,1.4,1.5,1.6,1.7,2.0_(pre--release)-darkcyan.svg)](https://github.com/CycloneDX/specification)
 [![License](https://img.shields.io/badge/SPDX-v2.1,2.2,2.3-purple.svg)](https://github.com/spdx/spdx-spec)
 [![Go Report Card](https://goreportcard.com/badge/github.com/CycloneDX/sbom-utility)](https://goreportcard.com/badge/github.com/CycloneDX/sbom-utility)
 <!--![CodeQL](https://github.com/CycloneDX/sbom-utility/actions/workflows/codeql.yml/badge.svg)-->
@@ -198,6 +198,7 @@ This example uses the `--format` flag on the `schema` command to output in markd
 ```md
 |name|format|version|variant|file (local)|url (remote)|
 |:--|:--|:--|:--|:--|:--|
+|CycloneDX v2.0 (pre-release)|CycloneDX|2.0|development|schema/cyclonedx/2.0/cyclonedx-2.0-bundled.schema.json|https://raw.githubusercontent.com/CycloneDX/specification/2.0-dev/schema/2.0/cyclonedx-2.0-bundled.schema.json|
 |CycloneDX v1.5|CycloneDX|1.5|(latest)|schema/cyclonedx/1.5/bom-1.5.schema.json|https://raw.githubusercontent.com/CycloneDX/specification/master/schema/bom-1.5.schema.json|
 |CycloneDX v1.4|CycloneDX|1.4|(latest)|schema/cyclonedx/1.4/bom-1.4.schema.json|https://raw.githubusercontent.com/CycloneDX/specification/master/schema/bom-1.4.schema.json|
 |CycloneDX/specification/master/schema/bom-1.3-strict.schema.json|
@@ -309,6 +310,7 @@ This example shows the `--quiet` flag being used on the `schema` command to turn
 ```bash
 name                          format     version   variant      file (local)                                     url (remote)
 ----                          ------     -------   -------      ------------                                     ------------
+CycloneDX v2.0 (pre-release)  CycloneDX  2.0       development  schema/cyclonedx/2.0/cyclonedx-2.0-bundled.schema.json  https://raw.githubusercontent.com/CycloneDX/specification/2.0-dev/schema/2.0/cyclonedx-2.0-bundled.schema.json
 CycloneDX v1.5                CycloneDX  1.5       (latest)     schema/cyclonedx/1.5/bom-1.5.schema.json         https://raw.githubusercontent.com/CycloneDX/specification/master/schema/bom-1.5.schema.json
 CycloneDX v1.4                CycloneDX  1.4       (latest)     schema/cyclonedx/1.4/bom-1.4.schema.json         https://raw.githubusercontent.com/CycloneDX/specification/master/schema/bom-1.4.schema.json
 CycloneDX v1.3                CycloneDX  1.3       (latest)     schema/cyclonedx/1.3/bom-1.3.schema.json         https://raw.githubusercontent.com/CycloneDX/specification/master/schema/bom-1.3.schema.json
@@ -447,6 +449,22 @@ echo $?
 0  // no error (valid)
 ```
 
+
+##### Example: Validate using the CycloneDX v2.0 pre-release schema
+
+CycloneDX v2.0 is an early pre-release registered in `config.json` with `variant: "development"`. Because v2.0 BOMs use `specFormat` (rather than `bomFormat`) for format identification, auto-detection is not yet supported; use the `--force` flag to point directly at the bundled schema file:
+
+```bash
+./sbom-utility validate -i <your-cdx-2.0-bom.json> --force schema/cyclonedx/2.0/cyclonedx-2.0-bundled.schema.json
+```
+
+Alternatively, you can reference the upstream pre-release schema directly via URL:
+
+```bash
+./sbom-utility validate -i <your-cdx-2.0-bom.json> --force https://raw.githubusercontent.com/CycloneDX/specification/2.0-dev/schema/2.0/cyclonedx-2.0-bundled.schema.json
+```
+
+> **Note**: Once auto-detection support for the `specFormat`/`specVersion` key names (introduced in v2.0) is added, the `--variant development` flag will be usable without `--force`.
 
 ##### Example: Validate using "custom" schema variants
 
@@ -2229,8 +2247,9 @@ This command supports the `--format` flag with any of the following values:
 ```
 
 ```bash
-name            variant      format     version   file                                             url
-----            -------      ------     -------   ----                                             ---
+name                         variant      format     version   file                                                    url
+----                         -------      ------     -------   ----                                                    ---
+CycloneDX v2.0 (pre-release) development  CycloneDX  2.0       schema/cyclonedx/2.0/cyclonedx-2.0-bundled.schema.json  https://raw.githubusercontent.com/CycloneDX/specification/2.0-dev/schema/2.0/cyclonedx-2.0-bundled.schema.json
 CycloneDX v1.7  (latest)     CycloneDX  1.7       schema/cyclonedx/1.7/bom-1.7.schema.json         https://raw.githubusercontent.com/CycloneDX/specification/master/schema/bom-1.7.schema.json
 CycloneDX v1.6.1(latest)     CycloneDX  1.6       schema/cyclonedx/1.6/bom-1.6.schema.json         https://raw.githubusercontent.com/CycloneDX/specification/master/schema/bom-1.6.schema.json
 CycloneDX v1.5  (latest)     CycloneDX  1.5       schema/cyclonedx/1.5/bom-1.5.schema.json         https://raw.githubusercontent.com/CycloneDX/specification/master/schema/bom-1.5.schema.json

--- a/cmd/cdx_2_0_test.go
+++ b/cmd/cdx_2_0_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// CycloneDX v2.0 tests.
+//
+// All tests in this file exercise functionality specific to CycloneDX v2.0 BOMs
+// (specFormat rename, parties[], identifiers[], etc.) and require the
+// SCHEMA_VARIANT_DEVELOPMENT schema variant to be selected.
+
+package cmd
+
+import (
+	"testing"
+)
+
+// -------------------------------------------
+// validate
+// -------------------------------------------
+
+// TestValidateCdx20MinRequiredBasic verifies that a CycloneDX v2.0 BOM using the
+// renamed "specFormat" key (replacing "bomFormat") is correctly identified, validated,
+// and unmarshalled into the CDXBom struct with SpecFormat populated.
+func TestValidateCdx20MinRequiredBasic(t *testing.T) {
+	const EXPECTED_SPEC_FORMAT = "CycloneDX"
+	const EXPECTED_SPEC_VERSION = "2.0"
+
+	vti := NewValidateTestInfo(TEST_CDX_2_0_MIN_REQUIRED, FORMAT_TEXT, SCHEMA_VARIANT_DEVELOPMENT, nil)
+	document, _, err := innerTestValidate(t, *vti)
+	if err != nil {
+		// innerTestValidate already calls t.Errorf; just return to avoid nil-deref below
+		return
+	}
+
+	// Unmarshal into CDX structs so we can inspect the Go model.
+	if err = document.UnmarshalCycloneDXBOM(); err != nil {
+		t.Errorf("UnmarshalCycloneDXBOM() failed: %v", err)
+		return
+	}
+
+	// Assert the v2.0 specFormat key was decoded into SpecFormat (not BOMFormat).
+	if got := document.GetCdxSpecFormat(); got != EXPECTED_SPEC_FORMAT {
+		t.Errorf("SpecFormat: expected %q, got %q", EXPECTED_SPEC_FORMAT, got)
+	}
+
+	// Assert specVersion is preserved correctly.
+	if cdxBom := document.GetCdxBom(); cdxBom == nil || cdxBom.SpecVersion != EXPECTED_SPEC_VERSION {
+		var got string
+		if cdxBom != nil {
+			got = cdxBom.SpecVersion
+		}
+		t.Errorf("SpecVersion: expected %q, got %q", EXPECTED_SPEC_VERSION, got)
+	}
+
+	// Assert BOMFormat is empty (not set by a v2.0 document).
+	if cdxBom := document.GetCdxBom(); cdxBom != nil && cdxBom.BOMFormat != "" {
+		t.Errorf("BOMFormat: expected empty string for v2.0 document, got %q", cdxBom.BOMFormat)
+	}
+}

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -135,9 +135,8 @@ var COMPONENT_LIST_ROW_DATA = []ColumnFormatData{
 
 // Flags. Reuse query flag values where possible
 const (
-	FLAG_COMPONENT_SUMMARY = "summary"
-	FLAG_COMPONENT_TYPE    = "type"
-	// FLAG_COMPONENT_TYPE_HELP    = "filter output by component type(s)"
+	FLAG_COMPONENT_SUMMARY      = "summary"
+	FLAG_COMPONENT_TYPE         = "type"
 	FLAG_COMPONENT_SUMMARY_HELP = "summarize component information when listing in supported formats"
 )
 
@@ -160,7 +159,7 @@ func NewCommandComponent() *cobra.Command {
 	command.Long = "Report on components found in the BOM input file"
 	command.Flags().StringVarP(&utils.GlobalFlags.PersistentFlags.OutputFormat, FLAG_FILE_OUTPUT_FORMAT, "", FORMAT_TEXT,
 		FLAG_COMPONENT_OUTPUT_FORMAT_HELP+COMPONENT_LIST_OUTPUT_SUPPORTED_FORMATS)
-	//command.Flags().StringP(FLAG_COMPONENT_TYPE, "", "", FLAG_COMPONENT_TYPE_HELP)
+	command.Flags().StringVarP(&utils.GlobalFlags.ValidateFlags.SchemaVariant, FLAG_VALIDATE_SCHEMA_VARIANT, "", "", MSG_VALIDATE_SCHEMA_VARIANT)
 	command.Flags().BoolVarP(
 		&utils.GlobalFlags.ComponentFlags.Summary,
 		FLAG_COMPONENT_SUMMARY, "", false,

--- a/cmd/component.go
+++ b/cmd/component.go
@@ -116,9 +116,9 @@ var COMPONENT_LIST_ROW_DATA = []ColumnFormatData{
 	*NewColumnFormatData(COMPONENT_FILTER_KEY_MANUFACTURER_NAME, REPORT_DO_NOT_TRUNCATE, REPORT_SUMMARY_DATA, false),
 	*NewColumnFormatData(COMPONENT_FILTER_KEY_MANUFACTURER_URL, REPORT_DO_NOT_TRUNCATE, REPORT_SUMMARY_DATA, false),
 	*NewColumnFormatData(COMPONENT_FILTER_KEY_PUBLISHER, REPORT_DO_NOT_TRUNCATE, REPORT_SUMMARY_DATA, false),
-	*NewColumnFormatData(COMPONENT_FILTER_KEY_PURL, REPORT_DO_NOT_TRUNCATE, REPORT_SUMMARY_DATA, false),
+	{DataKey: COMPONENT_FILTER_KEY_PURL, TruncateLength: REPORT_DO_NOT_TRUNCATE, IsSummaryData: REPORT_SUMMARY_DATA, MarkdownEscape: REPORT_MARKDOWN_ESCAPE_TRUE},
 	*NewColumnFormatData(COMPONENT_FILTER_KEY_SWID, REPORT_DO_NOT_TRUNCATE, REPORT_SUMMARY_DATA, false),
-	*NewColumnFormatData(COMPONENT_FILTER_KEY_CPE, REPORT_DO_NOT_TRUNCATE, REPORT_SUMMARY_DATA, false),
+	{DataKey: COMPONENT_FILTER_KEY_CPE, TruncateLength: REPORT_DO_NOT_TRUNCATE, IsSummaryData: REPORT_SUMMARY_DATA, MarkdownEscape: REPORT_MARKDOWN_ESCAPE_TRUE},
 	*NewColumnFormatData(COMPONENT_FILTER_KEY_MIME_TYPE, REPORT_DO_NOT_TRUNCATE, false, false),
 	*NewColumnFormatData(COMPONENT_FILTER_KEY_HAS_SCOPE, REPORT_DO_NOT_TRUNCATE, false, false),
 	*NewColumnFormatData(COMPONENT_FILTER_KEY_NUM_HASHES, REPORT_DO_NOT_TRUNCATE, REPORT_SUMMARY_DATA, false),
@@ -455,7 +455,7 @@ func DisplayComponentListMarkdown(bom *schema.BOM, writer io.Writer, flags utils
 	for _, entry := range entries {
 		// NOTE: component hashmap values are pointers to CDXComponentInfo structs
 		pComponentInfo = entry.Value.(*schema.CDXComponentInfo)
-		line, err = prepareReportLineData(
+		line, err = prepareReportLineDataMarkdown(
 			*pComponentInfo,
 			COMPONENT_LIST_ROW_DATA,
 			flags.Summary,

--- a/cmd/component_2_0_test.go
+++ b/cmd/component_2_0_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// CycloneDX v2.0 tests.
+//
+// All tests in this file exercise functionality specific to CycloneDX v2.0 BOMs
+// (specFormat rename, parties[], identifiers[], etc.) and require the
+// SCHEMA_VARIANT_DEVELOPMENT schema variant to be selected.
+
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/CycloneDX/sbom-utility/schema"
+	"github.com/CycloneDX/sbom-utility/utils"
+)
+
+// -------------------------------------------
+// validate
+// -------------------------------------------
+
+// TestValidateCdx20ValidComponent verifies that a CycloneDX v2.0 BOM containing a single
+// component with v2.0-only fields (identifiers, parties, implementationPlatform as []string)
+// is correctly validated and unmarshalled into the CDXComponent struct.
+func TestValidateCdx20ValidComponent(t *testing.T) {
+	vti := NewValidateTestInfo(TEST_CDX_2_0_VALID_COMPONENT, FORMAT_TEXT, SCHEMA_VARIANT_DEVELOPMENT, nil)
+	document, _, err := innerTestValidate(t, *vti)
+	if err != nil {
+		return
+	}
+
+	if err = document.UnmarshalCycloneDXBOM(); err != nil {
+		t.Errorf("UnmarshalCycloneDXBOM() failed: %v", err)
+		return
+	}
+
+	// v2.0: component is in metadata, not components array
+	comp := document.GetCdxMetadataComponent()
+	if comp == nil {
+		t.Errorf("expected metadata.component to be populated for v2.0 fixture")
+		return
+	}
+
+	// v2.0: identifiers field should be populated
+	if comp.Identifiers == nil || len(*comp.Identifiers) == 0 {
+		t.Errorf("expected component.identifiers to be populated for v2.0 fixture")
+	}
+
+	// v2.0: parties field should be populated
+	if comp.Parties == nil || len(*comp.Parties) == 0 {
+		t.Errorf("expected component.parties to be populated for v2.0 fixture")
+	}
+}
+
+// -------------------------------------------
+// resource list
+// -------------------------------------------
+
+// TestResourceListCdx20ValidComponentPurl verifies that resource list with --variant development
+// on a CycloneDX v2.0 BOM correctly surfaces the purl extracted from identifiers[].identities[].
+func TestResourceListCdx20ValidComponentPurl(t *testing.T) {
+	utils.GlobalFlags.ValidateFlags.SchemaVariant = SCHEMA_VARIANT_DEVELOPMENT
+	defer func() { utils.GlobalFlags.ValidateFlags.SchemaVariant = SCHEMA_VARIANT_NONE }()
+
+	rti := NewResourceTestInfoBasic(
+		TEST_CDX_2_0_VALID_COMPONENT,
+		FORMAT_CSV,
+		nil,
+		schema.RESOURCE_TYPE_COMPONENT,
+	)
+	rti.ResultExpectedLineCount = 3 // title + 1 data row + EOF LF
+	rti.ResultLineContainsValuesAtLineNum = 1
+	rti.ResultLineContainsValues = []string{"pkg:npm/acme-corp/acme-lib@2.3.1"}
+	innerTestResourceList(t, rti)
+}
+
+// -------------------------------------------
+// component list
+// -------------------------------------------
+
+// TestComponentListCdx20ValidComponentPartiesCsv verifies that "component list" for a CycloneDX
+// v2.0 BOM correctly reads supplier, manufacturer, and publisher from the component's v2.0
+// "parties" array (not the legacy metadata.supplier / metadata.manufacturer direct fields).
+func TestComponentListCdx20ValidComponentPartiesCsv(t *testing.T) {
+	utils.GlobalFlags.ValidateFlags.SchemaVariant = SCHEMA_VARIANT_DEVELOPMENT
+	defer func() { utils.GlobalFlags.ValidateFlags.SchemaVariant = SCHEMA_VARIANT_NONE }()
+
+	ti := NewComponentTestInfoBasic(TEST_COMPONENT_LIST_CDX_2_0_VALID_COMPONENT, FORMAT_CSV, nil)
+	ti.ResultExpectedLineCount = 3 // title + 1 data row + EOF LF
+	ti.ResultLineContainsValuesAtLineNum = 1
+	// All three party roles must be sourced from parties[], not legacy direct fields
+	ti.ResultLineContainsValues = []string{"Acme Supplier Ltd", "Acme Manufacturing Inc", "Acme Corp"}
+	innerTestComponentList(t, ti, COMPONENT_TEST_DEFAULT_FLAGS)
+}
+
+// TestComponentListCdx20WhereManufacturerNameMatchCsv verifies that the --where filter on
+// "manufacturer-name" correctly matches the value resolved from a v2.0 "parties" array entry
+// with role "manufacturer" (positive case: one component must be returned).
+func TestComponentListCdx20WhereManufacturerNameMatchCsv(t *testing.T) {
+	utils.GlobalFlags.ValidateFlags.SchemaVariant = SCHEMA_VARIANT_DEVELOPMENT
+	defer func() { utils.GlobalFlags.ValidateFlags.SchemaVariant = SCHEMA_VARIANT_NONE }()
+
+	ti := NewComponentTestInfoBasic(TEST_COMPONENT_LIST_CDX_2_0_VALID_COMPONENT, FORMAT_CSV, nil)
+	ti.WhereClause = "manufacturer-name=Acme Manufacturing Inc"
+	ti.ResultExpectedLineCount = 3 // title + 1 data row + EOF LF
+	ti.ResultLineContainsValuesAtLineNum = 1
+	ti.ResultLineContainsValues = []string{"Acme Manufacturing Inc"}
+	innerTestComponentList(t, ti, COMPONENT_TEST_DEFAULT_FLAGS)
+}
+
+// TestComponentListCdx20WhereManufacturerNameNoMatchCsv verifies that the --where filter on
+// "manufacturer-name" correctly returns no results when the value does not match any component
+// party with role "manufacturer" in a v2.0 BOM (negative case).
+func TestComponentListCdx20WhereManufacturerNameNoMatchCsv(t *testing.T) {
+	utils.GlobalFlags.ValidateFlags.SchemaVariant = SCHEMA_VARIANT_DEVELOPMENT
+	defer func() { utils.GlobalFlags.ValidateFlags.SchemaVariant = SCHEMA_VARIANT_NONE }()
+
+	ti := NewComponentTestInfoBasic(TEST_COMPONENT_LIST_CDX_2_0_VALID_COMPONENT, FORMAT_CSV, errors.New(""))
+	ti.WhereClause = "manufacturer-name=NonExistentManufacturer"
+	innerTestComponentList(t, ti, COMPONENT_TEST_DEFAULT_FLAGS)
+}

--- a/cmd/component_test.go
+++ b/cmd/component_test.go
@@ -232,21 +232,3 @@ func TestComponentListCdx16EmptyDefnsDecls(t *testing.T) {
 	innerTestComponentList(t, ti, COMPONENT_TEST_DEFAULT_FLAGS)
 }
 
-// -------------------------------------------
-// CDX v2.0 variants
-// -------------------------------------------
-
-// TestComponentListCdx20ValidComponentPartiesCsv verifies that "component list" for a CycloneDX
-// v2.0 BOM correctly reads supplier, manufacturer, and publisher from the component's v2.0
-// "parties" array (not the legacy metadata.supplier / metadata.manufacturer direct fields).
-func TestComponentListCdx20ValidComponentPartiesCsv(t *testing.T) {
-	utils.GlobalFlags.ValidateFlags.SchemaVariant = SCHEMA_VARIANT_DEVELOPMENT
-	defer func() { utils.GlobalFlags.ValidateFlags.SchemaVariant = SCHEMA_VARIANT_NONE }()
-
-	ti := NewComponentTestInfoBasic(TEST_COMPONENT_LIST_CDX_2_0_VALID_COMPONENT, FORMAT_CSV, nil)
-	ti.ResultExpectedLineCount = 3 // title + 1 data row + EOF LF
-	ti.ResultLineContainsValuesAtLineNum = 1
-	// All three party roles must be sourced from parties[], not legacy direct fields
-	ti.ResultLineContainsValues = []string{"Acme Supplier Ltd", "Acme Manufacturing Inc", "Acme Corp"}
-	innerTestComponentList(t, ti, COMPONENT_TEST_DEFAULT_FLAGS)
-}

--- a/cmd/component_test.go
+++ b/cmd/component_test.go
@@ -41,6 +41,8 @@ const (
 	// test/cyclonedx/1.6/specification/valid-empty-defns-decls.json
 	// Test general BOM with empty top-level bom objects, but valid components
 	TEST_COMPONENT_LIST_CDX_1_6_SBOM = "test/cyclonedx/1.6/specification/valid-empty-defns-decls.json"
+	// test/cyclonedx/2.0/cdx-2-0-valid-component.json
+	TEST_COMPONENT_LIST_CDX_2_0_VALID_COMPONENT = TEST_CDX_2_0_VALID_COMPONENT
 )
 
 var COMPONENT_TEST_DEFAULT_FLAGS utils.ComponentCommandFlags
@@ -227,5 +229,24 @@ func TestComponentListCdx16ValidComponentTypes(t *testing.T) {
 
 func TestComponentListCdx16EmptyDefnsDecls(t *testing.T) {
 	ti := NewComponentTestInfoBasic(TEST_COMPONENT_LIST_CDX_1_6_SBOM, FORMAT_CSV, nil)
+	innerTestComponentList(t, ti, COMPONENT_TEST_DEFAULT_FLAGS)
+}
+
+// -------------------------------------------
+// CDX v2.0 variants
+// -------------------------------------------
+
+// TestComponentListCdx20ValidComponentPartiesCsv verifies that "component list" for a CycloneDX
+// v2.0 BOM correctly reads supplier, manufacturer, and publisher from the component's v2.0
+// "parties" array (not the legacy metadata.supplier / metadata.manufacturer direct fields).
+func TestComponentListCdx20ValidComponentPartiesCsv(t *testing.T) {
+	utils.GlobalFlags.ValidateFlags.SchemaVariant = SCHEMA_VARIANT_DEVELOPMENT
+	defer func() { utils.GlobalFlags.ValidateFlags.SchemaVariant = SCHEMA_VARIANT_NONE }()
+
+	ti := NewComponentTestInfoBasic(TEST_COMPONENT_LIST_CDX_2_0_VALID_COMPONENT, FORMAT_CSV, nil)
+	ti.ResultExpectedLineCount = 3 // title + 1 data row + EOF LF
+	ti.ResultLineContainsValuesAtLineNum = 1
+	// All three party roles must be sourced from parties[], not legacy direct fields
+	ti.ResultLineContainsValues = []string{"Acme Supplier Ltd", "Acme Manufacturing Inc", "Acme Corp"}
 	innerTestComponentList(t, ti, COMPONENT_TEST_DEFAULT_FLAGS)
 }

--- a/cmd/license_list.go
+++ b/cmd/license_list.go
@@ -87,7 +87,7 @@ var LICENSE_LIST_ROW_DATA = []ColumnFormatData{
 	*NewColumnFormatData(LICENSE_FILTER_KEY_LICENSE_TEXT_ENCODING, -1, false, false),
 	*NewColumnFormatData(LICENSE_FILTER_KEY_LICENSE_TEXT_CONTENT_TYPE, -1, false, false),
 	*NewColumnFormatData(LICENSE_FILTER_KEY_LICENSE_TEXT_CONTENT, 8, false, false),
-	*NewColumnFormatData(LICENSE_FILTER_KEY_PURL, REPORT_DO_NOT_TRUNCATE, false, false),
+	{DataKey: LICENSE_FILTER_KEY_PURL, TruncateLength: REPORT_DO_NOT_TRUNCATE, MarkdownEscape: REPORT_MARKDOWN_ESCAPE_TRUE},
 }
 
 // Command help formatting
@@ -463,7 +463,7 @@ func DisplayLicenseListMarkdown(bom *schema.BOM, writer io.Writer, flags utils.L
 		// Format each LicenseInfo as a line and write to output
 		for _, iInfo := range arrLicenseInfo {
 			licenseInfo = iInfo.(schema.LicenseInfo)
-			line, err = prepareReportLineData(
+			line, err = prepareReportLineDataMarkdown(
 				licenseInfo,
 				LICENSE_LIST_ROW_DATA,
 				flags.Summary,

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -166,6 +166,7 @@ func wrapTableRowText(maxChars int, joinChar string, columns ...interface{}) (ta
 // Report column data values
 const REPORT_SUMMARY_DATA = true
 const REPORT_REPLACE_LINE_FEEDS_TRUE = true
+const REPORT_MARKDOWN_ESCAPE_TRUE = true
 const REPORT_DO_NOT_TRUNCATE = -1
 
 // TODO: Support additional flags to:
@@ -179,6 +180,7 @@ type ColumnFormatData struct {
 	TruncateLength   int    // truncate character data to this length (default=-1 means don't truncate)
 	IsSummaryData    bool   // include in `--summary` reports
 	ReplaceLineFeeds bool   // replace line feeds with spaces (e.g., for multi-line descriptions)
+	MarkdownEscape   bool   // wrap value in backticks when rendering markdown (e.g., purl, cpe)
 	Alignment        string // Align column data where possible (i.e., This is primarily for markdown format)
 }
 
@@ -212,7 +214,16 @@ func prepareReportTitleData(formatData []ColumnFormatData, summarizedReport bool
 	return
 }
 
-func prepareReportLineData(structIn interface{}, formatData []ColumnFormatData, summarizedReport bool) (lineData []string, err error) {
+// prepareReportLineDataMarkdown is like prepareReportLineData but wraps string values in
+// backticks for columns marked with MarkdownEscape (e.g. purl, cpe) to prevent markdown
+// renderers from misinterpreting special characters like colons and asterisks.
+func prepareReportLineDataMarkdown(structIn interface{}, formatData []ColumnFormatData, summarizedReport bool) (lineData []string, err error) {
+	lineData, err = prepareReportLineData(structIn, formatData, summarizedReport, true)
+	return
+}
+
+func prepareReportLineData(structIn interface{}, formatData []ColumnFormatData, summarizedReport bool, markdownFormat ...bool) (lineData []string, err error) {
+	isMarkdown := len(markdownFormat) > 0 && markdownFormat[0]
 	var mapStruct map[string]interface{}
 	var data interface{}
 	var dataFound bool
@@ -248,6 +259,11 @@ func prepareReportLineData(structIn interface{}, formatData []ColumnFormatData, 
 				if columnData.ReplaceLineFeeds {
 					// For tabbed text tables, replace line feeds with spaces
 					typedData = strings.ReplaceAll(typedData, "\n", " ")
+				}
+				if isMarkdown && columnData.MarkdownEscape {
+					// Wrap in backticks so markdown renderers treat it as code
+					// (prevents colons and asterisks in purl/cpe from being interpreted)
+					typedData = fmt.Sprintf("`%s`", typedData)
 				}
 			}
 			lineData = append(lineData, typedData)

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -59,7 +59,7 @@ var RESOURCE_LIST_ROW_DATA = []ColumnFormatData{
 	*NewColumnFormatData(RESOURCE_FILTER_KEY_NAME, REPORT_DO_NOT_TRUNCATE, REPORT_SUMMARY_DATA, false),
 	*NewColumnFormatData(RESOURCE_FILTER_KEY_VERSION, REPORT_DO_NOT_TRUNCATE, REPORT_SUMMARY_DATA, false),
 	*NewColumnFormatData(RESOURCE_FILTER_KEY_DESCRIPTION, REPORT_DO_NOT_TRUNCATE, REPORT_SUMMARY_DATA, REPORT_REPLACE_LINE_FEEDS_TRUE),
-	*NewColumnFormatData(RESOURCE_FILTER_KEY_PURL, REPORT_DO_NOT_TRUNCATE, REPORT_SUMMARY_DATA, false),
+	{DataKey: RESOURCE_FILTER_KEY_PURL, TruncateLength: REPORT_DO_NOT_TRUNCATE, IsSummaryData: REPORT_SUMMARY_DATA, MarkdownEscape: REPORT_MARKDOWN_ESCAPE_TRUE},
 }
 
 // Flags. Reuse query flag values where possible
@@ -405,7 +405,7 @@ func DisplayResourceListMarkdown(bom *schema.BOM, writer io.Writer) (err error) 
 	var line []string
 	var lineRow string
 	for _, entry := range entries {
-		line, err = prepareReportLineData(
+		line, err = prepareReportLineDataMarkdown(
 			entry.Value.(schema.CDXResourceInfo),
 			RESOURCE_LIST_ROW_DATA,
 			true,

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -49,6 +49,7 @@ const (
 	RESOURCE_FILTER_KEY_BOMREF        = "bom-ref"
 	RESOURCE_FILTER_KEY_GROUP         = "group"
 	RESOURCE_FILTER_KEY_DESCRIPTION   = "description"
+	RESOURCE_FILTER_KEY_PURL          = "purl"
 )
 
 var RESOURCE_LIST_ROW_DATA = []ColumnFormatData{
@@ -58,6 +59,7 @@ var RESOURCE_LIST_ROW_DATA = []ColumnFormatData{
 	*NewColumnFormatData(RESOURCE_FILTER_KEY_NAME, REPORT_DO_NOT_TRUNCATE, REPORT_SUMMARY_DATA, false),
 	*NewColumnFormatData(RESOURCE_FILTER_KEY_VERSION, REPORT_DO_NOT_TRUNCATE, REPORT_SUMMARY_DATA, false),
 	*NewColumnFormatData(RESOURCE_FILTER_KEY_DESCRIPTION, REPORT_DO_NOT_TRUNCATE, REPORT_SUMMARY_DATA, REPORT_REPLACE_LINE_FEEDS_TRUE),
+	*NewColumnFormatData(RESOURCE_FILTER_KEY_PURL, REPORT_DO_NOT_TRUNCATE, REPORT_SUMMARY_DATA, false),
 }
 
 // Flags. Reuse query flag values where possible
@@ -85,6 +87,7 @@ func NewCommandResource() *cobra.Command {
 	command.Long = "Report on resources (i.e., components, services) found in the BOM input file"
 	command.Flags().StringVarP(&utils.GlobalFlags.PersistentFlags.OutputFormat, FLAG_FILE_OUTPUT_FORMAT, "", FORMAT_TEXT,
 		FLAG_RESOURCE_OUTPUT_FORMAT_HELP+RESOURCE_LIST_OUTPUT_SUPPORTED_FORMATS)
+	command.Flags().StringVarP(&utils.GlobalFlags.ValidateFlags.SchemaVariant, FLAG_VALIDATE_SCHEMA_VARIANT, "", "", MSG_VALIDATE_SCHEMA_VARIANT)
 	command.Flags().StringP(FLAG_RESOURCE_TYPE, "", schema.RESOURCE_TYPE_DEFAULT, FLAG_RESOURCE_TYPE_HELP)
 	command.Flags().StringP(FLAG_REPORT_WHERE, "", "", FLAG_REPORT_WHERE_HELP)
 	command.RunE = resourceCmdImpl

--- a/cmd/resource_test.go
+++ b/cmd/resource_test.go
@@ -310,24 +310,3 @@ func TestResourceListUsingStdin(t *testing.T) {
 	innerTestResourceList(t, rti)
 }
 
-// -------------------------------------------
-// CDX 2.0 variant
-// -------------------------------------------
-
-// TestResourceListCdx20ValidComponentPurl verifies that resource list with --variant development
-// on a CycloneDX v2.0 BOM correctly surfaces the purl extracted from identifiers[].identities[].
-func TestResourceListCdx20ValidComponentPurl(t *testing.T) {
-	utils.GlobalFlags.ValidateFlags.SchemaVariant = SCHEMA_VARIANT_DEVELOPMENT
-	defer func() { utils.GlobalFlags.ValidateFlags.SchemaVariant = SCHEMA_VARIANT_NONE }()
-
-	rti := NewResourceTestInfoBasic(
-		TEST_CDX_2_0_VALID_COMPONENT,
-		FORMAT_CSV,
-		nil,
-		schema.RESOURCE_TYPE_COMPONENT,
-	)
-	rti.ResultExpectedLineCount = 3 // title + 1 data row + EOF LF
-	rti.ResultLineContainsValuesAtLineNum = 1
-	rti.ResultLineContainsValues = []string{"pkg:npm/acme-corp/acme-lib@2.3.1"}
-	innerTestResourceList(t, rti)
-}

--- a/cmd/resource_test.go
+++ b/cmd/resource_test.go
@@ -309,3 +309,25 @@ func TestResourceListUsingStdin(t *testing.T) {
 	rti.MockStdin = true
 	innerTestResourceList(t, rti)
 }
+
+// -------------------------------------------
+// CDX 2.0 variant
+// -------------------------------------------
+
+// TestResourceListCdx20ValidComponentPurl verifies that resource list with --variant development
+// on a CycloneDX v2.0 BOM correctly surfaces the purl extracted from identifiers[].identities[].
+func TestResourceListCdx20ValidComponentPurl(t *testing.T) {
+	utils.GlobalFlags.ValidateFlags.SchemaVariant = SCHEMA_VARIANT_DEVELOPMENT
+	defer func() { utils.GlobalFlags.ValidateFlags.SchemaVariant = SCHEMA_VARIANT_NONE }()
+
+	rti := NewResourceTestInfoBasic(
+		TEST_CDX_2_0_VALID_COMPONENT,
+		FORMAT_CSV,
+		nil,
+		schema.RESOURCE_TYPE_COMPONENT,
+	)
+	rti.ResultExpectedLineCount = 3 // title + 1 data row + EOF LF
+	rti.ResultLineContainsValuesAtLineNum = 1
+	rti.ResultLineContainsValues = []string{"pkg:npm/acme-corp/acme-lib@2.3.1"}
+	innerTestResourceList(t, rti)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,7 @@ const (
 	CMD_USAGE_LICENSE_LIST       = SUBCOMMAND_LICENSE_LIST + " --input-file <input_file> [--summary] [--where key=regex[,...]] [--format json|txt|csv|md]"
 	CMD_USAGE_LICENSE_POLICY     = SUBCOMMAND_LICENSE_POLICY + " [--where key=regex[,...]] [--format txt|csv|md]"
 	CMD_USAGE_QUERY              = CMD_QUERY + " --input-file <input_file> [--select * | field1[,fieldN]] [--from key1[.keyN]] [--where key=regex[,...]]"
-	CMD_USAGE_RESOURCE_LIST      = CMD_RESOURCE + " --input-file <input_file> [--type component|service] [--where key=regex[,...]] [--format txt|csv|md]"
+	CMD_USAGE_RESOURCE_LIST      = CMD_RESOURCE + " --input-file <input_file> [--variant <variant_name>] [--type component|service] [--where key=regex[,...]] [--format txt|csv|md]"
 	CMD_USAGE_SCHEMA_LIST        = CMD_SCHEMA + " [--where key=regex[,...]] [--format txt|csv|md]"
 	CMD_USAGE_VALIDATE           = CMD_VALIDATE + " --input-file <input_file> [--variant <variant_name>] [--format txt|json] [--force schema_file]"
 	CMD_USAGE_VULNERABILITY_LIST = CMD_VULNERABILITY + " " + SUBCOMMAND_VULNERABILITY_LIST + " --input-file <input_file> [--summary] [--where key=regex[,...]] [--format json|txt|csv|md]"

--- a/cmd/validate_cdx_test.go
+++ b/cmd/validate_cdx_test.go
@@ -28,6 +28,7 @@ const (
 	TEST_CDX_1_5_MIN_REQUIRED = "test/cyclonedx/1.5/cdx-1-5-min-required.json"
 	TEST_CDX_1_6_MIN_REQUIRED = "test/cyclonedx/1.6/cdx-1-6-min-required.json"
 	TEST_CDX_1_7_MIN_REQUIRED = "test/cyclonedx/1.7/cdx-1-7-min-required.json"
+	TEST_CDX_2_0_MIN_REQUIRED = "test/cyclonedx/2.0/cdx-2-0-min-required.json"
 )
 
 // Tests for MLBOM subtypes
@@ -81,6 +82,10 @@ const (
 )
 
 const (
+	TEST_CDX_2_0_VALID_COMPONENT = "test/cyclonedx/2.0/cdx-2-0-valid-component.json"
+)
+
+const (
 	TEST_CDX_SPEC_1_7_VALID_CRYPTO_CITATION = "test/cyclonedx/1.7/cdx-1-7-valid-crypto-citation.json"
 	TEST_CDX_SPEC_1_7_COMP_VERSION_RANGE    = "test/cyclonedx/1.7/cdx-1-7-comp-version-range.json"
 
@@ -129,6 +134,46 @@ func TestValidateCdx16MinRequiredBasic(t *testing.T) {
 func TestValidateCdx17MinRequiredBasic(t *testing.T) {
 	vti := NewValidateTestInfoMinimum(TEST_CDX_1_7_MIN_REQUIRED)
 	innerTestValidate(t, *vti)
+}
+
+// TestValidateCdx20MinRequiredBasic verifies that a CycloneDX v2.0 BOM using the
+// renamed "specFormat" key (replacing "bomFormat") is correctly identified, validated,
+// and unmarshalled into the CDXBom struct with SpecFormat populated.
+func TestValidateCdx20MinRequiredBasic(t *testing.T) {
+	const EXPECTED_SPEC_FORMAT = "CycloneDX"
+	const EXPECTED_SPEC_VERSION = "2.0"
+
+	vti := NewValidateTestInfo(TEST_CDX_2_0_MIN_REQUIRED, FORMAT_TEXT, SCHEMA_VARIANT_DEVELOPMENT, nil)
+	document, _, err := innerTestValidate(t, *vti)
+	if err != nil {
+		// innerTestValidate already calls t.Errorf; just return to avoid nil-deref below
+		return
+	}
+
+	// Unmarshal into CDX structs so we can inspect the Go model.
+	if err = document.UnmarshalCycloneDXBOM(); err != nil {
+		t.Errorf("UnmarshalCycloneDXBOM() failed: %v", err)
+		return
+	}
+
+	// Assert the v2.0 specFormat key was decoded into SpecFormat (not BOMFormat).
+	if got := document.GetCdxSpecFormat(); got != EXPECTED_SPEC_FORMAT {
+		t.Errorf("SpecFormat: expected %q, got %q", EXPECTED_SPEC_FORMAT, got)
+	}
+
+	// Assert specVersion is preserved correctly.
+	if cdxBom := document.GetCdxBom(); cdxBom == nil || cdxBom.SpecVersion != EXPECTED_SPEC_VERSION {
+		var got string
+		if cdxBom != nil {
+			got = cdxBom.SpecVersion
+		}
+		t.Errorf("SpecVersion: expected %q, got %q", EXPECTED_SPEC_VERSION, got)
+	}
+
+	// Assert BOMFormat is empty (not set by a v2.0 document).
+	if cdxBom := document.GetCdxBom(); cdxBom != nil && cdxBom.BOMFormat != "" {
+		t.Errorf("BOMFormat: expected empty string for v2.0 document, got %q", cdxBom.BOMFormat)
+	}
 }
 
 func TestValidateCdx13Mature(t *testing.T) {
@@ -320,4 +365,41 @@ func TestValidateCdx17ValidSignatures(t *testing.T) {
 func TestValidateCdx17ValidStandard(t *testing.T) {
 	vti := NewValidateTestInfoMinimum(TEST_CDX_SPEC_1_7_VALID_STANDARD)
 	innerTestValidate(t, *vti)
+}
+
+// 2.0 Tests
+
+// TestValidateCdx20ValidComponent verifies that a CycloneDX v2.0 BOM containing a single
+// component with v2.0-only fields (identifiers, parties, implementationPlatform as []string)
+// is correctly validated and unmarshalled into the CDXComponent struct.
+func TestValidateCdx20ValidComponent(t *testing.T) {
+	vti := NewValidateTestInfo(TEST_CDX_2_0_VALID_COMPONENT, FORMAT_TEXT, SCHEMA_VARIANT_DEVELOPMENT, nil)
+	document, _, err := innerTestValidate(t, *vti)
+	if err != nil {
+		return
+	}
+
+	if err = document.UnmarshalCycloneDXBOM(); err != nil {
+		t.Errorf("UnmarshalCycloneDXBOM() failed: %v", err)
+		return
+	}
+
+	components := document.GetCdxComponents()
+	if components == nil || len(*components) != 1 {
+		t.Errorf("expected 1 component, got %v", components)
+		return
+	}
+
+	comp := (*components)[0]
+
+	// v2.0: identifiers field should be populated
+	if comp.Identifiers == nil || len(*comp.Identifiers) == 0 {
+		t.Errorf("expected component.identifiers to be populated for v2.0 fixture")
+	}
+
+	// v2.0: parties field should be populated
+	if comp.Parties == nil || len(*comp.Parties) == 0 {
+		t.Errorf("expected component.parties to be populated for v2.0 fixture")
+	}
+
 }

--- a/cmd/validate_cdx_test.go
+++ b/cmd/validate_cdx_test.go
@@ -136,46 +136,6 @@ func TestValidateCdx17MinRequiredBasic(t *testing.T) {
 	innerTestValidate(t, *vti)
 }
 
-// TestValidateCdx20MinRequiredBasic verifies that a CycloneDX v2.0 BOM using the
-// renamed "specFormat" key (replacing "bomFormat") is correctly identified, validated,
-// and unmarshalled into the CDXBom struct with SpecFormat populated.
-func TestValidateCdx20MinRequiredBasic(t *testing.T) {
-	const EXPECTED_SPEC_FORMAT = "CycloneDX"
-	const EXPECTED_SPEC_VERSION = "2.0"
-
-	vti := NewValidateTestInfo(TEST_CDX_2_0_MIN_REQUIRED, FORMAT_TEXT, SCHEMA_VARIANT_DEVELOPMENT, nil)
-	document, _, err := innerTestValidate(t, *vti)
-	if err != nil {
-		// innerTestValidate already calls t.Errorf; just return to avoid nil-deref below
-		return
-	}
-
-	// Unmarshal into CDX structs so we can inspect the Go model.
-	if err = document.UnmarshalCycloneDXBOM(); err != nil {
-		t.Errorf("UnmarshalCycloneDXBOM() failed: %v", err)
-		return
-	}
-
-	// Assert the v2.0 specFormat key was decoded into SpecFormat (not BOMFormat).
-	if got := document.GetCdxSpecFormat(); got != EXPECTED_SPEC_FORMAT {
-		t.Errorf("SpecFormat: expected %q, got %q", EXPECTED_SPEC_FORMAT, got)
-	}
-
-	// Assert specVersion is preserved correctly.
-	if cdxBom := document.GetCdxBom(); cdxBom == nil || cdxBom.SpecVersion != EXPECTED_SPEC_VERSION {
-		var got string
-		if cdxBom != nil {
-			got = cdxBom.SpecVersion
-		}
-		t.Errorf("SpecVersion: expected %q, got %q", EXPECTED_SPEC_VERSION, got)
-	}
-
-	// Assert BOMFormat is empty (not set by a v2.0 document).
-	if cdxBom := document.GetCdxBom(); cdxBom != nil && cdxBom.BOMFormat != "" {
-		t.Errorf("BOMFormat: expected empty string for v2.0 document, got %q", cdxBom.BOMFormat)
-	}
-}
-
 func TestValidateCdx13Mature(t *testing.T) {
 	vti := NewValidateTestInfoMinimum(TEST_CDX_1_3_MATURE_EXAMPLE_1_BASE)
 	innerTestValidate(t, *vti)
@@ -367,38 +327,3 @@ func TestValidateCdx17ValidStandard(t *testing.T) {
 	innerTestValidate(t, *vti)
 }
 
-// 2.0 Tests
-
-// TestValidateCdx20ValidComponent verifies that a CycloneDX v2.0 BOM containing a single
-// component with v2.0-only fields (identifiers, parties, implementationPlatform as []string)
-// is correctly validated and unmarshalled into the CDXComponent struct.
-func TestValidateCdx20ValidComponent(t *testing.T) {
-	vti := NewValidateTestInfo(TEST_CDX_2_0_VALID_COMPONENT, FORMAT_TEXT, SCHEMA_VARIANT_DEVELOPMENT, nil)
-	document, _, err := innerTestValidate(t, *vti)
-	if err != nil {
-		return
-	}
-
-	if err = document.UnmarshalCycloneDXBOM(); err != nil {
-		t.Errorf("UnmarshalCycloneDXBOM() failed: %v", err)
-		return
-	}
-
-	// v2.0: component is in metadata, not components array
-	comp := document.GetCdxMetadataComponent()
-	if comp == nil {
-		t.Errorf("expected metadata.component to be populated for v2.0 fixture")
-		return
-	}
-
-	// v2.0: identifiers field should be populated
-	if comp.Identifiers == nil || len(*comp.Identifiers) == 0 {
-		t.Errorf("expected component.identifiers to be populated for v2.0 fixture")
-	}
-
-	// v2.0: parties field should be populated
-	if comp.Parties == nil || len(*comp.Parties) == 0 {
-		t.Errorf("expected component.parties to be populated for v2.0 fixture")
-	}
-
-}

--- a/cmd/validate_cdx_test.go
+++ b/cmd/validate_cdx_test.go
@@ -384,13 +384,12 @@ func TestValidateCdx20ValidComponent(t *testing.T) {
 		return
 	}
 
-	components := document.GetCdxComponents()
-	if components == nil || len(*components) != 1 {
-		t.Errorf("expected 1 component, got %v", components)
+	// v2.0: component is in metadata, not components array
+	comp := document.GetCdxMetadataComponent()
+	if comp == nil {
+		t.Errorf("expected metadata.component to be populated for v2.0 fixture")
 		return
 	}
-
-	comp := (*components)[0]
 
 	// v2.0: identifiers field should be populated
 	if comp.Identifiers == nil || len(*comp.Identifiers) == 0 {

--- a/docs/cdx-v2.0-gap-analysis.md
+++ b/docs/cdx-v2.0-gap-analysis.md
@@ -1,0 +1,170 @@
+# CycloneDX v2.0 — Go Struct Gap Analysis (P0–P4)
+
+**Branch:** `cdx-2`  
+**Schema:** `resources/schema/cyclonedx/2.0/cyclonedx-2.0-bundled.schema.json`  
+**Status:** Pre-release / early development
+
+---
+
+## Already Done
+
+| Item | File | Status |
+|------|------|--------|
+| Schema file | `resources/schema/cyclonedx/2.0/cyclonedx-2.0-bundled.schema.json` | ✅ present |
+| config.json v2.0 entry | `resources/config/config.json` | ✅ present (`version=2.0`, `variant=development`, `specFormat` key group) |
+| `PROPKEY_ID_CYCLONEDX_V2` constant | `schema/constants.go` | ✅ present (`"specFormat"`) |
+
+---
+
+## P0 — `CDXBom` top-level breaking changes
+
+**File:** `schema/cyclonedx.go`
+
+| Field | v1.x | v2.0 | Action |
+|-------|------|------|--------|
+| `BOMFormat` | `json:"bomFormat"` | `json:"specFormat"` | **CHANGE** — key renamed; `PROPKEY_ID_CYCLONEDX_V2` constant already set; BOM struct needs a parallel field or unmarshal logic must handle both |
+| `Signature` | `*JSFSignature` (single, JSF 0.82) | `signatures` (array, JSS/ITU-T X.590) | **CHANGE** — add `Signatures *[]JSFSignature`; keep old `Signature` with `cdx:"-2.0"` for backward compat |
+| `Perspectives` | — | new top-level array | **ADD** — `Perspectives *[]CDXPerspective` (new type, see P4) |
+
+> Root cause: v2.0 renames the format discriminator key (`bomFormat` → `specFormat`) and shifts from a single JSF 0.82 signature object to an array of JSS/X.590 signatures.
+
+---
+
+## P1 — `CDXComponent` mass field removal + new identity model
+
+**File:** `schema/cyclonedx.go`
+
+v2.0 removes flat identifier fields and replaces them with a structured identity model (`parties` + `identifiers`).
+
+### Fields removed in v2.0
+
+| Field | Last version | Action |
+|-------|-------------|--------|
+| `Purl` | v1.x | **REMOVE** (v2.0); annotate `cdx:"-2.0"` |
+| `Cpe` | v1.x | **REMOVE** (v2.0); annotate `cdx:"-2.0"` |
+| `Swid` | v1.x | **REMOVE** (v2.0); annotate `cdx:"-2.0"` |
+| `OmniborId` | added v1.6 | **REMOVE** (v2.0); annotate `cdx:"-2.0"` |
+| `Swhid` | added v1.6 | **REMOVE** (v2.0); annotate `cdx:"-2.0"` |
+| `Author` | deprecated v1.6 | **REMOVE** (v2.0); annotate `cdx:"-2.0"` |
+| `Modified` | deprecated v1.4 | **REMOVE** (v2.0); annotate `cdx:"-2.0"` |
+| `Publisher` | v1.x | **REMOVE** (v2.0); annotate `cdx:"-2.0"` |
+| `Supplier` | v1.x | **REMOVE** (v2.0); annotate `cdx:"-2.0"` |
+| `Manufacturer` | added v1.6 | **REMOVE** (v2.0); annotate `cdx:"-2.0"` |
+| `Signature` | added v1.4 | **CHANGE** → `Signatures` array |
+
+### Fields added in v2.0
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `Parties` | `*[]CDXParty` | New structured identity party model (see P4) |
+| `Identifiers` | `*[]CDXComponentIdentifier` | Structured identity claims replacing flat purl/cpe/swid |
+| `Signatures` | `*[]JSFSignature` | Array replaces single `Signature` |
+
+> **Strategy:** Because `CDXComponent` is shared across v1.2–v2.0, removed fields should be kept with `omitempty` and annotated `cdx:"-2.0"`; new fields annotated `cdx:"+2.0"`.
+
+---
+
+## P2 — `CDXMetadata` — `distributionConstraints` not wired up
+
+**File:** `schema/cyclonedx.go`
+
+> ✅ `CDXDistributionConstraints` type is already defined in `schema/cyclonedx_patents.go` — it just needs to be added as a field on `CDXMetadata`.
+
+| Field | v1.x | v2.0 | Action |
+|-------|------|------|--------|
+| `DistributionConstraints` | — | `distributionConstraints` object (contains `tlp`) | **ADD** `DistributionConstraints *CDXDistributionConstraints \`json:"distributionConstraints,omitempty" cdx:"+2.0"\`` |
+
+The TLP enum values (`CLEAR`, `GREEN`, `AMBER`, `AMBER_AND_STRICT`, `RED`) are already modelled by `CDXTlpClassification` in `cyclonedx_patents.go` — no new types needed.
+
+---
+
+## P3 — Crypto struct field changes (v1.7 → v2.0)
+
+**File:** `schema/cyclonedx_crypto.go`
+
+### `CDXAlgorithmProperties`
+
+| Field | v1.7 | v2.0 | Action |
+|-------|------|------|--------|
+| `Curve` | deprecated v1.7 | removed | **REMOVE** (v2.0); annotate `cdx:"-2.0"` |
+| `ImplementationPlatform` | `interface{}` (string or `[]string` workaround) | `[]string` only | **CHANGE** — can now be `*[]string`; `interface{}` workaround was for this exact transition. Keep `interface{}` or branch on specVersion. |
+| `SecProperties` | — | `[]string` | **ADD** `SecProperties *[]string \`json:"secProperties,omitempty" cdx:"+2.0"\`` |
+
+### `CDXCertificateProperties`
+
+| Field | v1.7 | v2.0 | Action |
+|-------|------|------|--------|
+| `SignatureAlgorithmRef` | deprecated v1.7 | removed | **REMOVE** (v2.0); annotate `cdx:"-2.0"` |
+| `SubjectPublicKeyRef` | deprecated v1.7 | removed | **REMOVE** (v2.0); annotate `cdx:"-2.0"` |
+| `CertificateState` | `*CDXCertificateState` (single object) | `[]CDXCertificateState` (array) | **CHANGE** → `*[]CDXCertificateState` |
+
+### `CDXRelatedCryptoMaterialProperties`
+
+| Field | v1.7 | v2.0 | Action |
+|-------|------|------|--------|
+| `AlgorithmRef` | added v1.6 | removed | **REMOVE** (v2.0); annotate `cdx:"-2.0"` |
+| `KeyUsage` | — | `[]string` | **ADD** `KeyUsage *[]string \`json:"keyUsage,omitempty" cdx:"+2.0"\`` |
+
+### `CDXProtocolProperties`
+
+| Field | v1.7 | v2.0 | Action |
+|-------|------|------|--------|
+| `CryptoRefArray` | deprecated v1.7 | removed | **REMOVE** (v2.0); annotate `cdx:"-2.0"` |
+
+---
+
+## P4 — New types + signatures-as-arrays throughout
+
+### Signatures propagation
+
+Old `Signature` fields must be retained with `cdx:"-2.0"` so v1.x documents continue to unmarshal correctly.
+
+| Struct | File | Current | v2.0 addition |
+|--------|------|---------|----------------|
+| `CDXBom` | `cyclonedx.go` | `Signature *JSFSignature` | Add `Signatures *[]JSFSignature \`cdx:"+2.0"\`` |
+| `CDXComponent` | `cyclonedx.go` | `Signature *JSFSignature` | Add `Signatures *[]JSFSignature \`cdx:"+2.0"\`` |
+| `CDXService` | `cyclonedx.go` | `Signature *JSFSignature` | Add `Signatures *[]JSFSignature \`cdx:"+2.0"\`` |
+| `CDXDeclaration` | `cyclonedx_declarations.go` | `Signature *JSFSignature` | Add `Signatures *[]JSFSignature \`cdx:"+2.0"\`` |
+
+### New file: `schema/cyclonedx_party.go`
+
+v2.0 introduces a rich party module replacing flat `supplier`/`manufacturer` on `CDXComponent`.
+
+| New Go type | Schema definition | Key fields |
+|-------------|-------------------|------------|
+| `CDXParty` | `cyclonedx-party-2.0 / party` | `BOMRef`, `Roles`, `Organization`, `Person`, `System`, `Persona`, `Relations`, `Tags`, `Properties`, `ExternalReferences` |
+| `CDXPartyOrganization` | `organization` | `Name`, `LegalName`, `Description`, `Jurisdiction`, `Identifiers`, `FormerNames`, `Aliases`, `Url`, `Addresses` |
+| `CDXPartyPerson` | `person` | `Name`, `SortName`, `HonorificPrefix`, `HonorificSuffix`, `JobTitle`, `Email`, `Phone`, `Url`, `Address`, `Affiliation` |
+| `CDXPartySystem` | `system` | `Kind`, `Ref`, `Identifiers`, `Permissions` |
+| `CDXPartyPersona` | `persona` | (mirrors person with contextual attributes) |
+| `CDXPartyRole` | `role` | Pre-defined or custom role string |
+| `CDXPartyRelation` | `partyRelations` | Typed relationships between parties |
+| `CDXComponentIdentifier` | `identifier` | `BOMRef`, `Party`, `Identities` (replaces flat purl/cpe/swid) |
+
+### New type: `CDXPerspective`
+
+Added to `schema/cyclonedx.go` or a new `schema/cyclonedx_perspectives.go`.
+
+| Field | Type |
+|-------|------|
+| `BOMRef` | `*CDXRefType` |
+| `Name` | `string` |
+| `Description` | `string` |
+| `Domains` | `*[]interface{}` (oneOf: pre-defined enum string or custom object) |
+| `Mappings` | `*[]CDXPerspectiveMapping` |
+| `ExternalReferences` | `*[]CDXExternalReference` |
+| `Properties` | `*[]CDXProperty` |
+
+`CDXPerspectiveMapping` fields: `Expression`, `NativeName`, `NativeDescription`, `Relevance`, `Weight`, `Rationale`.
+
+---
+
+## Work Items by File
+
+| File | Priority | Summary |
+|------|----------|---------|
+| `schema/cyclonedx.go` | P0, P1, P2 | `CDXBom`: `specFormat` field, `Signatures`, `Perspectives`; `CDXComponent`: remove 10 dropped fields, add `Parties`/`Identifiers`/`Signatures`; `CDXMetadata`: add `DistributionConstraints`; `CDXService`: add `Signatures` |
+| `schema/cyclonedx_crypto.go` | P3 | Add `SecProperties`; mark `Curve` deprecated; `CertificateState` → array; remove deprecated refs/`AlgorithmRef`/`CryptoRefArray`; add `KeyUsage` |
+| `schema/cyclonedx_declarations.go` | P4 | `CDXDeclaration`: add `Signatures *[]JSFSignature` |
+| `schema/cyclonedx_party.go` *(new)* | P4 | `CDXParty`, `CDXPartyOrganization`, `CDXPartyPerson`, `CDXPartySystem`, `CDXPartyPersona`, `CDXPartyRole`, `CDXPartyRelation`, `CDXComponentIdentifier` |
+| `schema/cyclonedx_perspectives.go` *(new)* | P4 | `CDXPerspective`, `CDXPerspectiveMapping` |

--- a/resources/config/config.json
+++ b/resources/config/config.json
@@ -166,6 +166,16 @@
                     "dependencies": ["jsf-0.82.schema.json", "spdx.schema.json", "cryptography-defs.schema.json"]
                 },
                 {
+                    "version": "2.0",
+                    "variant": "development",
+                    "name": "CycloneDX v2.0 (pre-release)",
+                    "file": "schema/cyclonedx/2.0/cyclonedx-2.0-bundled.schema.json",
+                    "development": "https://github.com/CycloneDX/specification/blob/2.0-dev/schema/2.0/cyclonedx-2.0-bundled.schema.json",
+                    "url": "https://raw.githubusercontent.com/CycloneDX/specification/2.0-dev/schema/2.0/cyclonedx-2.0-bundled.schema.json",
+                    "default": false,
+                    "dependencies": []
+                },
+                {
                     "version": "1.3",
                     "variant": "custom",
                     "name": "CycloneDX v1.3",

--- a/resources/config/config.json
+++ b/resources/config/config.json
@@ -166,16 +166,6 @@
                     "dependencies": ["jsf-0.82.schema.json", "spdx.schema.json", "cryptography-defs.schema.json"]
                 },
                 {
-                    "version": "2.0",
-                    "variant": "development",
-                    "name": "CycloneDX v2.0 (pre-release)",
-                    "file": "schema/cyclonedx/2.0/cyclonedx-2.0-bundled.schema.json",
-                    "development": "https://github.com/CycloneDX/specification/blob/2.0-dev/schema/2.0/cyclonedx-2.0-bundled.schema.json",
-                    "url": "https://raw.githubusercontent.com/CycloneDX/specification/2.0-dev/schema/2.0/cyclonedx-2.0-bundled.schema.json",
-                    "default": false,
-                    "dependencies": []
-                },
-                {
                     "version": "1.3",
                     "variant": "custom",
                     "name": "CycloneDX v1.3",
@@ -194,6 +184,24 @@
                     "url": "",
                     "default": false,
                     "dependencies": ["jsf-0.82.schema.json", "spdx.schema.json"]
+                }
+            ]
+        },
+        {
+            "canonicalName": "CycloneDX",
+            "propertyKeyFormat": "specFormat",
+            "propertyKeyVersion": "specVersion",
+            "propertyValueFormat": "CycloneDX",
+            "schemas": [
+                {
+                    "version": "2.0",
+                    "variant": "development",
+                    "name": "CycloneDX v2.0 (pre-release)",
+                    "file": "schema/cyclonedx/2.0/cyclonedx-2.0-bundled.schema.json",
+                    "development": "https://github.com/CycloneDX/specification/blob/2.0-dev/schema/2.0/cyclonedx-2.0-bundled.schema.json",
+                    "url": "https://raw.githubusercontent.com/CycloneDX/specification/2.0-dev/schema/2.0/cyclonedx-2.0-bundled.schema.json",
+                    "default": true,
+                    "dependencies": []
                 }
             ]
         }

--- a/resources/schema/cyclonedx/2.0/cyclonedx-2.0-bundled.schema.json
+++ b/resources/schema/cyclonedx/2.0/cyclonedx-2.0-bundled.schema.json
@@ -1,0 +1,9025 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyclonedx.org/schema/2.0/cyclonedx-2.0.schema.json",
+  "type": "object",
+  "title": "CycloneDX Transparency Expression Language",
+  "$comment": "OWASP CycloneDX is an Ecma International standard (ECMA-424) developed in collaboration between the OWASP Foundation and Ecma Technical Committee 54 (TC54). The standard is published under a royalty-free patent policy. This JSON schema is the reference implementation and is licensed under the Apache License 2.0.",
+  "required": [
+    "specFormat",
+    "specVersion"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "specFormat": {
+      "type": "string",
+      "title": "Specification Format",
+      "description": "Specifies the format. This value shall be \"CycloneDX\".",
+      "enum": [
+        "CycloneDX"
+      ]
+    },
+    "specVersion": {
+      "type": "string",
+      "title": "Specification Version",
+      "description": "The version of the CycloneDX specification the BOM conforms to.",
+      "examples": [
+        "2.0"
+      ]
+    },
+    "serialNumber": {
+      "type": "string",
+      "title": "BOM Serial Number",
+      "description": "Every BOM generated SHOULD have a unique serial number, even if the contents of the BOM have not changed over time. If specified, the serial number must conform to [RFC 4122](https://www.ietf.org/rfc/rfc4122.html). Use of serial numbers is recommended.",
+      "examples": [
+        "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
+      ],
+      "pattern": "^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
+    "version": {
+      "type": "integer",
+      "title": "BOM Version",
+      "description": "Whenever an existing BOM is modified, either manually or through automated processes, the version of the BOM SHOULD be incremented by 1. When a system is presented with multiple BOMs with identical serial numbers, the system SHOULD use the most recent version of the BOM. The default version is '1'.",
+      "minimum": 1,
+      "default": 1
+    },
+    "metadata": {
+      "$ref": "#/$defs/cyclonedx-metadata-2.0/$defs/metadata"
+    },
+    "components": {
+      "$ref": "#/$defs/cyclonedx-component-2.0/$defs/components",
+      "description": "A collection of components. When a metadata component is present, this array represents the inventory of components associated with that subject, forming a bill of materials. When the metadata component is omitted, the array provides component data for interchange purposes without establishing a compositional relationship."
+    },
+    "services": {
+      "$ref": "#/$defs/cyclonedx-service-2.0/$defs/services"
+    },
+    "dependencies": {
+      "$ref": "#/$defs/cyclonedx-dependency-2.0/$defs/dependencies"
+    },
+    "compositions": {
+      "$ref": "#/$defs/cyclonedx-composition-2.0/$defs/compositions"
+    },
+    "vulnerabilities": {
+      "$ref": "#/$defs/cyclonedx-vulnerability-2.0/$defs/vulnerabilities"
+    },
+    "annotations": {
+      "$ref": "#/$defs/cyclonedx-annotation-2.0/$defs/annotations"
+    },
+    "formulation": {
+      "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/formulation"
+    },
+    "declarations": {
+      "$ref": "#/$defs/cyclonedx-declaration-2.0/$defs/declarations"
+    },
+    "definitions": {
+      "$ref": "#/$defs/cyclonedx-definition-2.0/$defs/definitions"
+    },
+    "citations": {
+      "$ref": "#/$defs/cyclonedx-citation-2.0/$defs/citations"
+    },
+    "perspectives": {
+      "$ref": "#/$defs/cyclonedx-perspective-2.0/$defs/perspectives"
+    },
+    "properties": {
+      "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+    },
+    "externalReferences": {
+      "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReferences"
+    },
+    "signatures": {
+      "$ref": "#/$defs/cyclonedx-common-2.0/$defs/signatures"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/$defs/cyclonedx-common-2.0/$defs/extensibleProperties"
+    }
+  ],
+  "$defs": {
+    "cyclonedx-ai-modelcard-2.0": {
+      "type": "null",
+      "title": "CycloneDX AI Model Card",
+      "$defs": {
+        "modelCard": {
+          "$comment": "Model card support in CycloneDX is derived from TensorFlow Model Card Toolkit released under the Apache 2.0 license and available from https://github.com/tensorflow/model-card-toolkit/blob/main/model_card_toolkit/schema/v0.0.2/model_card.schema.json. In addition, CycloneDX model card support includes portions of VerifyML, also released under the Apache 2.0 license and available from https://github.com/cylynx/verifyml/blob/main/verifyml/model_card_toolkit/schema/v0.0.4/model_card.schema.json.",
+          "type": "object",
+          "title": "Model Card",
+          "description": "A model card describes the intended uses of a machine learning model and potential limitations, including biases and ethical considerations. Model cards typically contain the training parameters, which datasets were used to train the model, performance metrics, and other relevant data useful for ML transparency. This object SHOULD be specified for any component of type `machine-learning-model` and must not be specified for other component types.",
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the model card elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+            },
+            "modelParameters": {
+              "type": "object",
+              "title": "Model Parameters",
+              "description": "Hyper-parameters for construction of the model.",
+              "additionalProperties": false,
+              "properties": {
+                "approach": {
+                  "type": "object",
+                  "title": "Approach",
+                  "description": "The overall approach to learning used by the model for problem solving.",
+                  "additionalProperties": false,
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "title": "Learning Type",
+                      "description": "Learning types describing the learning problem or hybrid learning problem.",
+                      "enum": [
+                        "supervised",
+                        "unsupervised",
+                        "reinforcement-learning",
+                        "semi-supervised",
+                        "self-supervised"
+                      ],
+                      "meta:enum": {
+                        "supervised": "Supervised machine learning involves training an algorithm on labeled data to predict or classify new data based on the patterns learned from the labeled examples.",
+                        "unsupervised": "Unsupervised machine learning involves training algorithms on unlabeled data to discover patterns, structures, or relationships without explicit guidance, allowing the model to identify inherent structures or clusters within the data.",
+                        "reinforcement-learning": "Reinforcement learning is a type of machine learning where an agent learns to make decisions by interacting with an environment to maximize cumulative rewards, through trial and error.",
+                        "semi-supervised": "Semi-supervised machine learning utilizes a combination of labeled and unlabeled data during training to improve model performance, leveraging the benefits of both supervised and unsupervised learning techniques.",
+                        "self-supervised": "Self-supervised machine learning involves training models to predict parts of the input data from other parts of the same data, without requiring external labels, enabling learning from large amounts of unlabeled data."
+                      }
+                    }
+                  }
+                },
+                "task": {
+                  "type": "string",
+                  "title": "Task",
+                  "description": "Directly influences the input and/or output. Examples include classification, regression, clustering, etc."
+                },
+                "architectureFamily": {
+                  "type": "string",
+                  "title": "Architecture Family",
+                  "description": "The model architecture family such as transformer network, convolutional neural network, residual neural network, LSTM neural network, etc."
+                },
+                "modelArchitecture": {
+                  "type": "string",
+                  "title": "Model Architecture",
+                  "description": "The specific architecture of the model such as GPT-1, ResNet-50, YOLOv3, etc."
+                },
+                "datasets": {
+                  "type": "array",
+                  "title": "Datasets",
+                  "description": "The datasets used to train and evaluate the model.",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "title": "Inline Data Information",
+                        "$ref": "#/$defs/cyclonedx-component-2.0/$defs/componentData"
+                      },
+                      {
+                        "type": "object",
+                        "title": "Data Reference",
+                        "additionalProperties": false,
+                        "properties": {
+                          "ref": {
+                            "anyOf": [
+                              {
+                                "title": "Ref",
+                                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType"
+                              },
+                              {
+                                "title": "BOM-Link Element",
+                                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/bomLinkElementType"
+                              }
+                            ],
+                            "title": "Reference",
+                            "type": "string",
+                            "description": "References a data component by the components bom-ref attribute"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "inputs": {
+                  "type": "array",
+                  "title": "Inputs",
+                  "description": "The input format(s) of the model",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-ai-modelcard-2.0/$defs/inputOutputMLParameters"
+                  }
+                },
+                "outputs": {
+                  "type": "array",
+                  "title": "Outputs",
+                  "description": "The output format(s) from the model",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-ai-modelcard-2.0/$defs/inputOutputMLParameters"
+                  }
+                }
+              }
+            },
+            "quantitativeAnalysis": {
+              "type": "object",
+              "title": "Quantitative Analysis",
+              "description": "A quantitative analysis of the model",
+              "additionalProperties": false,
+              "properties": {
+                "performanceMetrics": {
+                  "type": "array",
+                  "title": "Performance Metrics",
+                  "description": "The model performance metrics being reported. Examples may include accuracy, F1 score, precision, top-3 error rates, MSC, etc.",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-ai-modelcard-2.0/$defs/performanceMetric"
+                  }
+                },
+                "graphics": {
+                  "$ref": "#/$defs/cyclonedx-ai-modelcard-2.0/$defs/graphicsCollection"
+                }
+              }
+            },
+            "considerations": {
+              "type": "object",
+              "title": "Considerations",
+              "description": "What considerations should be taken into account regarding the model's construction, training, and application?",
+              "additionalProperties": false,
+              "properties": {
+                "users": {
+                  "type": "array",
+                  "title": "Users",
+                  "description": "Who are the intended users of the model?",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "useCases": {
+                  "type": "array",
+                  "title": "Use Cases",
+                  "description": "What are the intended use cases of the model?",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "technicalLimitations": {
+                  "type": "array",
+                  "title": "Technical Limitations",
+                  "description": "What are the known technical limitations of the model? E.g. What kind(s) of data should the model be expected not to perform well on? What are the factors that might degrade model performance?",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "performanceTradeoffs": {
+                  "type": "array",
+                  "title": "Performance Tradeoffs",
+                  "description": "What are the known tradeoffs in accuracy/performance of the model?",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ethicalConsiderations": {
+                  "type": "array",
+                  "title": "Ethical Considerations",
+                  "description": "What are the ethical risks involved in the application of this model?",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-ai-modelcard-2.0/$defs/risk"
+                  }
+                },
+                "environmentalConsiderations": {
+                  "$ref": "#/$defs/cyclonedx-ai-modelcard-2.0/$defs/environmentalConsiderations",
+                  "title": "Environmental Considerations",
+                  "description": "What are the various environmental impacts the corresponding machine learning model has exhibited across its lifecycle?"
+                },
+                "fairnessAssessments": {
+                  "type": "array",
+                  "title": "Fairness Assessments",
+                  "description": "How does the model affect groups at risk of being systematically disadvantaged? What are the harms and benefits to the various affected groups?",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-ai-modelcard-2.0/$defs/fairnessAssessment"
+                  }
+                }
+              }
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "inputOutputMLParameters": {
+          "type": "object",
+          "title": "Input and Output Parameters",
+          "additionalProperties": false,
+          "properties": {
+            "format": {
+              "title": "Input/Output Format",
+              "description": "The data format for input/output to the model.",
+              "type": "string",
+              "examples": [
+                "string",
+                "image",
+                "time-series"
+              ]
+            }
+          }
+        },
+        "environmentalConsiderations": {
+          "type": "object",
+          "title": "Environmental Considerations",
+          "description": "Describes various environmental impact metrics.",
+          "additionalProperties": false,
+          "properties": {
+            "energyConsumptions": {
+              "title": "Energy Consumptions",
+              "description": "Describes energy consumption information incurred for one or more component lifecycle activities.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-ai-modelcard-2.0/$defs/energyConsumption"
+              }
+            },
+            "properties": {
+              "type": "array",
+              "title": "Properties",
+              "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/property"
+              }
+            }
+          }
+        },
+        "energyConsumption": {
+          "title": "Energy consumption",
+          "description": "Describes energy consumption information incurred for the specified lifecycle activity.",
+          "type": "object",
+          "required": [
+            "activity",
+            "energyProviders",
+            "activityEnergyCost"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "activity": {
+              "type": "string",
+              "title": "Activity",
+              "description": "The type of activity that is part of a machine learning model development or operational lifecycle.",
+              "enum": [
+                "design",
+                "data-collection",
+                "data-preparation",
+                "training",
+                "fine-tuning",
+                "validation",
+                "deployment",
+                "inference",
+                "other"
+              ],
+              "meta:enum": {
+                "design": "A model design including problem framing, goal definition and algorithm selection.",
+                "data-collection": "Model data acquisition including search, selection and transfer.",
+                "data-preparation": "Model data preparation including data cleaning, labeling and conversion.",
+                "training": "Model building, training and generalized tuning.",
+                "fine-tuning": "Refining a trained model to produce desired outputs for a given problem space.",
+                "validation": "Model validation including model output evaluation and testing.",
+                "deployment": "Explicit model deployment to a target hosting infrastructure.",
+                "inference": "Generating an output response from a hosted model from a set of inputs.",
+                "other": "A lifecycle activity type whose description does not match currently defined values."
+              }
+            },
+            "energyProviders": {
+              "title": "Energy Providers",
+              "description": "The provider(s) of the energy consumed by the associated model development lifecycle activity.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-ai-modelcard-2.0/$defs/energyProvider"
+              }
+            },
+            "activityEnergyCost": {
+              "title": "Activity Energy Cost",
+              "description": "The total energy cost associated with the model lifecycle activity.",
+              "$ref": "#/$defs/cyclonedx-ai-modelcard-2.0/$defs/energyMeasure"
+            },
+            "co2CostEquivalent": {
+              "title": "CO2 Equivalent Cost",
+              "description": "The CO2 cost (debit) equivalent to the total energy cost.",
+              "$ref": "#/$defs/cyclonedx-ai-modelcard-2.0/$defs/co2Measure"
+            },
+            "co2CostOffset": {
+              "title": "CO2 Cost Offset",
+              "description": "The CO2 offset (credit) for the CO2 equivalent cost.",
+              "$ref": "#/$defs/cyclonedx-ai-modelcard-2.0/$defs/co2Measure"
+            },
+            "properties": {
+              "type": "array",
+              "title": "Properties",
+              "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/property"
+              }
+            }
+          }
+        },
+        "energyMeasure": {
+          "type": "object",
+          "title": "Energy Measure",
+          "description": "A measure of energy.",
+          "required": [
+            "value",
+            "unit"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "value": {
+              "type": "number",
+              "title": "Value",
+              "description": "Quantity of energy."
+            },
+            "unit": {
+              "type": "string",
+              "enum": [
+                "kWh"
+              ],
+              "title": "Unit",
+              "description": "Unit of energy.",
+              "meta:enum": {
+                "kWh": "Kilowatt-hour (kWh) is the energy delivered by one kilowatt (kW) of power for one hour (h)."
+              }
+            }
+          }
+        },
+        "co2Measure": {
+          "type": "object",
+          "title": "CO2 Measure",
+          "description": "A measure of carbon dioxide (CO2).",
+          "required": [
+            "value",
+            "unit"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "value": {
+              "type": "number",
+              "title": "Value",
+              "description": "Quantity of carbon dioxide (CO2)."
+            },
+            "unit": {
+              "type": "string",
+              "enum": [
+                "tCO2eq"
+              ],
+              "title": "Unit",
+              "description": "Unit of carbon dioxide (CO2).",
+              "meta:enum": {
+                "tCO2eq": "Tonnes (t) of carbon dioxide (CO2) equivalent (eq)."
+              }
+            }
+          }
+        },
+        "energyProvider": {
+          "type": "object",
+          "title": "Energy Provider",
+          "description": "Describes the physical provider of energy used for model development or operations.",
+          "required": [
+            "organization",
+            "energySource",
+            "energyProvided"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the energy provider elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType"
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "A description of the energy provider."
+            },
+            "organization": {
+              "type": "object",
+              "title": "Organization",
+              "description": "The organization that provides energy.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalEntity"
+            },
+            "energySource": {
+              "type": "string",
+              "enum": [
+                "coal",
+                "oil",
+                "natural-gas",
+                "nuclear",
+                "wind",
+                "solar",
+                "geothermal",
+                "hydropower",
+                "biofuel",
+                "unknown",
+                "other"
+              ],
+              "meta:enum": {
+                "coal": "Energy produced by types of coal.",
+                "oil": "Petroleum products (primarily crude oil and its derivative fuel oils).",
+                "natural-gas": "Hydrocarbon gas liquids (HGL) that occur as gases at atmospheric pressure and as liquids under higher pressures including Natural gas (C5H12 and heavier), Ethane (C2H6), Propane (C3H8), etc.",
+                "nuclear": "Energy produced from the cores of atoms (i.e., through nuclear fission or fusion).",
+                "wind": "Energy produced from moving air.",
+                "solar": "Energy produced from the sun (i.e., solar radiation).",
+                "geothermal": "Energy produced from heat within the earth.",
+                "hydropower": "Energy produced from flowing water.",
+                "biofuel": "Liquid fuels produced from biomass feedstocks (i.e., organic materials such as plants or animals).",
+                "unknown": "The energy source is unknown.",
+                "other": "An energy source that is not listed."
+              },
+              "title": "Energy Source",
+              "description": "The energy source for the energy provider."
+            },
+            "energyProvided": {
+              "$ref": "#/$defs/cyclonedx-ai-modelcard-2.0/$defs/energyMeasure",
+              "title": "Energy Provided",
+              "description": "The energy provided by the energy source for an associated activity."
+            },
+            "externalReferences": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReference"
+              },
+              "title": "External References",
+              "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+            }
+          }
+        },
+        "graphicsCollection": {
+          "type": "object",
+          "title": "Graphics Collection",
+          "description": "A collection of graphics that represent various measurements.",
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "title": "Description",
+              "description": "A description of this collection of graphics.",
+              "type": "string"
+            },
+            "collection": {
+              "title": "Collection",
+              "description": "A collection of graphics.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-ai-modelcard-2.0/$defs/graphic"
+              }
+            }
+          }
+        },
+        "graphic": {
+          "type": "object",
+          "title": "Graphic",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "title": "Name",
+              "description": "The name of the graphic.",
+              "type": "string"
+            },
+            "image": {
+              "title": "Graphic Image",
+              "description": "The graphic (vector or raster). Base64 encoding must be specified for binary images.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/attachment"
+            }
+          }
+        },
+        "performanceMetric": {
+          "type": "object",
+          "title": "Performance Metric",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "title": "Type",
+              "description": "The type of performance metric.",
+              "type": "string"
+            },
+            "value": {
+              "title": "Value",
+              "description": "The value of the performance metric.",
+              "type": "string"
+            },
+            "slice": {
+              "title": "Slice",
+              "description": "The name of the slice this metric was computed on. By default, assume this metric is not sliced.",
+              "type": "string"
+            },
+            "confidenceInterval": {
+              "title": "Confidence Interval",
+              "description": "The confidence interval of the metric.",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "lowerBound": {
+                  "title": "Lower Bound",
+                  "description": "The lower bound of the confidence interval.",
+                  "type": "string"
+                },
+                "upperBound": {
+                  "title": "Upper Bound",
+                  "description": "The upper bound of the confidence interval.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "risk": {
+          "type": "object",
+          "title": "Risk",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "title": "Name",
+              "description": "The name of the risk.",
+              "type": "string"
+            },
+            "mitigationStrategy": {
+              "title": "Mitigation Strategy",
+              "description": "Strategy used to address this risk.",
+              "type": "string"
+            }
+          }
+        },
+        "fairnessAssessment": {
+          "type": "object",
+          "title": "Fairness Assessment",
+          "description": "Information about the benefits and harms of the model to an identified at risk group.",
+          "additionalProperties": false,
+          "properties": {
+            "groupAtRisk": {
+              "type": "string",
+              "title": "Group at Risk",
+              "description": "The groups or individuals at risk of being systematically disadvantaged by the model."
+            },
+            "benefits": {
+              "type": "string",
+              "title": "Benefits",
+              "description": "Expected benefits to the identified groups."
+            },
+            "harms": {
+              "type": "string",
+              "title": "Harms",
+              "description": "Expected harms to the identified groups."
+            },
+            "mitigationStrategy": {
+              "type": "string",
+              "title": "Mitigation Strategy",
+              "description": "With respect to the benefits and harms outlined, please describe any mitigation strategy implemented."
+            }
+          }
+        }
+      }
+    },
+    "cyclonedx-annotation-2.0": {
+      "type": "null",
+      "title": "CycloneDX Annotation Model",
+      "$defs": {
+        "annotations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-annotation-2.0/$defs/annotation"
+          },
+          "uniqueItems": true,
+          "title": "Annotations",
+          "description": "Comments made by people, organizations, or tools about any object with a bom-ref, such as components, services, vulnerabilities, or the BOM itself. Unlike inventory information, annotations may contain opinions or commentary from various stakeholders. Annotations may be inline (with inventory) or externalized via BOM-Link and may optionally be signed."
+        },
+        "annotation": {
+          "type": "object",
+          "title": "Annotations",
+          "description": "A comment, note, explanation, or similar textual content which provides additional context to the object(s) being annotated.",
+          "required": [
+            "subjects",
+            "annotator",
+            "timestamp",
+            "text"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the annotation elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+            },
+            "subjects": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "anyOf": [
+                  {
+                    "title": "Ref",
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType"
+                  },
+                  {
+                    "title": "BOM-Link Element",
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/bomLinkElementType"
+                  }
+                ]
+              },
+              "title": "Subjects",
+              "description": "The object in the BOM identified by its bom-ref. This is often a component or service, but may be any object type supporting bom-refs."
+            },
+            "annotator": {
+              "type": "object",
+              "title": "Annotator",
+              "description": "The organization, person, component, or service which created the textual content of the annotation.",
+              "oneOf": [
+                {
+                  "required": [
+                    "organization"
+                  ]
+                },
+                {
+                  "required": [
+                    "individual"
+                  ]
+                },
+                {
+                  "required": [
+                    "component"
+                  ]
+                },
+                {
+                  "required": [
+                    "service"
+                  ]
+                }
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "organization": {
+                  "description": "The organization that created the annotation",
+                  "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalEntity"
+                },
+                "individual": {
+                  "description": "The person that created the annotation",
+                  "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalContact"
+                },
+                "component": {
+                  "description": "The tool or component that created the annotation",
+                  "$ref": "#/$defs/cyclonedx-component-2.0/$defs/component"
+                },
+                "service": {
+                  "description": "The service that created the annotation",
+                  "$ref": "#/$defs/cyclonedx-service-2.0/$defs/service"
+                }
+              }
+            },
+            "timestamp": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Timestamp",
+              "description": "The date and time (timestamp) when the annotation was created."
+            },
+            "text": {
+              "type": "string",
+              "title": "Text",
+              "description": "The textual content of the annotation."
+            },
+            "signatures": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/signatures"
+            }
+          }
+        }
+      }
+    },
+    "cyclonedx-citation-2.0": {
+      "type": "null",
+      "title": "CycloneDX Citation Model",
+      "$defs": {
+        "citations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-citation-2.0/$defs/citation"
+          },
+          "uniqueItems": true,
+          "title": "Citations",
+          "description": "A collection of attributions indicating which entity supplied information for specific fields within the BOM."
+        },
+        "citation": {
+          "type": "object",
+          "title": "Citation",
+          "description": "Details a specific attribution of data within the BOM to a contributing entity or process.",
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference"
+            },
+            "pointers": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "title": "Field Reference",
+                "description": "A [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) identifying the BOM field to which the attribution applies."
+              },
+              "minItems": 1,
+              "title": "Field References",
+              "description": "One or more [JSON Pointers](https://datatracker.ietf.org/doc/html/rfc6901) identifying the BOM fields to which the attribution applies.\nExactly one of the \"pointers\" or \"expressions\" elements must be present."
+            },
+            "expressions": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "title": "Path Expression",
+                "description": "Specifies a [JSONPath](https://datatracker.ietf.org/doc/html/rfc9535) expression used to locate a value within a BOM."
+              },
+              "minItems": 1,
+              "title": "Path Expressions",
+              "description": "One or more path expressions used to locate values within a BOM.\nExactly one of the \"pointers\" or \"expressions\" elements must be present."
+            },
+            "timestamp": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Timestamp",
+              "description": "The date and time when the attribution was made or the information was supplied."
+            },
+            "attributedTo": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType",
+              "title": "Attributed To",
+              "description": "The `bom-ref` of an object, such as a component, service, tool, organisational entity, or person that supplied the cited information.\nAt least one of the \"attributedTo\" or \"process\" elements must be present."
+            },
+            "process": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType",
+              "title": "Process Reference",
+              "description": "The `bom-ref` to a process (such as a formula, workflow, task, or step) defined in the `formulation` section that executed or generated the attributed data.\nAt least one of the \"attributedTo\" or \"process\" elements must be present."
+            },
+            "note": {
+              "type": "string",
+              "title": "Note",
+              "description": "A description or comment about the context or quality of the data attribution."
+            },
+            "signatures": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/signatures",
+              "title": "Signature",
+              "description": "A digital signature verifying the authenticity or integrity of the attribution."
+            }
+          },
+          "required": [
+            "timestamp"
+          ],
+          "anyOf": [
+            {
+              "required": [
+                "attributedTo"
+              ]
+            },
+            {
+              "required": [
+                "process"
+              ]
+            }
+          ],
+          "oneOf": [
+            {
+              "required": [
+                "pointers"
+              ]
+            },
+            {
+              "required": [
+                "expressions"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "cyclonedx-common-2.0": {
+      "type": "null",
+      "title": "CycloneDX Common Model",
+      "$defs": {
+        "refType": {
+          "description": "Identifier for referable and therefore interlinkable elements.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+          "type": "string",
+          "minLength": 1,
+          "$comment": "TODO (breaking change): add a format constraint that prevents the value from staring with 'urn:cdx:'"
+        },
+        "refLinkType": {
+          "description": "Descriptor for an element identified by the attribute 'bom-ref' in the same BOM document.\nIn contrast to `bomLinkElementType`.",
+          "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType"
+        },
+        "bomLinkDocumentType": {
+          "title": "BOM-Link Document",
+          "description": "Descriptor for another BOM document. See https://cyclonedx.org/capabilities/bomlink/",
+          "type": "string",
+          "format": "iri-reference",
+          "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*$",
+          "$comment": "part of the pattern is based on `bom.serialNumber`'s pattern"
+        },
+        "bomLinkElementType": {
+          "title": "BOM-Link Element",
+          "description": "Descriptor for an element in a BOM document. See https://cyclonedx.org/capabilities/bomlink/",
+          "type": "string",
+          "format": "iri-reference",
+          "pattern": "^urn:cdx:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[1-9][0-9]*#.+$",
+          "$comment": "part of the pattern is based on `bom.serialNumber`'s pattern"
+        },
+        "bomLink": {
+          "title": "BOM-Link",
+          "anyOf": [
+            {
+              "title": "BOM-Link Document",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/bomLinkDocumentType"
+            },
+            {
+              "title": "BOM-Link Element",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/bomLinkElementType"
+            }
+          ]
+        },
+        "hash": {
+          "type": "object",
+          "title": "Hash",
+          "required": [
+            "alg",
+            "content"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "alg": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/hashAlgorithm",
+              "title": "Hash Algorithm",
+              "description": "The standard, well-known algorithm used to compute the hash."
+            },
+            "content": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/hashValue",
+              "title": "Hash Value",
+              "description": "The value of the hash computed using the standard, well-known algorithm."
+            }
+          }
+        },
+        "hashAlgorithm": {
+          "type": "string",
+          "title": "Hash Algorithm",
+          "description": "The algorithm that generated the hash value.",
+          "enum": [
+            "MD5",
+            "SHA-1",
+            "SHA-256",
+            "SHA-384",
+            "SHA-512",
+            "SHA3-256",
+            "SHA3-384",
+            "SHA3-512",
+            "BLAKE2b-256",
+            "BLAKE2b-384",
+            "BLAKE2b-512",
+            "BLAKE3",
+            "Streebog-256",
+            "Streebog-512"
+          ]
+        },
+        "hashValue": {
+          "type": "string",
+          "title": "Hash Value",
+          "description": "The value of the hash.",
+          "examples": [
+            "3942447fac867ae5cdb3229b658f4d48"
+          ],
+          "pattern": "^([a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$"
+        },
+        "mediaType": {
+          "type": "string",
+          "title": "Media Type",
+          "description": "The media type of the object. The media type can provide additional context about the kind of data being represented, such as an image, font, or executable.",
+          "examples": [
+            "text/plain",
+            "application/json",
+            "image/png"
+          ],
+          "pattern": "^[-+a-z0-9.]+/[-+a-z0-9.]+$"
+        },
+        "attachment": {
+          "type": "object",
+          "title": "Attachment",
+          "description": "Specifies the metadata and content for an attachment.",
+          "required": [
+            "content"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "mediaType": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/mediaType"
+            },
+            "encoding": {
+              "type": "string",
+              "title": "Encoding",
+              "description": "Specifies the optional encoding the text is represented in.",
+              "enum": [
+                "base64"
+              ],
+              "meta:enum": {
+                "base64": "Base64 is a binary-to-text encoding scheme that represents binary data in an ASCII string."
+              }
+            },
+            "content": {
+              "type": "string",
+              "title": "Attachment Text",
+              "description": "The attachment data. Proactive controls such as input validation and sanitization should be employed to prevent misuse of attachment text."
+            }
+          }
+        },
+        "base64": {
+          "type": "string",
+          "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+          "description": "A Base64-encoded string."
+        },
+        "externalReferences": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReference"
+          },
+          "title": "External References",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM."
+        },
+        "externalReference": {
+          "type": "object",
+          "title": "External Reference",
+          "description": "External references provide a way to document systems, sites, and information that may be relevant but are not included with the BOM. They may also establish specific relationships within or external to the BOM.",
+          "required": [
+            "url",
+            "type"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "url": {
+              "anyOf": [
+                {
+                  "title": "URL",
+                  "type": "string",
+                  "format": "iri-reference"
+                },
+                {
+                  "title": "BOM-Link",
+                  "$ref": "#/$defs/cyclonedx-common-2.0/$defs/bomLink"
+                }
+              ],
+              "title": "URL",
+              "description": "The URI (URL or URN) to the external reference. External references are URIs and therefore can accept any URL scheme including https ([RFC-7230](https://www.ietf.org/rfc/rfc7230.txt)), mailto ([RFC-2368](https://www.ietf.org/rfc/rfc2368.txt)), tel ([RFC-3966](https://www.ietf.org/rfc/rfc3966.txt)), and dns ([RFC-4501](https://www.ietf.org/rfc/rfc4501.txt)). External references may also include formally registered URNs such as [CycloneDX BOM-Link](https://cyclonedx.org/capabilities/bomlink/) to reference CycloneDX BOMs or any object within a BOM. BOM-Link transforms applicable external references into relationships that can be expressed in a BOM or across BOMs."
+            },
+            "comment": {
+              "type": "string",
+              "title": "Comment",
+              "description": "A comment describing the external reference"
+            },
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "description": "Specifies the type of external reference.",
+              "enum": [
+                "vcs",
+                "issue-tracker",
+                "website",
+                "advisories",
+                "bom",
+                "mailing-list",
+                "social",
+                "chat",
+                "documentation",
+                "support",
+                "source-distribution",
+                "distribution",
+                "distribution-intake",
+                "license",
+                "build-meta",
+                "build-system",
+                "release-notes",
+                "security-contact",
+                "model-card",
+                "log",
+                "configuration",
+                "evidence",
+                "formulation",
+                "attestation",
+                "threat-model",
+                "adversary-model",
+                "risk-assessment",
+                "vulnerability-assertion",
+                "exploitability-statement",
+                "pentest-report",
+                "static-analysis-report",
+                "dynamic-analysis-report",
+                "runtime-analysis-report",
+                "component-analysis-report",
+                "maturity-report",
+                "certification-report",
+                "codified-infrastructure",
+                "quality-metrics",
+                "poam",
+                "perspective",
+                "electronic-signature",
+                "digital-signature",
+                "rfc-9116",
+                "patent",
+                "patent-family",
+                "patent-assertion",
+                "citation",
+                "swid-tag",
+                "other"
+              ],
+              "meta:enum": {
+                "vcs": "Version Control System",
+                "issue-tracker": "Issue or defect tracking system, or an Application Lifecycle Management (ALM) system",
+                "website": "Website",
+                "advisories": "Security advisories",
+                "bom": "Bill of Materials (SBOM, OBOM, HBOM, SaaSBOM, etc)",
+                "mailing-list": "Mailing list or discussion group",
+                "social": "Social media account",
+                "chat": "Real-time chat platform",
+                "documentation": "Documentation, guides, or how-to instructions",
+                "support": "Community or commercial support",
+                "source-distribution": "The location where the source code distributable can be obtained. This is often an archive format such as zip or tgz. The source-distribution type complements use of the version control (vcs) type.",
+                "distribution": "Direct or repository download location",
+                "distribution-intake": "The location where a component was published to. This is often the same as \"distribution\" but may also include specialized publishing processes that act as an intermediary.",
+                "license": "The reference to the license file. If a license URL has been defined in the license node, it should also be defined as an external reference for completeness.",
+                "build-meta": "Build-system specific meta file (i.e. pom.xml, package.json, .nuspec, etc)",
+                "build-system": "Reference to an automated build system",
+                "release-notes": "Reference to release notes",
+                "security-contact": "Specifies a way to contact the maintainer, supplier, or provider in the event of a security incident. Common URIs include links to a disclosure procedure, a mailto (RFC-2368) that specifies an email address, a tel (RFC-3966) that specifies a phone number, or dns (RFC-4501) that specifies the records containing DNS Security TXT.",
+                "model-card": "A model card describes the intended uses of a machine learning model, potential limitations, biases, ethical considerations, training parameters, datasets used to train the model, performance metrics, and other relevant data useful for ML transparency.",
+                "log": "A record of events that occurred in a computer system or application, such as problems, errors, or information on current operations.",
+                "configuration": "Parameters or settings that may be used by other components or services.",
+                "evidence": "Information used to substantiate a claim.",
+                "formulation": "Describes the formulation of any referencable object within the BOM, including components, services, metadata, declarations, or the BOM itself.",
+                "attestation": "Human or machine-readable statements containing facts, evidence, or testimony.",
+                "threat-model": "An enumeration of identified weaknesses, threats, and countermeasures, dataflow diagram (DFD), attack tree, and other supporting documentation in human-readable or machine-readable format.",
+                "adversary-model": "The defined assumptions, goals, and capabilities of an adversary.",
+                "risk-assessment": "Identifies and analyzes the potential of future events that may negatively impact individuals, assets, and/or the environment. Risk assessments may also include judgments on the tolerability of each risk.",
+                "vulnerability-assertion": "A Vulnerability Disclosure Report (VDR) which asserts the known and previously unknown vulnerabilities that affect a component, service, or product including the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on a component, service, or product.",
+                "exploitability-statement": "A Vulnerability Exploitability eXchange (VEX) which asserts the known vulnerabilities that do not affect a product, product family, or organization, and optionally the ones that do. The VEX should include the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on the product, product family, or organization.",
+                "pentest-report": "Results from an authorized simulated cyberattack on a component or service, otherwise known as a penetration test.",
+                "static-analysis-report": "SARIF or proprietary machine or human-readable report for which static analysis has identified code quality, security, and other potential issues with the source code.",
+                "dynamic-analysis-report": "Dynamic analysis report that has identified issues such as vulnerabilities and misconfigurations.",
+                "runtime-analysis-report": "Report generated by analyzing the call stack of a running application.",
+                "component-analysis-report": "Report generated by Software Composition Analysis (SCA), container analysis, or other forms of component analysis.",
+                "maturity-report": "Report containing a formal assessment of an organization, business unit, or team against a maturity model.",
+                "certification-report": "Industry, regulatory, or other certification from an accredited (if applicable) certification body.",
+                "codified-infrastructure": "Code or configuration that defines and provisions virtualized infrastructure, commonly referred to as Infrastructure as Code (IaC).",
+                "quality-metrics": "Report or system in which quality metrics can be obtained.",
+                "poam": "Plans of Action and Milestones (POA&M) complement an \"attestation\" external reference. POA&M is defined by NIST as a \"document that identifies tasks needing to be accomplished. It details resources required to accomplish the elements of the plan, any milestones in meeting the tasks and scheduled completion dates for the milestones\".",
+                "perspective": "A CycloneDX perspective defines a domain-specific view, enabling different audiences to interpret and navigate the data through their own conceptual lens.",
+                "electronic-signature": "An e-signature is commonly a scanned representation of a written signature or a stylized script of the person's name.",
+                "digital-signature": "A signature that leverages cryptography, typically public/private key pairs, which provides strong authenticity verification.",
+                "rfc-9116": "Document that complies with [RFC 9116](https://www.ietf.org/rfc/rfc9116.html) (A File Format to Aid in Security Vulnerability Disclosure)",
+                "patent": "References information about patents which may be defined in human-readable documents or in machine-readable formats such as CycloneDX or ST.96. For detailed patent information or to reference the information provided directly by patent offices, it is recommended to leverage standards from the World Intellectual Property Organization (WIPO) such as [ST.96](https://www.wipo.int/standards/en/st96).",
+                "patent-family": "References information about a patent family which may be defined in human-readable documents or in machine-readable formats such as CycloneDX or ST.96. A patent family is a group of related patent applications or granted patents that cover the same or similar invention. For detailed patent family information or to reference the information provided directly by patent offices, it is recommended to leverage standards from the World Intellectual Property Organization (WIPO) such as [ST.96](https://www.wipo.int/standards/en/st96).",
+                "patent-assertion": "References assertions made regarding patents associated with a component or service. Assertions distinguish between ownership, licensing, and other relevant interactions with patents.",
+                "citation": "A reference to external citations applicable to the object identified by this BOM entry or the BOM itself. When used with a BOM-Link, this allows offloading citations into a separate CycloneDX BOM.",
+                "swid-tag": "A Software Identification (SWID) tag document conforming to ISO/IEC 19770-2. The reference resolves to the XML SoftwareIdentity document itself, including all of its metadata (entities, evidence, payload, links, and meta elements). This is distinct from the `swid` identifier scheme, which carries only the tagId of a SWID tag.",
+                "other": "Use this if no other types accurately describe the purpose of the external reference."
+              }
+            },
+            "hashes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/hash"
+              },
+              "title": "Hashes",
+              "description": "The hashes of the external reference (if applicable)."
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "postalAddress": {
+          "type": "object",
+          "title": "Postal address",
+          "description": "An address used to identify a contactable location.",
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "title": "BOM Reference",
+              "description": "An optional identifier which can be used to reference the address elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType"
+            },
+            "country": {
+              "type": "string",
+              "title": "Country",
+              "description": "The country name or the two-letter ISO 3166-1 country code."
+            },
+            "region": {
+              "type": "string",
+              "title": "Region",
+              "description": "The region or state in the country.",
+              "examples": [
+                "Texas"
+              ]
+            },
+            "locality": {
+              "type": "string",
+              "title": "Locality",
+              "description": "The locality or city within the country.",
+              "examples": [
+                "Austin"
+              ]
+            },
+            "postOfficeBoxNumber": {
+              "type": "string",
+              "title": "Post Office Box Number",
+              "description": "The post office box number.",
+              "examples": [
+                "901"
+              ]
+            },
+            "postalCode": {
+              "type": "string",
+              "title": "Postal Code",
+              "description": "The postal code.",
+              "examples": [
+                "78758"
+              ]
+            },
+            "streetAddress": {
+              "type": "string",
+              "title": "Street Address",
+              "description": "The street address.",
+              "examples": [
+                "100 Main Street"
+              ]
+            }
+          }
+        },
+        "organizationalEntity": {
+          "type": "object",
+          "title": "Organizational Entity",
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference",
+              "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+            },
+            "name": {
+              "type": "string",
+              "title": "Organization Name",
+              "description": "The name of the organization",
+              "examples": [
+                "Example Inc."
+              ]
+            },
+            "address": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/postalAddress",
+              "title": "Organization Address",
+              "description": "The physical address (location) of the organization"
+            },
+            "url": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "iri-reference"
+              },
+              "title": "Organization URL(s)",
+              "description": "The URL of the organization. Multiple URLs are allowed.",
+              "examples": [
+                "https://example.com"
+              ]
+            },
+            "contact": {
+              "type": "array",
+              "title": "Organizational Contact",
+              "description": "A contact at the organization. Multiple contacts are allowed.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalContact"
+              }
+            }
+          }
+        },
+        "organizationalContact": {
+          "type": "object",
+          "title": "Organizational Contact",
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference",
+              "description": "An optional identifier which can be used to reference the object elsewhere in the BOM. Every bom-ref must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The name of a contact",
+              "examples": [
+                "Contact name"
+              ]
+            },
+            "email": {
+              "type": "string",
+              "format": "idn-email",
+              "title": "Email Address",
+              "description": "The email address of the contact.",
+              "examples": [
+                "firstname.lastname@example.com"
+              ]
+            },
+            "phone": {
+              "type": "string",
+              "title": "Phone",
+              "description": "The phone number of the contact.",
+              "examples": [
+                "800-555-1212"
+              ]
+            }
+          }
+        },
+        "organizationalEntityOrContact": {},
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-common-2.0/$defs/property"
+          }
+        },
+        "property": {
+          "type": "object",
+          "title": "Lightweight name-value pair",
+          "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The name of the property. Duplicate names are allowed, each potentially having a different value."
+            },
+            "value": {
+              "type": "string",
+              "title": "Value",
+              "description": "The value of the property."
+            }
+          },
+          "additionalProperties": false
+        },
+        "extensibleProperties": {
+          "type": "object",
+          "title": "Extensible Properties",
+          "patternProperties": {
+            "^ext:[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}:.+$": {
+              "description": "CycloneDX supports a structured and namespace-aware mechanism for extensibility through the use of extensible properties. This mechanism enables organizations, ecosystems, and tool vendors to safely introduce custom properties without conflicting with the core schema or other extensions.\n\nExtensible properties are defined as a JSON object whose keys must conform to a strict pattern that resembles a reverse domain name structure, prefixed with ext:. This pattern provides a namespacing convention that aligns with well-established practices in other structured formats (e.g., XML namespaces).",
+              "examples": [
+                "ext:<domain>:<name>",
+                "ext:example.org:myExtension"
+              ],
+              "if": {
+                "type": [
+                  "object",
+                  "array"
+                ]
+              },
+              "then": {
+                "type": "object",
+                "required": [
+                  "$schema"
+                ],
+                "properties": {
+                  "$schema": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                }
+              },
+              "else": {
+                "type": [
+                  "string",
+                  "number",
+                  "boolean",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "baseObject": {
+          "description": "Base object for all CycloneDX entities. Automatically includes support for extensible properties.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/extensibleProperties"
+            }
+          ],
+          "properties": {
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            },
+            "externalReferences": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReferences"
+            }
+          }
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z$",
+          "description": "An RFC 3339-compliant UTC timestamp using Zulu time (i.e., ending with 'Z'). The format must be 'YYYY-MM-DDTHH:MM:SSZ' or include optional fractional seconds, e.g., 'YYYY-MM-DDTHH:MM:SS.sssZ'. Offsets such as '+00:00' are not allowed."
+        },
+        "lifecycle": {
+          "type": "object",
+          "title": "Lifecycle",
+          "description": "The product lifecycle(s) that this BOM represents.",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/preDefinedLifecyclePhase"
+            },
+            {
+              "title": "Custom Lifecycle Phase",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "Name",
+                  "description": "The name of the lifecycle phase"
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "The description of the lifecycle phase"
+                }
+              }
+            }
+          ]
+        },
+        "lifecycles": {
+          "type": "array",
+          "title": "Lifecycles",
+          "description": "Lifecycles communicate the stage(s) in which data in the BOM was captured. Different types of data may be available at various phases of a lifecycle, such as the Software Development Lifecycle (SDLC), IT Asset Management (ITAM), and Software Asset Management (SAM). Thus, a BOM may include data specific to or only obtainable in a given lifecycle.",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-common-2.0/$defs/lifecycle"
+          }
+        },
+        "preDefinedLifecyclePhase": {
+          "title": "Pre-Defined Phase",
+          "required": [
+            "phase"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "phase": {
+              "type": "string",
+              "title": "Phase",
+              "description": "A pre-defined phase in the product lifecycle.",
+              "enum": [
+                "design",
+                "pre-build",
+                "build",
+                "post-build",
+                "operations",
+                "discovery",
+                "decommission"
+              ],
+              "meta:enum": {
+                "design": "BOM produced early in the development lifecycle containing an inventory of components and services that are proposed or planned to be used. The inventory may need to be procured, retrieved, or resourced prior to use.",
+                "pre-build": "BOM consisting of information obtained prior to a build process and may contain source files and development artifacts and manifests. The inventory may need to be resolved and retrieved prior to use.",
+                "build": "BOM consisting of information obtained during a build process where component inventory is available for use. The precise versions of resolved components are usually available at this time as well as the provenance of where the components were retrieved from.",
+                "post-build": "BOM consisting of information obtained after a build process has completed and the resulting components(s) are available for further analysis. Built components may exist as the result of a CI/CD process, may have been installed or deployed to a system or device, and may need to be retrieved or extracted from the system or device.",
+                "operations": "BOM produced that represents inventory that is running and operational. This may include staging or production environments and will generally encompass multiple SBOMs describing the applications and operating system, along with HBOMs describing the hardware that makes up the system. Operations Bill of Materials (OBOM) can provide full-stack inventory of runtime environments, configurations, and additional dependencies.",
+                "discovery": "BOM consisting of information observed through network discovery providing point-in-time enumeration of embedded, on-premise, and cloud-native services such as server applications, connected devices, microservices, and serverless functions.",
+                "decommission": "BOM containing inventory that will be, or has been retired from operations."
+              }
+            }
+          }
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Tags",
+          "description": "Textual strings that aid in discovery, search, and retrieval of the associated object. Tags often serve as a way to group or categorize similar or related objects by various attributes.",
+          "examples": [
+            "json-parser",
+            "object-persistence",
+            "text-to-image",
+            "translation",
+            "object-detection"
+          ]
+        },
+        "commit": {
+          "type": "object",
+          "title": "Commit",
+          "description": "Specifies an individual commit",
+          "additionalProperties": false,
+          "properties": {
+            "uid": {
+              "type": "string",
+              "title": "UID",
+              "description": "A unique identifier of the commit. This may be version control specific. For example, Subversion uses revision numbers whereas git uses commit hashes."
+            },
+            "url": {
+              "type": "string",
+              "title": "URL",
+              "description": "The URL to the commit. This URL will typically point to a commit in a version control system.",
+              "format": "iri-reference"
+            },
+            "author": {
+              "title": "Author",
+              "description": "The author who created the changes in the commit",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/identifiableAction"
+            },
+            "committer": {
+              "title": "Committer",
+              "description": "The person who committed or pushed the commit",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/identifiableAction"
+            },
+            "message": {
+              "type": "string",
+              "title": "Message",
+              "description": "The text description of the contents of the commit"
+            }
+          }
+        },
+        "patch": {
+          "type": "object",
+          "title": "Patch",
+          "description": "Specifies an individual patch",
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "unofficial",
+                "monkey",
+                "backport",
+                "cherry-pick"
+              ],
+              "meta:enum": {
+                "unofficial": "A patch which is not developed by the creators or maintainers of the software being patched. Refer to [https://en.wikipedia.org/wiki/Unofficial_patch](https://en.wikipedia.org/wiki/Unofficial_patch).",
+                "monkey": "A patch which dynamically modifies runtime behavior. Refer to [https://en.wikipedia.org/wiki/Monkey_patch](https://en.wikipedia.org/wiki/Monkey_patch).",
+                "backport": "A patch which takes code from a newer version of the software and applies it to older versions of the same software. Refer to [https://en.wikipedia.org/wiki/Backporting](https://en.wikipedia.org/wiki/Backporting).",
+                "cherry-pick": "A patch created by selectively applying commits from other versions or branches of the same software."
+              },
+              "title": "Patch Type",
+              "description": "Specifies the purpose for the patch including the resolution of defects, security issues, or new behavior or functionality."
+            },
+            "diff": {
+              "title": "Diff",
+              "description": "The patch file (or diff) that shows changes. Refer to [https://en.wikipedia.org/wiki/Diff](https://en.wikipedia.org/wiki/Diff)",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/diff"
+            },
+            "resolves": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/issue"
+              },
+              "title": "Resolves",
+              "description": "A collection of issues the patch resolves"
+            }
+          }
+        },
+        "diff": {
+          "type": "object",
+          "title": "Diff",
+          "description": "The patch file (or diff) that shows changes. Refer to https://en.wikipedia.org/wiki/Diff",
+          "additionalProperties": false,
+          "properties": {
+            "text": {
+              "title": "Diff text",
+              "description": "Specifies the optional text of the diff",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/attachment"
+            },
+            "url": {
+              "type": "string",
+              "title": "URL",
+              "description": "Specifies the URL to the diff",
+              "format": "iri-reference"
+            }
+          }
+        },
+        "issue": {
+          "type": "object",
+          "title": "Issue",
+          "description": "An individual issue that has been resolved.",
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "defect",
+                "enhancement",
+                "security"
+              ],
+              "meta:enum": {
+                "defect": "A fault, flaw, or bug in software.",
+                "enhancement": "A new feature or behavior in software.",
+                "security": "A special type of defect which impacts security."
+              },
+              "title": "Issue Type",
+              "description": "Specifies the type of issue"
+            },
+            "id": {
+              "type": "string",
+              "title": "Issue ID",
+              "description": "The identifier of the issue assigned by the source of the issue"
+            },
+            "name": {
+              "type": "string",
+              "title": "Issue Name",
+              "description": "The name of the issue"
+            },
+            "description": {
+              "type": "string",
+              "title": "Issue Description",
+              "description": "A description of the issue"
+            },
+            "source": {
+              "type": "object",
+              "title": "Source",
+              "description": "The source of the issue where it is documented",
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "Name",
+                  "description": "The name of the source.",
+                  "examples": [
+                    "National Vulnerability Database",
+                    "NVD",
+                    "Apache"
+                  ]
+                },
+                "url": {
+                  "type": "string",
+                  "title": "URL",
+                  "description": "The url of the issue documentation as provided by the source",
+                  "format": "iri-reference"
+                }
+              }
+            },
+            "references": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "iri-reference"
+              },
+              "title": "References",
+              "description": "A collection of URL's for reference. Multiple URLs are allowed.",
+              "examples": [
+                "https://example.com"
+              ]
+            }
+          }
+        },
+        "identifiableAction": {
+          "type": "object",
+          "title": "Identifiable Action",
+          "description": "Specifies an individual commit",
+          "additionalProperties": false,
+          "properties": {
+            "timestamp": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Timestamp",
+              "description": "The timestamp in which the action occurred"
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The name of the individual who performed the action"
+            },
+            "email": {
+              "type": "string",
+              "format": "idn-email",
+              "title": "E-mail",
+              "description": "The email address of the individual who performed the action"
+            }
+          }
+        },
+        "locale": {
+          "type": "string",
+          "pattern": "^([a-z]{2})(-[A-Z]{2})?$",
+          "title": "Locale",
+          "description": "Defines a syntax for representing two character language code (ISO-639) followed by an optional two character country code. The language code must be lower case. If the country code is specified, the country code must be upper case. The language code and country code must be separated by a minus sign. Examples: en, en-US, fr, fr-CA"
+        },
+        "signatures": {
+          "$ref": "#/$defs/cyclonedx-jss_X590_2023_10-2.0/$defs/signatures",
+          "title": "Signatures",
+          "description": "Enveloped signatures in [JSON Signature Scheme (JSS/ITU-T X.590)](https://www.itu.int/epublications/publication/itu-t-x-590-2023-10-json-signature-scheme-jss)."
+        }
+      }
+    },
+    "cyclonedx-component-2.0": {
+      "type": "null",
+      "title": "CycloneDX Component Model",
+      "$defs": {
+        "components": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-component-2.0/$defs/componentOrChoice"
+          },
+          "uniqueItems": true,
+          "title": "Components"
+        },
+        "component": {
+          "type": "object",
+          "title": "Component",
+          "required": [
+            "type",
+            "name"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "application",
+                "framework",
+                "library",
+                "container",
+                "platform",
+                "operating-system",
+                "device",
+                "device-driver",
+                "firmware",
+                "file",
+                "machine-learning-model",
+                "data",
+                "cryptographic-asset"
+              ],
+              "meta:enum": {
+                "application": "A software application. Refer to [https://en.wikipedia.org/wiki/Application_software](https://en.wikipedia.org/wiki/Application_software) for information about applications.",
+                "framework": "A software framework. Refer to [https://en.wikipedia.org/wiki/Software_framework](https://en.wikipedia.org/wiki/Software_framework) for information on how frameworks vary slightly from libraries.",
+                "library": "A software library. Refer to [https://en.wikipedia.org/wiki/Library_(computing)](https://en.wikipedia.org/wiki/Library_(computing)) for information about libraries. All third-party and open source reusable components will likely be a library. If the library also has key features of a framework, then it should be classified as a framework. If not, or is unknown, then specifying library is recommended.",
+                "container": "A packaging and/or runtime format, not specific to any particular technology, which isolates software inside the container from software outside of a container through virtualization technology. Refer to [https://en.wikipedia.org/wiki/OS-level_virtualization](https://en.wikipedia.org/wiki/OS-level_virtualization).",
+                "platform": "A runtime environment that interprets or executes software. This may include runtimes such as those that execute bytecode, just-in-time compilers, interpreters, or low-code/no-code application platforms.",
+                "operating-system": "A software operating system without regard to deployment model (i.e. installed on physical hardware, virtual machine, image, etc) Refer to [https://en.wikipedia.org/wiki/Operating_system](https://en.wikipedia.org/wiki/Operating_system).",
+                "device": "A hardware device such as a processor or chip-set. A hardware device containing firmware SHOULD include a component for the physical hardware itself and another component of type 'firmware' or 'operating-system' (whichever is relevant), describing information about the software running on the device. See also the list of [known device properties](https://github.com/CycloneDX/cyclonedx-property-taxonomy/blob/main/cdx/device.md).",
+                "device-driver": "A special type of software that operates or controls a particular type of device. Refer to [https://en.wikipedia.org/wiki/Device_driver](https://en.wikipedia.org/wiki/Device_driver).",
+                "firmware": "A special type of software that provides low-level control over a device's hardware. Refer to [https://en.wikipedia.org/wiki/Firmware](https://en.wikipedia.org/wiki/Firmware).",
+                "file": "A computer file. Refer to [https://en.wikipedia.org/wiki/Computer_file](https://en.wikipedia.org/wiki/Computer_file) for information about files.",
+                "machine-learning-model": "A model based on training data that can make predictions or decisions without being explicitly programmed to do so.",
+                "data": "A collection of discrete values that convey information.",
+                "cryptographic-asset": "A cryptographic asset including algorithms, protocols, certificates, keys, tokens, and secrets."
+              },
+              "title": "Component Type",
+              "description": "Specifies the type of component. For software components, classify as application if no more specific appropriate classification is available or cannot be determined for the component.",
+              "examples": [
+                "library"
+              ]
+            },
+            "mime-type": {
+              "type": "string",
+              "title": "Mime-Type",
+              "description": "The mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented, such as an image, font, or executable. Some library or framework components may also have an associated mime-type.",
+              "examples": [
+                "image/jpeg"
+              ],
+              "pattern": "^[-+a-z0-9.]+/[-+a-z0-9.]+$"
+            },
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the component elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+            },
+            "parties": {
+              "$ref": "#/$defs/cyclonedx-party-2.0/$defs/parties"
+            },
+            "group": {
+              "type": "string",
+              "title": "Component Group",
+              "description": "The grouping name or identifier. This will often be a shortened, single name of the company or project that produced the component, or the source package or domain name. Whitespace and special characters should be avoided. Examples include: apache, org.apache.commons, and apache.org.",
+              "examples": [
+                "com.acme"
+              ]
+            },
+            "name": {
+              "type": "string",
+              "title": "Component Name",
+              "description": "The name of the component. This will often be a shortened, single name of the component. Examples: commons-lang3 and jquery",
+              "examples": [
+                "tomcat-catalina"
+              ]
+            },
+            "version": {
+              "$ref": "#/$defs/cyclonedx-component-2.0/$defs/version",
+              "title": "Component Version",
+              "description": "The component version. The version should ideally comply with semantic versioning but is not enforced.\nMust be used exclusively, either 'version' or 'versionRange', but not both."
+            },
+            "versionRange": {
+              "$ref": "#/$defs/cyclonedx-component-2.0/$defs/versionRange",
+              "title": "Component Version Range",
+              "description": "For an external component, this specifies the accepted version range.\nThe value must adhere to the Package URL Version Range syntax (vers), as defined at <https://github.com/package-url/vers-spec\nMay only be used if `.isExternal` is set to `true`.\nMust be used exclusively, either 'version' or 'versionRange', but not both."
+            },
+            "isExternal": {
+              "type": "boolean",
+              "title": "Component Is External",
+              "description": "Determine whether this component is external.\nAn external component is one that is not part of an assembly, but is expected to be provided by the environment, regardless of the component's `.scope`. This setting can be useful for distinguishing which components are bundled with the product and which can be relied upon to be present in the deployment environment.\nThis may be set to `true` for runtime components only. For `$.metadata.component`, it must be set to `false`.",
+              "default": false
+            },
+            "description": {
+              "type": "string",
+              "title": "Component Description",
+              "description": "Specifies a description for the component"
+            },
+            "scope": {
+              "type": "string",
+              "enum": [
+                "required",
+                "optional",
+                "excluded"
+              ],
+              "meta:enum": {
+                "required": "The component is required for runtime",
+                "optional": "The component is optional at runtime. Optional components are components that are not capable of being called due to them not being installed or otherwise accessible by any means. Components that are installed but due to configuration or other restrictions are prohibited from being called must be scoped as 'required'.",
+                "excluded": "Components that are excluded provide the ability to document component usage for test and other non-runtime purposes. Excluded components are not reachable within a call graph at runtime."
+              },
+              "title": "Component Scope",
+              "description": "Specifies the scope of the component. If scope is not specified, 'required' scope SHOULD be assumed by the consumer of the BOM.",
+              "default": "required"
+            },
+            "hashes": {
+              "type": "array",
+              "title": "Component Hashes",
+              "description": "The hashes of the component.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/hash"
+              }
+            },
+            "licenses": {
+              "$ref": "#/$defs/cyclonedx-license-2.0/$defs/licenseChoice",
+              "title": "Component License(s)"
+            },
+            "copyright": {
+              "$ref": "#/$defs/cyclonedx-component-2.0/$defs/copyrightText"
+            },
+            "patentAssertions": {
+              "$ref": "#/$defs/cyclonedx-patent-2.0/$defs/patentAssertions",
+              "title": "Component Patent(s)"
+            },
+            "identifiers": {
+              "$ref": "#/$defs/cyclonedx-component-2.0/$defs/identifiers"
+            },
+            "pedigree": {
+              "type": "object",
+              "title": "Component Pedigree",
+              "description": "Component pedigree is a way to document complex supply chain scenarios where components are created, distributed, modified, redistributed, combined with other components, etc. Pedigree supports viewing this complex chain from the beginning, the end, or anywhere in the middle. It also provides a way to document variants where the exact relation may not be known.",
+              "additionalProperties": false,
+              "properties": {
+                "ancestors": {
+                  "type": "array",
+                  "title": "Ancestors",
+                  "description": "Describes zero or more components in which a component is derived from. This is commonly used to describe forks from existing projects where the forked version contains an ancestor node containing the original component it was forked from. For example, Component A is the original component. Component B is the component being used and documented in the BOM. However, Component B contains a pedigree node with a single ancestor documenting Component A - the original component from which Component B is derived from.",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-component-2.0/$defs/component"
+                  }
+                },
+                "descendants": {
+                  "type": "array",
+                  "title": "Descendants",
+                  "description": "Descendants are the exact opposite of ancestors. This provides a way to document all forks (and their forks) of an original or root component.",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-component-2.0/$defs/component"
+                  }
+                },
+                "variants": {
+                  "type": "array",
+                  "title": "Variants",
+                  "description": "Variants describe relations where the relationship between the components is not known. For example, if Component A contains nearly identical code to Component B. They are both related, but it is unclear if one is derived from the other, or if they share a common ancestor.",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-component-2.0/$defs/component"
+                  }
+                },
+                "commits": {
+                  "type": "array",
+                  "title": "Commits",
+                  "description": "A list of zero or more commits which provide a trail describing how the component deviates from an ancestor, descendant, or variant.",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/commit"
+                  }
+                },
+                "patches": {
+                  "type": "array",
+                  "title": "Patches",
+                  "description": ">A list of zero or more patches describing how the component deviates from an ancestor, descendant, or variant. Patches may be complementary to commits or may be used in place of commits.",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/patch"
+                  }
+                },
+                "notes": {
+                  "type": "string",
+                  "title": "Notes",
+                  "description": "Notes, observations, and other non-structured commentary describing the components pedigree."
+                }
+              }
+            },
+            "components": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-component-2.0/$defs/componentOrChoice"
+              },
+              "uniqueItems": true,
+              "title": "Components",
+              "description": "A list of software and hardware components included in the parent component. Entries may be concrete components or component-choice wrappers expressing conditional or alternate relationships. This is not a dependency tree. It provides a way to specify a hierarchical representation of component assemblies, similar to system &#8594; subsystem &#8594; parts assembly in physical supply chains."
+            },
+            "evidence": {
+              "$ref": "#/$defs/cyclonedx-component-2.0/$defs/componentEvidence",
+              "title": "Evidence",
+              "description": "Provides the ability to document evidence collected through various forms of extraction or analysis."
+            },
+            "releaseNotes": {
+              "$ref": "#/$defs/cyclonedx-release-notes-2.0/$defs/releaseNotes",
+              "title": "Release notes",
+              "description": "Specifies release notes."
+            },
+            "modelCard": {
+              "$ref": "#/$defs/cyclonedx-ai-modelcard-2.0/$defs/modelCard",
+              "title": "AI/ML Model Card"
+            },
+            "data": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-component-2.0/$defs/componentData"
+              },
+              "title": "Data",
+              "description": "This object SHOULD be specified for any component of type `data` and must not be specified for other component types."
+            },
+            "cryptoProperties": {
+              "$ref": "#/$defs/cyclonedx-cryptography-2.0/$defs/cryptoProperties",
+              "title": "Cryptographic Properties"
+            },
+            "tags": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/tags",
+              "title": "Tags"
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            },
+            "externalReferences": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReferences"
+            },
+            "signatures": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/signatures"
+            }
+          },
+          "allOf": [
+            {
+              "description": "Requirement: ensure that `version` and `versionRange` are not present simultaneously.",
+              "not": {
+                "required": [
+                  "version",
+                  "versionRange"
+                ]
+              }
+            },
+            {
+              "description": "Requirement: 'versionRange' must not be present when 'isExternal' is `false`.",
+              "if": {
+                "properties": {
+                  "isExternal": {
+                    "const": false
+                  }
+                }
+              },
+              "then": {
+                "not": {
+                  "required": [
+                    "versionRange"
+                  ]
+                }
+              },
+              "else": true
+            }
+          ]
+        },
+        "componentOrChoice": {
+          "title": "Component or Component Choice",
+          "description": "An entry in a components array. May be a concrete component, or a component-choice wrapper that expresses a conditional or alternate relationship between two or more components. The discriminator is the `type` property: when `type` is `component-choice`, the entry shall conform to the `componentChoice` schema; otherwise it shall conform to the `component` schema.",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/cyclonedx-component-2.0/$defs/component"
+            },
+            {
+              "$ref": "#/$defs/cyclonedx-component-2.0/$defs/componentChoice"
+            }
+          ]
+        },
+        "componentChoice": {
+          "type": "object",
+          "title": "Component Choice",
+          "description": "A wrapper that expresses a conditional or alternate relationship between two or more components. Use to model approved alternates, multi-sourced parts, build variants, and required component groups in physical device bills of materials.",
+          "required": [
+            "type",
+            "operator",
+            "components"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "component-choice",
+              "title": "Type",
+              "description": "Discriminator for a component-choice entry. The value shall be the literal string `component-choice`."
+            },
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the component-choice elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "A display name for the choice. Typically corresponds to a reference designator, a design intent name, or a description of the role the chosen component fulfils.",
+              "examples": [
+                "2N2222 or PN2222A Transistor",
+                "U1 5V LDO Regulator"
+              ]
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "A description of the choice and the rationale behind the alternates."
+            },
+            "operator": {
+              "type": "string",
+              "enum": [
+                "OR",
+                "XOR",
+                "AND"
+              ],
+              "meta:enum": {
+                "OR": "Any non-empty subset of the contained components may be installed. Use for approved alternates where more than one may legitimately appear in a given instance.",
+                "XOR": "Exactly one of the contained components is installed in any single instance. Use for approved alternates that are mutually exclusive per instance, while the population of units may include multiple alternates across sourcing.",
+                "AND": "All of the contained components are installed together as a group. Use for tightly coupled component sets such as a transceiver and its required matching balun."
+              },
+              "title": "Operator",
+              "description": "The logical relationship between the contained components."
+            },
+            "components": {
+              "type": "array",
+              "minItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/cyclonedx-component-2.0/$defs/componentOrChoice"
+              },
+              "title": "Components",
+              "description": "Two or more alternate or grouped entries. Each entry may itself be a component-choice to express nested alternates, such as a choice between kits."
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            },
+            "externalReferences": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReferences"
+            }
+          }
+        },
+        "version": {
+          "description": "A single disjunctive version identifier, for a component or service.",
+          "type": "string",
+          "maxLength": 1024,
+          "examples": [
+            "9.0.14",
+            "v1.33.7",
+            "7.0.0-M1",
+            "2.0pre1",
+            "1.0.0-beta1",
+            "0.8.15"
+          ]
+        },
+        "versionRange": {
+          "description": "A version range specified in Package-URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4096,
+          "examples": [
+            "vers:cargo/9.0.14",
+            "vers:npm/1.2.3|>=2.0.0|<5.0.0",
+            "vers:pypi/0.0.0|0.0.1|0.0.2|0.0.3|1.0|2.0pre1",
+            "vers:tomee/>=1.0.0-beta1|<=1.7.5|>=7.0.0-M1|<=7.0.7|>=7.1.0|<=7.1.2|>=8.0.0-M1|<=8.0.1",
+            "vers:gem/>=2.2.0|!= 2.2.1|<2.3.0"
+          ]
+        },
+        "copyrightText": {
+          "type": "string",
+          "title": "Component Copyright",
+          "description": "A copyright notice informing users of the underlying claims to copyright ownership in a published work.",
+          "examples": [
+            "Acme Inc"
+          ]
+        },
+        "copyright": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-component-2.0/$defs/copyrightObject"
+          },
+          "title": "Copyright",
+          "description": "Captures intellectual property assertions, providing evidence of possible ownership and legal protection."
+        },
+        "copyrightObject": {
+          "type": "object",
+          "title": "Copyright",
+          "description": "A copyright notice informing users of the underlying claims to copyright ownership in a published work.",
+          "required": [
+            "text"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "text": {
+              "type": "string",
+              "title": "Copyright Text",
+              "description": "The textual content of the copyright."
+            }
+          }
+        },
+        "componentEvidence": {
+          "type": "object",
+          "title": "Evidence",
+          "description": "Provides the ability to document evidence collected through various forms of extraction or analysis.",
+          "additionalProperties": false,
+          "properties": {
+            "identity": {
+              "type": "array",
+              "title": "Identity Evidence",
+              "description": "Evidence that substantiates the identity of a component. The identity may be an object or an array of identity objects. Support for specifying identity as a single object was introduced in CycloneDX v1.5. Arrays were introduced in v1.6. It is recommended that all implementations use arrays, even if only one identity object is specified.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-component-2.0/$defs/componentIdentityEvidence"
+              }
+            },
+            "occurrences": {
+              "type": "array",
+              "title": "Occurrences",
+              "description": "Evidence of individual instances of a component spread across multiple locations.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "location"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "bom-ref": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+                    "title": "BOM Reference",
+                    "description": "An identifier which can be used to reference the occurrence elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+                  },
+                  "location": {
+                    "type": "string",
+                    "title": "Location",
+                    "description": "The location or path to where the component was found."
+                  },
+                  "line": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "title": "Line Number",
+                    "description": "The line number where the component was found."
+                  },
+                  "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "title": "Offset",
+                    "description": "The offset where the component was found."
+                  },
+                  "symbol": {
+                    "type": "string",
+                    "title": "Symbol",
+                    "description": "The symbol name that was found associated with the component."
+                  },
+                  "additionalContext": {
+                    "type": "string",
+                    "title": "Additional Context",
+                    "description": "Any additional context of the detected component (e.g. a code snippet)."
+                  },
+                  "accountInfo": {
+                    "type": "string",
+                    "title": "Account Information",
+                    "description": "The account or user information associated with the occurrence."
+                  },
+                  "systemOwner": {
+                    "type": "string",
+                    "title": "System Owner",
+                    "description": "The owner of the system where the component was found."
+                  },
+                  "startTime": {
+                    "type": "string",
+                    "format": "date-time",
+                    "title": "Start Time",
+                    "description": "The date and time when the process detecting the occurrence started."
+                  },
+                  "endTime": {
+                    "type": "string",
+                    "format": "date-time",
+                    "title": "End Time",
+                    "description": "The date and time when the process detecting the occurrence ended."
+                  },
+                  "usageCount": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "title": "Usage Count",
+                    "description": "The number of times the component occurred in the detecting process."
+                  }
+                }
+              }
+            },
+            "callstack": {
+              "type": "object",
+              "title": "Call Stack",
+              "description": "Evidence of the components use through the callstack.",
+              "additionalProperties": false,
+              "properties": {
+                "frames": {
+                  "type": "array",
+                  "title": "Frames",
+                  "description": "Within a call stack, a frame is a discrete unit that encapsulates an execution context, including local variables, parameters, and the return address. As function calls are made, frames are pushed onto the stack, forming an array-like structure that orchestrates the flow of program execution and manages the sequence of function invocations.",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "module"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "package": {
+                        "title": "Package",
+                        "description": "A package organizes modules into namespaces, providing a unique namespace for each type it contains.",
+                        "type": "string"
+                      },
+                      "module": {
+                        "title": "Module",
+                        "description": "A module or class that encloses functions/methods and other code.",
+                        "type": "string"
+                      },
+                      "function": {
+                        "title": "Function",
+                        "description": "A block of code designed to perform a particular task.",
+                        "type": "string"
+                      },
+                      "parameters": {
+                        "title": "Parameters",
+                        "description": "Arguments that are passed to the module or function.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "line": {
+                        "title": "Line",
+                        "description": "The line number the code that is called resides on.",
+                        "type": "integer"
+                      },
+                      "column": {
+                        "title": "Column",
+                        "description": "The column the code that is called resides.",
+                        "type": "integer"
+                      },
+                      "fullFilename": {
+                        "title": "Full Filename",
+                        "description": "The full path and filename of the module.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "licenses": {
+              "$ref": "#/$defs/cyclonedx-license-2.0/$defs/licenseChoice",
+              "title": "License Evidence"
+            },
+            "copyright": {
+              "$ref": "#/$defs/cyclonedx-component-2.0/$defs/copyright"
+            }
+          }
+        },
+        "componentIdentityEvidence": {
+          "type": "object",
+          "title": "Identity Evidence",
+          "description": "Evidence that substantiates the identity of a component.",
+          "required": [
+            "scheme"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "scheme": {
+              "$ref": "#/$defs/cyclonedx-component-2.0/$defs/identityScheme"
+            },
+            "confidence": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "title": "Confidence",
+              "description": "The overall confidence of the evidence from 0 - 1, where 1 is 100% confidence."
+            },
+            "concludedValue": {
+              "type": "string",
+              "title": "Concluded Value",
+              "description": "The value of the scheme that has been concluded based on the aggregate of all methods (if available)."
+            },
+            "methods": {
+              "type": "array",
+              "title": "Methods",
+              "description": "The methods used to extract and/or analyze the evidence.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "technique",
+                  "confidence"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "technique": {
+                    "title": "Technique",
+                    "description": "The technique used in this method of analysis.",
+                    "type": "string",
+                    "enum": [
+                      "source-code-analysis",
+                      "binary-analysis",
+                      "manifest-analysis",
+                      "ast-fingerprint",
+                      "hash-comparison",
+                      "instrumentation",
+                      "dynamic-analysis",
+                      "filename",
+                      "attestation",
+                      "other"
+                    ]
+                  },
+                  "confidence": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1,
+                    "title": "Confidence",
+                    "description": "The confidence of the evidence from 0 - 1, where 1 is 100% confidence. Confidence is specific to the technique used. Each technique of analysis can have independent confidence."
+                  },
+                  "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "The value or contents of the evidence."
+                  }
+                }
+              }
+            },
+            "tools": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "anyOf": [
+                  {
+                    "title": "Ref",
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType"
+                  },
+                  {
+                    "title": "BOM-Link Element",
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/bomLinkElementType"
+                  }
+                ]
+              },
+              "title": "BOM References",
+              "description": "The object in the BOM identified by its bom-ref. This is often a component or service but may be any object type supporting bom-refs. Tools used for analysis should already be defined in the BOM, either in the metadata/tools, components, or formulation."
+            }
+          }
+        },
+        "componentData": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the dataset elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+            },
+            "type": {
+              "type": "string",
+              "title": "Type of Data",
+              "description": "The general theme or subject matter of the data being specified.",
+              "enum": [
+                "source-code",
+                "configuration",
+                "dataset",
+                "definition",
+                "other"
+              ],
+              "meta:enum": {
+                "source-code": "Any type of code, code snippet, or data-as-code.",
+                "configuration": "Parameters or settings that may be used by other components.",
+                "dataset": "A collection of data.",
+                "definition": "Data that can be used to create new instances of what the definition defines.",
+                "other": "Any other type of data that does not fit into existing definitions."
+              }
+            },
+            "name": {
+              "title": "Dataset Name",
+              "description": "The name of the dataset.",
+              "type": "string"
+            },
+            "contents": {
+              "type": "object",
+              "title": "Data Contents",
+              "description": "The contents or references to the contents of the data being described.",
+              "additionalProperties": false,
+              "properties": {
+                "attachment": {
+                  "title": "Data Attachment",
+                  "description": "A way to include textual or encoded data.",
+                  "$ref": "#/$defs/cyclonedx-common-2.0/$defs/attachment"
+                },
+                "url": {
+                  "type": "string",
+                  "title": "Data URL",
+                  "description": "The URL to where the data can be retrieved.",
+                  "format": "iri-reference"
+                },
+                "properties": {
+                  "type": "array",
+                  "title": "Configuration Properties",
+                  "description": "Provides the ability to document name-value parameters used for configuration.",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/property"
+                  }
+                }
+              }
+            },
+            "classification": {
+              "$ref": "#/$defs/cyclonedx-data-2.0/$defs/dataClassification"
+            },
+            "sensitiveData": {
+              "type": "array",
+              "title": "Sensitive Data",
+              "description": "A description of any sensitive data in a dataset.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "graphics": {
+              "$ref": "#/$defs/cyclonedx-ai-modelcard-2.0/$defs/graphicsCollection"
+            },
+            "description": {
+              "title": "Dataset Description",
+              "description": "A description of the dataset. Can describe size of dataset, whether it's used for source code, training, testing, or validation, etc.",
+              "type": "string"
+            },
+            "governance": {
+              "title": "Data Governance",
+              "$ref": "#/$defs/cyclonedx-data-2.0/$defs/dataGovernance"
+            }
+          }
+        },
+        "identifiers": {
+          "type": "array",
+          "title": "Identifiers",
+          "description": "Identifiers asserted by one or more parties to identify this component. Each entry groups one or more identity claims by the party asserting them. Identifiers carry positive claims of identity. For unverified or inferred identity data, use evidence.",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-component-2.0/$defs/identifier"
+          },
+          "uniqueItems": true
+        },
+        "identifier": {
+          "type": "object",
+          "title": "Identifier",
+          "description": "A set of identifiers attributed to a single asserting party.",
+          "required": [
+            "party",
+            "identities"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType"
+            },
+            "party": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType",
+              "title": "Asserting Party",
+              "description": "Reference using bom-link or bom-ref to the party making the identity assertion."
+            },
+            "identities": {
+              "type": "array",
+              "title": "Identities",
+              "description": "The discrete identity claims asserted by the party.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-component-2.0/$defs/identity"
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          }
+        },
+        "identity": {
+          "type": "object",
+          "title": "Identity",
+          "description": "A single identity claim, pairing a typed identifier scheme with the value asserted under that scheme.",
+          "required": [
+            "scheme",
+            "value"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "scheme": {
+              "$ref": "#/$defs/cyclonedx-component-2.0/$defs/identityScheme"
+            },
+            "value": {
+              "$ref": "#/$defs/cyclonedx-component-2.0/$defs/identityValue"
+            }
+          }
+        },
+        "identityScheme": {
+          "title": "Identifier Scheme",
+          "description": "The scheme under which an identifier is asserted. Either a predefined value or a custom scheme described by name and description.",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "purl",
+                "cpe",
+                "swid",
+                "swhid",
+                "omniborid",
+                "epc-rfid",
+                "giai",
+                "gln",
+                "gmn",
+                "gtin-8",
+                "gtin-12",
+                "gtin-13",
+                "gtin-14",
+                "mpn",
+                "part-number",
+                "model-number",
+                "sku",
+                "serial-number",
+                "asset-tag",
+                "udi-di",
+                "udi-pi",
+                "fcc-id",
+                "imei",
+                "mac-address",
+                "tei"
+              ],
+              "meta:enum": {
+                "purl": "Package-URL identifier, conforming to the Package-URL specification.",
+                "cpe": "Common Platform Enumeration name, conforming to NIST Interagency Report 7695.",
+                "swid": "Software Identification tag identifier, conforming to ISO/IEC 19770-2.",
+                "swhid": "Software Heritage persistent identifier.",
+                "omniborid": "OmniBOR Artifact Identifier, also known as a gitoid.",
+                "epc-rfid": "Electronic Product Code - RFID (EPC Tag Data Standard)",
+                "giai": "Global Individual Asset Identifier (GIAI)",
+                "gln": "Global Location Number (GLN)",
+                "gmn": "Global Model Number (GMN)",
+                "gtin-8": "Global Trade Identification Number (GTIN-8 / EAN/UCC-8)",
+                "gtin-12": "Global Trade Identification Number (GTIN-12 / UPC-A)",
+                "gtin-13": "Global Trade Identification Number (GTIN-13 / EAN/UCC-13)",
+                "gtin-14": "Global Trade Identification Number (GTIN / EAN/UCC-14 or ITF-14)",
+                "mpn": "Manufacturer Part Number, assigned by the original manufacturer.",
+                "part-number": "Part number assigned by a distributor, integrator, or operator.",
+                "model-number": "Product model number assigned by the manufacturer.",
+                "sku": "Stock Keeping Unit, assigned by a seller or distributor.",
+                "serial-number": "Unique identifier for an individual instance of a product.",
+                "asset-tag": "Asset tag assigned by the owning or operating organization.",
+                "udi-di": "Unique Device Identifier, Device Identifier portion, conforming to ISO/IEC 15459 and applicable regulatory frameworks.",
+                "udi-pi": "Unique Device Identifier, Production Identifier portion, conforming to ISO/IEC 15459 and applicable regulatory frameworks.",
+                "fcc-id": "United States Federal Communications Commission equipment identifier.",
+                "imei": "International Mobile Equipment Identity, conforming to 3GPP TS 23.003.",
+                "mac-address": "IEEE 802 Media Access Control address.",
+                "tei": "Transparency Exchange Identifier conforming to the Transparency Exchange API specification."
+              }
+            },
+            {
+              "type": "object",
+              "title": "Custom Identifier Scheme",
+              "description": "A custom identifier scheme not represented in the predefined taxonomy.",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name",
+                  "description": "The name of the custom identifier scheme."
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom identifier scheme."
+                }
+              }
+            }
+          ]
+        },
+        "identityValue": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Identifier Value",
+          "description": "The value of an identifier."
+        }
+      }
+    },
+    "cyclonedx-composition-2.0": {
+      "type": "null",
+      "title": "CycloneDX Composition Model",
+      "$defs": {
+        "compositions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-composition-2.0/$defs/composition"
+          },
+          "uniqueItems": true,
+          "title": "Compositions",
+          "description": "Compositions describe constituent parts (including components, services, and dependency relationships) and their completeness. The completeness of vulnerabilities expressed in a BOM may also be described."
+        },
+        "composition": {
+          "type": "object",
+          "title": "Compositions",
+          "required": [
+            "aggregate"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the composition elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+            },
+            "aggregate": {
+              "$ref": "#/$defs/cyclonedx-composition-2.0/$defs/aggregateType",
+              "title": "Aggregate",
+              "description": "Specifies an aggregate type that describes how complete a relationship is."
+            },
+            "assemblies": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "anyOf": [
+                  {
+                    "title": "Ref",
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType"
+                  },
+                  {
+                    "title": "BOM-Link Element",
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/bomLinkElementType"
+                  }
+                ]
+              },
+              "title": "BOM references",
+              "description": "The bom-ref identifiers of the components or services being described. Assemblies refer to nested relationships whereby a constituent part may include other constituent parts. References do not cascade to child parts. References are explicit for the specified constituent part only."
+            },
+            "dependencies": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              },
+              "title": "BOM references",
+              "description": "The bom-ref identifiers of the components or services being described. Dependencies refer to a relationship whereby an independent constituent part requires another independent constituent part. References do not cascade to transitive dependencies. References are explicit for the specified dependency only."
+            },
+            "vulnerabilities": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              },
+              "title": "BOM references",
+              "description": "The bom-ref identifiers of the vulnerabilities being described."
+            },
+            "signatures": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/signatures"
+            }
+          }
+        },
+        "aggregateType": {
+          "type": "string",
+          "default": "not_specified",
+          "enum": [
+            "complete",
+            "incomplete",
+            "incomplete_first_party_only",
+            "incomplete_first_party_proprietary_only",
+            "incomplete_first_party_opensource_only",
+            "incomplete_third_party_only",
+            "incomplete_third_party_proprietary_only",
+            "incomplete_third_party_opensource_only",
+            "unknown",
+            "not_specified"
+          ],
+          "meta:enum": {
+            "complete": "The relationship is complete. No further relationships including constituent components, services, or dependencies are known to exist.",
+            "incomplete": "The relationship is incomplete. Additional relationships exist and may include constituent components, services, or dependencies.",
+            "incomplete_first_party_only": "The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented.",
+            "incomplete_first_party_proprietary_only": "The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.",
+            "incomplete_first_party_opensource_only": "The relationship is incomplete. Only relationships for first-party components, services, or their dependencies are represented, limited specifically to those that are opensource.",
+            "incomplete_third_party_only": "The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented.",
+            "incomplete_third_party_proprietary_only": "The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are proprietary.",
+            "incomplete_third_party_opensource_only": "The relationship is incomplete. Only relationships for third-party components, services, or their dependencies are represented, limited specifically to those that are opensource.",
+            "unknown": "The relationship may be complete or incomplete. This usually signifies a 'best-effort' to obtain constituent components, services, or dependencies but the completeness is inconclusive.",
+            "not_specified": "The relationship completeness is not specified."
+          }
+        }
+      }
+    },
+    "cyclonedx-cryptography-2.0": {
+      "type": "null",
+      "title": "CycloneDX Cryptography Model",
+      "$defs": {
+        "cryptoProperties": {
+          "type": "object",
+          "title": "Cryptographic Properties",
+          "description": "Cryptographic assets have properties that uniquely define them and that make them actionable for further reasoning. As an example, it makes a difference if one knows the algorithm family (e.g. AES) or the specific variant or instantiation (e.g. AES-128-GCM). This is because the security level and the algorithm primitive (authenticated encryption) are only defined by the definition of the algorithm variant. The presence of a weak cryptographic algorithm like SHA1 vs. HMAC-SHA1 also makes a difference.",
+          "additionalProperties": false,
+          "required": [
+            "assetType"
+          ],
+          "properties": {
+            "assetType": {
+              "type": "string",
+              "title": "Asset Type",
+              "description": "Cryptographic assets occur in several forms. Algorithms and protocols are most commonly implemented in specialized cryptographic libraries. They may, however, also be 'hardcoded' in software components. Certificates and related cryptographic material like keys, tokens, secrets or passwords are other cryptographic assets to be modelled.",
+              "enum": [
+                "algorithm",
+                "certificate",
+                "protocol",
+                "related-crypto-material"
+              ],
+              "meta:enum": {
+                "algorithm": "Mathematical function commonly used for data encryption, authentication, and digital signatures.",
+                "certificate": "An electronic document that is used to provide the identity or validate a public key.",
+                "protocol": "A set of rules and guidelines that govern the behavior and communication with each other.",
+                "related-crypto-material": "Other cryptographic assets related to algorithms, certificates, and protocols such as keys and tokens."
+              }
+            },
+            "algorithmProperties": {
+              "type": "object",
+              "title": "Algorithm Properties",
+              "description": "Additional properties specific to a cryptographic algorithm.",
+              "additionalProperties": false,
+              "properties": {
+                "primitive": {
+                  "type": "string",
+                  "title": "primitive",
+                  "description": "Cryptographic building blocks used in higher-level cryptographic systems and protocols. Primitives represent different cryptographic routines: deterministic random bit generators (drbg, e.g. CTR_DRBG from NIST SP800-90A-r1), message authentication codes (mac, e.g. HMAC-SHA-256), blockciphers (e.g. AES), streamciphers (e.g. Salsa20), signatures (e.g. ECDSA), hash functions (e.g. SHA-256), public-key encryption schemes (pke, e.g. RSA), extended output functions (xof, e.g. SHAKE256), key derivation functions (e.g. pbkdf2), key agreement algorithms (e.g. ECDH), key encapsulation mechanisms (e.g. ML-KEM), authenticated encryption (ae, e.g. AES-GCM) and the combination of multiple algorithms (combiner, e.g. SP800-56Cr2).",
+                  "enum": [
+                    "drbg",
+                    "mac",
+                    "block-cipher",
+                    "stream-cipher",
+                    "signature",
+                    "hash",
+                    "pke",
+                    "xof",
+                    "kdf",
+                    "key-agree",
+                    "kem",
+                    "ae",
+                    "combiner",
+                    "key-wrap",
+                    "other",
+                    "unknown"
+                  ],
+                  "meta:enum": {
+                    "drbg": "Deterministic Random Bit Generator (DRBG) is a type of pseudorandom number generator designed to produce a sequence of bits from an initial seed value. DRBGs are commonly used in cryptographic applications where reproducibility of random values is important.",
+                    "mac": "In cryptography, a Message Authentication Code (MAC) is information used for authenticating and integrity-checking a message.",
+                    "block-cipher": "A block cipher is a symmetric key algorithm that operates on fixed-size blocks of data. It encrypts or decrypts the data in block units, providing confidentiality. Block ciphers are widely used in various cryptographic modes and protocols for secure data transmission.",
+                    "stream-cipher": "A stream cipher is a symmetric key cipher where plaintext digits are combined with a pseudorandom cipher digit stream (keystream).",
+                    "signature": "In cryptography, a signature is a digital representation of a message or data that proves its origin, identity, and integrity. Digital signatures are generated using cryptographic algorithms and are widely used for authentication and verification in secure communication.",
+                    "hash": "A hash function is a mathematical algorithm that takes an input (or 'message') and produces a fixed-size string of characters, which is typically a hash value. Hash functions are commonly used in various cryptographic applications, including data integrity verification and password hashing.",
+                    "pke": "Public Key Encryption (PKE) is a type of encryption that uses a pair of public and private keys for secure communication. The public key is used for encryption, while the private key is used for decryption. PKE is a fundamental component of public-key cryptography.",
+                    "xof": "An XOF is an extendable output function that can take arbitrary input and creates a stream of output, up to a limit determined by the size of the internal state of the hash function that underlies the XOF.",
+                    "kdf": "A Key Derivation Function (KDF) derives key material from another source of entropy while preserving the entropy of the input.",
+                    "key-agree": "In cryptography, a key-agreement is a protocol whereby two or more parties agree on a cryptographic key in such a way that both influence the outcome.",
+                    "kem": "A Key Encapsulation Mechanism (KEM) algorithm is a mechanism for transporting random keying material to a recipient using the recipient's public key.",
+                    "ae": "Authenticated Encryption (AE) is a cryptographic process that provides both confidentiality and data integrity. It ensures that the encrypted data has not been tampered with and comes from a legitimate source. AE is commonly used in secure communication protocols.",
+                    "combiner": "A combiner aggregates many candidates for a cryptographic primitive and generates a new candidate for the same primitive.",
+                    "key-wrap": "Key-wrap is a cryptographic technique used to securely encrypt and protect cryptographic keys using algorithms like AES.",
+                    "other": "Another primitive type.",
+                    "unknown": "The primitive is not known."
+                  }
+                },
+                "algorithmFamily": {
+                  "$ref": "../cryptography-defs.schema.json#/definitions/algorithmFamiliesEnum",
+                  "title": "Algorithm Family",
+                  "description": "A valid algorithm family identifier. If specified, this value shall be one of the enumeration of valid algorithm Family identifiers defined in the `cryptography-defs.schema.json` subschema.",
+                  "examples": [
+                    "3DES",
+                    "Blowfish",
+                    "ECDH"
+                  ]
+                },
+                "parameterSetIdentifier": {
+                  "type": "string",
+                  "title": "Parameter Set Identifier",
+                  "description": "An identifier for the parameter set of the cryptographic algorithm. Examples: in AES128, '128' identifies the key length in bits, in SHA256, '256' identifies the digest length, '128' in SHAKE128 identifies its maximum security level in bits, and 'SHA2-128s' identifies a parameter set used in SLH-DSA (FIPS205)."
+                },
+                "ellipticCurve": {
+                  "$ref": "../cryptography-defs.schema.json#/definitions/ellipticCurvesEnum",
+                  "title": "Elliptic Curve",
+                  "description": "The specific underlying Elliptic Curve (EC) definition employed which is an indicator of the level of security strength, performance and complexity. If specified, this value shall be one of the enumeration of valid elliptic curves identifiers defined in the `cryptography-defs.schema.json` subschema."
+                },
+                "executionEnvironment": {
+                  "type": "string",
+                  "title": "Execution Environment",
+                  "description": "The target and execution environment in which the algorithm is implemented in.",
+                  "enum": [
+                    "software-plain-ram",
+                    "software-encrypted-ram",
+                    "software-tee",
+                    "hardware",
+                    "other",
+                    "unknown"
+                  ],
+                  "meta:enum": {
+                    "software-plain-ram": "A software implementation running in plain unencrypted RAM.",
+                    "software-encrypted-ram": "A software implementation running in encrypted RAM.",
+                    "software-tee": "A software implementation running in a trusted execution environment.",
+                    "hardware": "A hardware implementation.",
+                    "other": "Another implementation environment.",
+                    "unknown": "The execution environment is not known."
+                  }
+                },
+                "implementationPlatform": {
+                  "type": "array",
+                  "title": "Implementation platforms",
+                  "description": "The target platforms for which the algorithm is implemented. The implementation can be 'generic', running on any platform or for a specific platform.",
+                  "items": {
+                    "type": "string",
+                    "title": "Platform",
+                    "description": "The target platform for the implementation.",
+                    "enum": [
+                      "generic",
+                      "x86_32",
+                      "x86_64",
+                      "armv7-a",
+                      "armv7-m",
+                      "armv8-a",
+                      "armv8-m",
+                      "armv9-a",
+                      "armv9-m",
+                      "s390x",
+                      "ppc64",
+                      "ppc64le",
+                      "riscv32",
+                      "riscv64",
+                      "other",
+                      "unknown"
+                    ],
+                    "meta:enum": {
+                      "generic": "Platform-independent implementation.",
+                      "x86_32": "Intel/AMD 32-bit x86 architecture.",
+                      "x86_64": "Intel/AMD 64-bit x86-64 architecture.",
+                      "armv7-a": "ARM 32-bit application profile (Cortex-A).",
+                      "armv7-m": "ARM 32-bit microcontroller profile (Cortex-M).",
+                      "armv8-a": "ARM 64-bit application profile (AArch64).",
+                      "armv8-m": "ARM 32-bit microcontroller with TrustZone.",
+                      "armv9-a": "ARM 64-bit with enhanced security features.",
+                      "armv9-m": "ARM microcontroller with advanced security.",
+                      "s390x": "IBM Z series mainframe 64-bit.",
+                      "ppc64": "IBM PowerPC 64-bit big-endian.",
+                      "ppc64le": "IBM PowerPC 64-bit little-endian.",
+                      "riscv32": "RISC-V 32-bit open standard architecture.",
+                      "riscv64": "RISC-V 64-bit open standard architecture.",
+                      "other": "Another platform.",
+                      "unknown": "The platform is not known."
+                    }
+                  }
+                },
+                "certificationLevel": {
+                  "type": "array",
+                  "title": "Certification Level",
+                  "description": "The certification that the implementation of the cryptographic algorithm has received, if any. Certifications include revisions and levels of FIPS 140 or Common Criteria of different Extended Assurance Levels (CC-EAL).",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "none",
+                      "fips140-1-l1",
+                      "fips140-1-l2",
+                      "fips140-1-l3",
+                      "fips140-1-l4",
+                      "fips140-2-l1",
+                      "fips140-2-l2",
+                      "fips140-2-l3",
+                      "fips140-2-l4",
+                      "fips140-3-l1",
+                      "fips140-3-l2",
+                      "fips140-3-l3",
+                      "fips140-3-l4",
+                      "cc-eal1",
+                      "cc-eal1+",
+                      "cc-eal2",
+                      "cc-eal2+",
+                      "cc-eal3",
+                      "cc-eal3+",
+                      "cc-eal4",
+                      "cc-eal4+",
+                      "cc-eal5",
+                      "cc-eal5+",
+                      "cc-eal6",
+                      "cc-eal6+",
+                      "cc-eal7",
+                      "cc-eal7+",
+                      "cavp",
+                      "other",
+                      "unknown"
+                    ],
+                    "meta:enum": {
+                      "none": "No certification obtained",
+                      "fips140-1-l1": "FIPS 140-1 Level 1",
+                      "fips140-1-l2": "FIPS 140-1 Level 2",
+                      "fips140-1-l3": "FIPS 140-1 Level 3",
+                      "fips140-1-l4": "FIPS 140-1 Level 4",
+                      "fips140-2-l1": "FIPS 140-2 Level 1",
+                      "fips140-2-l2": "FIPS 140-2 Level 2",
+                      "fips140-2-l3": "FIPS 140-2 Level 3",
+                      "fips140-2-l4": "FIPS 140-2 Level 4",
+                      "fips140-3-l1": "FIPS 140-3 Level 1",
+                      "fips140-3-l2": "FIPS 140-3 Level 2",
+                      "fips140-3-l3": "FIPS 140-3 Level 3",
+                      "fips140-3-l4": "FIPS 140-3 Level 4",
+                      "cc-eal1": "Common Criteria - Evaluation Assurance Level 1",
+                      "cc-eal1+": "Common Criteria - Evaluation Assurance Level 1 (Augmented)",
+                      "cc-eal2": "Common Criteria - Evaluation Assurance Level 2",
+                      "cc-eal2+": "Common Criteria - Evaluation Assurance Level 2 (Augmented)",
+                      "cc-eal3": "Common Criteria - Evaluation Assurance Level 3",
+                      "cc-eal3+": "Common Criteria - Evaluation Assurance Level 3 (Augmented)",
+                      "cc-eal4": "Common Criteria - Evaluation Assurance Level 4",
+                      "cc-eal4+": "Common Criteria - Evaluation Assurance Level 4 (Augmented)",
+                      "cc-eal5": "Common Criteria - Evaluation Assurance Level 5",
+                      "cc-eal5+": "Common Criteria - Evaluation Assurance Level 5 (Augmented)",
+                      "cc-eal6": "Common Criteria - Evaluation Assurance Level 6",
+                      "cc-eal6+": "Common Criteria - Evaluation Assurance Level 6 (Augmented)",
+                      "cc-eal7": "Common Criteria - Evaluation Assurance Level 7",
+                      "cc-eal7+": "Common Criteria - Evaluation Assurance Level 7 (Augmented)",
+                      "cavp": "Cryptographic Algorithm Validation Program",
+                      "other": "Another certification",
+                      "unknown": "The certification level is not known"
+                    }
+                  }
+                },
+                "mode": {
+                  "type": "string",
+                  "title": "Mode",
+                  "description": "The mode of operation in which the cryptographic algorithm (block cipher) is used.",
+                  "enum": [
+                    "cbc",
+                    "ecb",
+                    "ccm",
+                    "gcm",
+                    "cfb",
+                    "ofb",
+                    "ctr",
+                    "siv",
+                    "gcm-siv",
+                    "ocb",
+                    "eax",
+                    "kw",
+                    "kwp",
+                    "cts",
+                    "xts",
+                    "gmac",
+                    "cmac",
+                    "xpn",
+                    "ff1",
+                    "ff3-1",
+                    "other",
+                    "unknown"
+                  ],
+                  "meta:enum": {
+                    "cbc": "Cipher Block Chaining mode.",
+                    "ecb": "Electronic Codebook mode.",
+                    "ccm": "Counter with CBC-MAC (AEAD).",
+                    "gcm": "Galois/Counter Mode (AEAD).",
+                    "cfb": "Cipher Feedback mode.",
+                    "ofb": "Output Feedback mode.",
+                    "ctr": "Counter mode.",
+                    "siv": "Synthetic Initialization Vector mode.",
+                    "gcm-siv": "GCM with Synthetic IV (nonce-misuse resistant).",
+                    "ocb": "Offset Codebook Mode (AEAD).",
+                    "eax": "Encrypt-then-Authenticate-then-Translate mode.",
+                    "kw": "AES Key Wrap (RFC 3394).",
+                    "kwp": "AES Key Wrap with Padding (RFC 5649).",
+                    "cts": "Ciphertext Stealing mode.",
+                    "xts": "XEX Tweaked-codebook with Stealing (disk encryption).",
+                    "gmac": "Galois Message Authentication Code",
+                    "cmac": "Cipher-based Message Authentication Code",
+                    "xpn": "Extended Packet Numbering mode.",
+                    "ff1": "Format-preserving encryption mode 1.",
+                    "ff3-1": "Format-preserving encryption mode 3, update 1.",
+                    "other": "Another mode of operation.",
+                    "unknown": "The mode is not known."
+                  }
+                },
+                "padding": {
+                  "type": "string",
+                  "title": "Padding",
+                  "description": "The padding scheme that is used for the cryptographic algorithm.",
+                  "enum": [
+                    "pkcs5",
+                    "pkcs7",
+                    "pkcs1v15",
+                    "oaep",
+                    "raw",
+                    "pss",
+                    "x931",
+                    "other",
+                    "unknown"
+                  ],
+                  "meta:enum": {
+                    "pkcs5": "PKCS#5 padding for password-based cryptography.",
+                    "pkcs7": "PKCS#7 padding with length-indicating bytes.",
+                    "pkcs1v15": "PKCS#1 v1.5 padding for RSA.",
+                    "oaep": "Optimal Asymmetric Encryption Padding for RSA.",
+                    "raw": "No padding applied.",
+                    "pss": "Probabilistic Signature Scheme for RSA signatures.",
+                    "x931": "ANSI X9.31 padding for RSA.",
+                    "other": "Another padding scheme.",
+                    "unknown": "The padding scheme is not known."
+                  }
+                },
+                "cryptoFunctions": {
+                  "type": "array",
+                  "title": "Cryptographic functions",
+                  "description": "The cryptographic functions implemented by the cryptographic algorithm.",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-cryptography-2.0/$defs/cryptographicFunction"
+                  }
+                },
+                "classicalSecurityLevel": {
+                  "type": "integer",
+                  "title": "classical security level",
+                  "description": "The classical security level that a cryptographic algorithm provides (in bits).",
+                  "minimum": 0
+                },
+                "nistQuantumSecurityLevel": {
+                  "type": "integer",
+                  "title": "NIST security strength category",
+                  "description": "The NIST security strength category as defined in https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/evaluation-criteria/security-(evaluation-criteria). A value of 0 indicates that none of the categories are met.",
+                  "minimum": 0,
+                  "maximum": 6
+                },
+                "secProperties": {
+                  "type": "array",
+                  "title": "Security Properties",
+                  "description": "Formal guarantees about an algorithm's resistance to specific adversarial capabilities under a defined threat model. Example: Key Encapsulation Mechanisms (KEMs) may target IND-CPA or IND-CCA security; choosing IND-CCA impacts safe use in settings with active/chosen-ciphertext attacks.",
+                  "items": {
+                    "type": "string",
+                    "title": "Security Property",
+                    "examples": [
+                      "IND-CPA",
+                      "IND-CCA",
+                      "IND-CCA2",
+                      "SUF-CMA",
+                      "EUF-CMA",
+                      "collision-resistant",
+                      "preimage-resistant",
+                      "second-preimage-resistant"
+                    ]
+                  }
+                }
+              }
+            },
+            "certificateProperties": {
+              "type": "object",
+              "title": "Certificate Properties",
+              "description": "Properties for cryptographic assets of asset type 'certificate'.",
+              "additionalProperties": false,
+              "properties": {
+                "serialNumber": {
+                  "type": "string",
+                  "title": "Serial Number",
+                  "description": "The serial number is a unique identifier for the certificate issued by a CA."
+                },
+                "subjectName": {
+                  "type": "string",
+                  "title": "Subject Name",
+                  "description": "The subject name for the certificate."
+                },
+                "issuerName": {
+                  "type": "string",
+                  "title": "Issuer Name",
+                  "description": "The issuer name for the certificate."
+                },
+                "notValidBefore": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "Not Valid Before",
+                  "description": "The date and time according to ISO-8601 standard from which the certificate is valid."
+                },
+                "notValidAfter": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "Not Valid After",
+                  "description": "The date and time according to ISO-8601 standard from which the certificate is not valid anymore."
+                },
+                "certificateFormat": {
+                  "type": "string",
+                  "title": "Certificate Format",
+                  "description": "The format of the certificate.",
+                  "examples": [
+                    "X.509",
+                    "PEM",
+                    "DER",
+                    "CVC"
+                  ]
+                },
+                "certificateFileExtension": {
+                  "type": "string",
+                  "title": "Certificate File Extension",
+                  "description": "The file extension of the certificate.",
+                  "examples": [
+                    "crt",
+                    "pem",
+                    "cer",
+                    "der",
+                    "p12"
+                  ]
+                },
+                "fingerprint": {
+                  "$ref": "#/$defs/cyclonedx-cryptography-2.0/$defs/fingerprint",
+                  "title": "Certificate Fingerprint",
+                  "description": "The fingerprint is a cryptographic hash of the certificate excluding it's signature."
+                },
+                "certificateState": {
+                  "type": "array",
+                  "title": "Certificate Lifecycle State",
+                  "description": "The certificate lifecycle is a comprehensive process that manages digital certificates from their initial creation to eventual expiration or revocation. It typically involves several stages.",
+                  "items": {
+                    "type": "object",
+                    "title": "State",
+                    "description": "The state of the certificate.",
+                    "oneOf": [
+                      {
+                        "title": "Pre-Defined State",
+                        "required": [
+                          "state"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                          "state": {
+                            "type": "string",
+                            "title": "State",
+                            "description": "A pre-defined state in the certificate lifecycle.",
+                            "enum": [
+                              "pre-activation",
+                              "active",
+                              "suspended",
+                              "deactivated",
+                              "revoked",
+                              "destroyed"
+                            ],
+                            "meta:enum": {
+                              "pre-activation": "The certificate has been issued by the issuing certificate authority (CA) but has not been authorized for use.",
+                              "active": "The certificate may be used to cryptographically protect information, cryptographically process previously protected information, or both.",
+                              "deactivated": "Certificates in the deactivated state shall not be used to apply cryptographic protection but, in some cases, may be used to process cryptographically protected information.",
+                              "suspended": "The use of a certificate may be suspended for several possible reasons.",
+                              "revoked": "A revoked certificate is a digital certificate that has been invalidated by the issuing certificate authority (CA) before its scheduled expiration date.",
+                              "destroyed": "The certificate has been destroyed."
+                            }
+                          },
+                          "reason": {
+                            "type": "string",
+                            "title": "Reason",
+                            "description": "A reason for the certificate being in this state."
+                          }
+                        }
+                      },
+                      {
+                        "title": "Custom State",
+                        "required": [
+                          "name"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "title": "State",
+                            "description": "The name of the certificate lifecycle state."
+                          },
+                          "description": {
+                            "type": "string",
+                            "title": "Description",
+                            "description": "The description of the certificate lifecycle state."
+                          },
+                          "reason": {
+                            "type": "string",
+                            "title": "Reason",
+                            "description": "A reason for the certificate being in this state."
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "creationDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "Creation Date",
+                  "description": "The date and time (timestamp) when the certificate was created or pre-activated."
+                },
+                "activationDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "Activation Date",
+                  "description": "The date and time (timestamp) when the certificate was activated."
+                },
+                "deactivationDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "Deactivation Date",
+                  "description": "The date and time (timestamp) when the related certificate was deactivated."
+                },
+                "revocationDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "Revocation Date",
+                  "description": "The date and time (timestamp) when the certificate was revoked."
+                },
+                "destructionDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "Destruction Date",
+                  "description": "The date and time (timestamp) when the certificate was destroyed."
+                },
+                "certificateExtensions": {
+                  "type": "array",
+                  "title": "Certificate Extensions",
+                  "description": "A certificate extension is a field that provides additional information about the certificate or its use. Extensions are used to convey additional information beyond the standard fields.",
+                  "items": {
+                    "type": "object",
+                    "title": "Extension",
+                    "description": "",
+                    "oneOf": [
+                      {
+                        "title": "Common Extensions",
+                        "required": [
+                          "commonExtensionName",
+                          "commonExtensionValue"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                          "commonExtensionName": {
+                            "type": "string",
+                            "title": "name",
+                            "description": "The name of the extension.",
+                            "enum": [
+                              "basicConstraints",
+                              "keyUsage",
+                              "extendedKeyUsage",
+                              "subjectAlternativeName",
+                              "authorityKeyIdentifier",
+                              "subjectKeyIdentifier",
+                              "authorityInformationAccess",
+                              "certificatePolicies",
+                              "crlDistributionPoints",
+                              "signedCertificateTimestamp"
+                            ],
+                            "meta:enum": {
+                              "basicConstraints": "Specifies whether a certificate can be used as a CA certificate or not.",
+                              "keyUsage": "Specifies the allowed uses of the public key in the certificate.",
+                              "extendedKeyUsage": "Specifies additional purposes for which the public key can be used.",
+                              "subjectAlternativeName": "Allows inclusion of additional names to identify the entity associated with the certificate.",
+                              "authorityKeyIdentifier": "Identifies the public key of the CA that issued the certificate.",
+                              "subjectKeyIdentifier": "Identifies the public key associated with the entity the certificate was issued to.",
+                              "authorityInformationAccess": "Contains CA issuers and OCSP information.",
+                              "certificatePolicies": "Defines the policies under which the certificate was issued and can be used.",
+                              "crlDistributionPoints": "Contains one or more URLs where a Certificate Revocation List (CRL) can be obtained.",
+                              "signedCertificateTimestamp": "Shows that the certificate has been publicly logged, which helps prevent the issuance of rogue certificates by a CA. Log ID, timestamp and signature as proof."
+                            }
+                          },
+                          "commonExtensionValue": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The value of the certificate extension."
+                          }
+                        }
+                      },
+                      {
+                        "title": "Custom Extensions",
+                        "description": "Custom extensions may convey application-specific or vendor-specific data not covered by standard extensions. The structure and semantics of custom extensions are typically defined outside of public standards. CycloneDX leverages properties to support this capability.",
+                        "required": [
+                          "customExtensionName"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                          "customExtensionName": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The name for the custom certificate extension."
+                          },
+                          "customExtensionValue": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "The description of the custom certificate extension."
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "relatedCryptographicAssets": {
+                  "$ref": "#/$defs/cyclonedx-cryptography-2.0/$defs/relatedCryptographicAssets"
+                }
+              }
+            },
+            "relatedCryptoMaterialProperties": {
+              "type": "object",
+              "title": "Related Cryptographic Material Properties",
+              "description": "Properties for cryptographic assets of asset type: `related-crypto-material`.",
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "title": "relatedCryptoMaterialType",
+                  "description": "The type for the related cryptographic material.",
+                  "enum": [
+                    "private-key",
+                    "public-key",
+                    "secret-key",
+                    "key",
+                    "ciphertext",
+                    "signature",
+                    "digest",
+                    "initialization-vector",
+                    "nonce",
+                    "seed",
+                    "salt",
+                    "shared-secret",
+                    "tag",
+                    "additional-data",
+                    "password",
+                    "credential",
+                    "token",
+                    "other",
+                    "unknown"
+                  ],
+                  "meta:enum": {
+                    "private-key": "The confidential key of a key pair used in asymmetric cryptography.",
+                    "public-key": "The non-confidential key of a key pair used in asymmetric cryptography.",
+                    "secret-key": "A key used to encrypt and decrypt messages in symmetric cryptography.",
+                    "key": "A piece of information, usually an octet string, which, when processed through a cryptographic algorithm, processes cryptographic data.",
+                    "ciphertext": "The result of encryption performed on plaintext using an algorithm (or cipher).",
+                    "signature": "A cryptographic value that is calculated from the data and a key known only by the signer.",
+                    "digest": "The output of the hash function.",
+                    "initialization-vector": "A fixed-size random or pseudo-random value used as an input parameter for cryptographic algorithms.",
+                    "nonce": "A random or pseudo-random number that can only be used once in a cryptographic communication.",
+                    "seed": "The input to a pseudo-random number generator. Different seeds generate different pseudo-random sequences.",
+                    "salt": "A value used in a cryptographic process, usually to ensure that the results of computations for one instance cannot be reused by an attacker.",
+                    "shared-secret": "A piece of data known only to the parties involved, in a secure communication.",
+                    "tag": "A message authentication code (MAC), sometimes known as an authentication tag, is a short piece of information used for authenticating and integrity-checking a message.",
+                    "additional-data": "An unspecified collection of data with relevance to cryptographic activity.",
+                    "password": "A secret word, phrase, or sequence of characters used during authentication or authorization.",
+                    "credential": "Establishes the identity of a party to communication, usually in the form of cryptographic keys or passwords.",
+                    "token": "An object encapsulating a security identity.",
+                    "other": "Another type of cryptographic asset.",
+                    "unknown": "The type of cryptographic asset is not known."
+                  }
+                },
+                "id": {
+                  "type": "string",
+                  "title": "ID",
+                  "description": "The unique identifier for the related cryptographic material."
+                },
+                "state": {
+                  "type": "string",
+                  "title": "State",
+                  "description": "The key state as defined by NIST SP 800-57.",
+                  "enum": [
+                    "pre-activation",
+                    "active",
+                    "suspended",
+                    "deactivated",
+                    "compromised",
+                    "destroyed"
+                  ]
+                },
+                "creationDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "Creation Date",
+                  "description": "The date and time (timestamp) when the related cryptographic material was created."
+                },
+                "activationDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "Activation Date",
+                  "description": "The date and time (timestamp) when the related cryptographic material was activated."
+                },
+                "updateDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "Update Date",
+                  "description": "The date and time (timestamp) when the related cryptographic material was updated."
+                },
+                "expirationDate": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "Expiration Date",
+                  "description": "The date and time (timestamp) when the related cryptographic material expires."
+                },
+                "value": {
+                  "type": "string",
+                  "title": "Value",
+                  "description": "The associated value of the cryptographic material."
+                },
+                "size": {
+                  "type": "integer",
+                  "title": "Size",
+                  "description": "The size of the cryptographic asset (in bits)."
+                },
+                "format": {
+                  "type": "string",
+                  "title": "Format",
+                  "description": "The format of the related cryptographic material (e.g. P8, PEM, DER)."
+                },
+                "securedBy": {
+                  "$ref": "#/$defs/cyclonedx-cryptography-2.0/$defs/securedBy",
+                  "title": "Secured By",
+                  "description": "The mechanism by which the cryptographic asset is secured by."
+                },
+                "fingerprint": {
+                  "$ref": "#/$defs/cyclonedx-cryptography-2.0/$defs/fingerprint"
+                },
+                "relatedCryptographicAssets": {
+                  "$ref": "#/$defs/cyclonedx-cryptography-2.0/$defs/relatedCryptographicAssets"
+                },
+                "keyUsage": {
+                  "type": "array",
+                  "title": "Key Usage",
+                  "description": "Defines the permitted cryptographic usage for the asset.",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-cryptography-2.0/$defs/cryptographicFunction",
+                    "title": "Usage",
+                    "description": "A permitted cryptographic usage."
+                  }
+                }
+              }
+            },
+            "protocolProperties": {
+              "type": "object",
+              "title": "Protocol Properties",
+              "description": "Properties specific to cryptographic assets of type: `protocol`.",
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "title": "Type",
+                  "description": "The concrete protocol type.",
+                  "enum": [
+                    "tls",
+                    "ssh",
+                    "ipsec",
+                    "ike",
+                    "sstp",
+                    "wpa",
+                    "dtls",
+                    "quic",
+                    "eap-aka",
+                    "eap-aka-prime",
+                    "prins",
+                    "5g-aka",
+                    "other",
+                    "unknown"
+                  ],
+                  "meta:enum": {
+                    "tls": "Transport Layer Security",
+                    "ssh": "Secure Shell",
+                    "ipsec": "Internet Protocol Security",
+                    "ike": "Internet Key Exchange",
+                    "sstp": "Secure Socket Tunneling Protocol",
+                    "wpa": "Wi-Fi Protected Access",
+                    "dtls": "Datagram Transport Layer Security",
+                    "quic": "Quick UDP Internet Connections",
+                    "eap-aka": "Extensible Authentication Protocol variant",
+                    "eap-aka-prime": "Enhanced version of EAP-AKA",
+                    "prins": "Protection of Inter-Network Signaling",
+                    "5g-aka": "Authentication and Key Agreement for 5G",
+                    "other": "Another protocol type",
+                    "unknown": "The protocol type is not known"
+                  }
+                },
+                "version": {
+                  "type": "string",
+                  "title": "Protocol Version",
+                  "description": "The version of the protocol.",
+                  "examples": [
+                    "1.0",
+                    "1.2",
+                    "1.99"
+                  ]
+                },
+                "cipherSuites": {
+                  "type": "array",
+                  "title": "Cipher Suites",
+                  "description": "A list of cipher suites related to the protocol.",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-cryptography-2.0/$defs/cipherSuite",
+                    "title": "Cipher Suite"
+                  }
+                },
+                "ikev2TransformTypes": {
+                  "type": "object",
+                  "title": "IKEv2 Transform Types",
+                  "description": "The IKEv2 transform types supported (types 1-4), defined in [RFC 7296 section 3.3.2](https://www.ietf.org/rfc/rfc7296.html#section-3.3.2), and additional properties.",
+                  "additionalProperties": false,
+                  "properties": {
+                    "encr": {
+                      "type": "array",
+                      "title": "Encryption Algorithms (ENCR)",
+                      "description": "Transform Type 1: encryption algorithms.",
+                      "items": {
+                        "$ref": "#/$defs/cyclonedx-cryptography-2.0/$defs/ikeV2Enc",
+                        "title": "Encryption Algorithm (ENCR)"
+                      }
+                    },
+                    "prf": {
+                      "type": "array",
+                      "title": "Pseudorandom Functions (PRF)",
+                      "description": "Transform Type 2: pseudorandom functions.",
+                      "items": {
+                        "$ref": "#/$defs/cyclonedx-cryptography-2.0/$defs/ikeV2Prf",
+                        "title": "Pseudorandom Function (PRF)"
+                      }
+                    },
+                    "integ": {
+                      "type": "array",
+                      "title": "Integrity Algorithms (INTEG)",
+                      "description": "Transform Type 3: integrity algorithms.",
+                      "items": {
+                        "$ref": "#/$defs/cyclonedx-cryptography-2.0/$defs/ikeV2Integ",
+                        "title": "Integrity Algorithm (INTEG)"
+                      }
+                    },
+                    "ke": {
+                      "type": "array",
+                      "title": "Key Exchange Methods (KE)",
+                      "description": "Transform Type 4: Key Exchange Method (KE) per [RFC 9370](https://www.ietf.org/rfc/rfc9370.html), formerly called Diffie-Hellman Group (D-H).",
+                      "items": {
+                        "$ref": "#/$defs/cyclonedx-cryptography-2.0/$defs/ikeV2Ke"
+                      }
+                    },
+                    "esn": {
+                      "type": "boolean",
+                      "title": "Extended Sequence Number (ESN)",
+                      "description": "Specifies if an Extended Sequence Number (ESN) is used."
+                    },
+                    "auth": {
+                      "type": "array",
+                      "title": "IKEv2 Authentication methods",
+                      "description": "IKEv2 Authentication method per [RFC9593](https://www.ietf.org/rfc/rfc9593.html).",
+                      "items": {
+                        "$ref": "#/$defs/cyclonedx-cryptography-2.0/$defs/ikeV2Auth",
+                        "title": "IKEv2 Authentication Method"
+                      }
+                    }
+                  }
+                },
+                "relatedCryptographicAssets": {
+                  "$ref": "#/$defs/cyclonedx-cryptography-2.0/$defs/relatedCryptographicAssets"
+                }
+              }
+            },
+            "oid": {
+              "type": "string",
+              "title": "OID",
+              "description": "The object identifier (OID) of the cryptographic asset."
+            }
+          }
+        },
+        "cipherSuite": {
+          "type": "object",
+          "title": "Cipher Suite",
+          "description": "Object representing a cipher suite.",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Common Name",
+              "description": "A common name for the cipher suite.",
+              "examples": [
+                "TLS_DHE_RSA_WITH_AES_128_CCM"
+              ]
+            },
+            "algorithms": {
+              "type": "array",
+              "title": "Related Algorithms",
+              "description": "A list of algorithms related to the cipher suite.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+                "title": "Algorithm reference",
+                "description": "The bom-ref to algorithm cryptographic asset."
+              }
+            },
+            "identifiers": {
+              "type": "array",
+              "title": "Cipher Suite Identifiers",
+              "description": "A list of common identifiers for the cipher suite.",
+              "items": {
+                "type": "string",
+                "title": "identifier",
+                "description": "Cipher suite identifier.",
+                "examples": [
+                  "0xC0",
+                  "0x9E"
+                ]
+              }
+            },
+            "tlsGroups": {
+              "type": "array",
+              "title": "TLS Groups",
+              "description": "A list of TLS named groups (formerly known as curves) for this cipher suite. These groups define the parameters for key exchange algorithms like ECDHE.",
+              "items": {
+                "type": "string",
+                "title": "Group Name",
+                "description": "The name of the TLS group.",
+                "examples": [
+                  "x25519",
+                  "ffdhe2048"
+                ]
+              }
+            },
+            "tlsSignatureSchemes": {
+              "type": "array",
+              "title": "TLS Signature Schemes",
+              "description": "A list of signature schemes supported for cipher suite. These schemes specify the algorithms used for digital signatures in TLS handshakes and certificate verification.",
+              "items": {
+                "type": "string",
+                "title": "Signature Scheme",
+                "description": "The name of the TLS signature scheme.",
+                "examples": [
+                  "ecdsa_secp256r1_sha256",
+                  "rsa_pss_rsae_sha256",
+                  "ed25519"
+                ]
+              }
+            }
+          }
+        },
+        "ikeV2Enc": {
+          "type": "object",
+          "title": "Encryption Algorithm (ENCR)",
+          "description": "Object representing an encryption algorithm (ENCR).",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "A name for the encryption method.",
+              "examples": [
+                "ENCR_AES_GCM_16"
+              ]
+            },
+            "keyLength": {
+              "type": "integer",
+              "title": "Encryption algorithm key length",
+              "description": "The key length of the encryption algorithm."
+            },
+            "algorithm": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "Algorithm reference",
+              "description": "The bom-ref to algorithm cryptographic asset."
+            }
+          }
+        },
+        "ikeV2Prf": {
+          "type": "object",
+          "title": "Pseudorandom Function (PRF)",
+          "description": "Object representing a pseudorandom function (PRF).",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "A name for the pseudorandom function.",
+              "examples": [
+                "PRF_HMAC_SHA2_256"
+              ]
+            },
+            "algorithm": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "Algorithm reference",
+              "description": "The bom-ref to algorithm cryptographic asset."
+            }
+          }
+        },
+        "ikeV2Integ": {
+          "type": "object",
+          "title": "Integrity Algorithm (INTEG)",
+          "description": "Object representing an integrity algorithm (INTEG).",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "A name for the integrity algorithm.",
+              "examples": [
+                "AUTH_HMAC_SHA2_256_128"
+              ]
+            },
+            "algorithm": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "Algorithm reference",
+              "description": "The bom-ref to algorithm cryptographic asset."
+            }
+          }
+        },
+        "ikeV2Ke": {
+          "type": "object",
+          "title": "Key Exchange Method (KE)",
+          "description": "Object representing a key exchange method (KE).",
+          "additionalProperties": false,
+          "properties": {
+            "group": {
+              "type": "integer",
+              "title": "Group Identifier",
+              "description": "A group identifier for the key exchange algorithm."
+            },
+            "algorithm": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "Algorithm reference",
+              "description": "The bom-ref to algorithm cryptographic asset."
+            }
+          }
+        },
+        "ikeV2Auth": {
+          "type": "object",
+          "title": "IKEv2 Authentication method",
+          "description": "Object representing a IKEv2 Authentication method.",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "A name for the authentication method."
+            },
+            "algorithm": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "Algorithm reference",
+              "description": "The bom-ref to algorithm cryptographic asset."
+            }
+          }
+        },
+        "cryptographicFunction": {
+          "type": "string",
+          "title": "Cryptographic Function",
+          "description": "A cryptographic function or usage.",
+          "enum": [
+            "generate",
+            "paramgen",
+            "paramver",
+            "keygen",
+            "keyver",
+            "encrypt",
+            "decrypt",
+            "digest",
+            "tag",
+            "keyderive",
+            "sign",
+            "verify",
+            "encapsulate",
+            "decapsulate",
+            "keyagree",
+            "wrap",
+            "unwrap",
+            "other",
+            "unknown"
+          ],
+          "meta:enum": {
+            "generate": "Generates random data, IVs, or nonces.",
+            "paramgen": "Generates cryptographic domain parameters.",
+            "paramver": "Verifies cryptographic domain parameters.",
+            "keygen": "Generates cryptographic keys.",
+            "keyver": "Verifies cryptographic keys.",
+            "encrypt": "Transforms plaintext into ciphertext.",
+            "decrypt": "Transforms ciphertext into plaintext.",
+            "digest": "Computes a hash value from input data.",
+            "tag": "Generates an authentication tag for data integrity.",
+            "keyderive": "Derives keys from another key or shared secret.",
+            "sign": "Creates a digital signature using a private key.",
+            "verify": "Verifies a digital signature using a public key.",
+            "encapsulate": "Encapsulates a secret using a public key (KEM).",
+            "decapsulate": "Decapsulates a secret using a private key (KEM).",
+            "keyagree": "Derives a shared secret between parties.",
+            "wrap": "Encrypts a key for secure storage or transport.",
+            "unwrap": "Decrypts a wrapped key to recover the original key.",
+            "other": "Another cryptographic function.",
+            "unknown": "The cryptographic function is not known."
+          }
+        },
+        "relatedCryptographicAssets": {
+          "type": "array",
+          "title": "Related Cryptographic Assets",
+          "description": "A list of cryptographic assets related to this component.",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-cryptography-2.0/$defs/relatedCryptographicAsset"
+          }
+        },
+        "relatedCryptographicAsset": {
+          "type": "object",
+          "title": "Related Cryptographic Asset",
+          "description": "A cryptographic assets related to this component.",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "description": "Specifies the mechanism by which the cryptographic asset is secured by.",
+              "examples": [
+                "publicKey",
+                "privateKey",
+                "algorithm"
+              ]
+            },
+            "ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "Reference to cryptographic asset",
+              "description": "The bom-ref to cryptographic asset."
+            }
+          }
+        },
+        "fingerprint": {
+          "type": "object",
+          "title": "Fingerprint",
+          "description": "The fingerprint is a cryptographic hash of the asset.",
+          "oneOf": [
+            {
+              "title": "Standard Hash",
+              "description": "A fingerprint computed using a standard, well-known hash algorithm.",
+              "required": [
+                "alg",
+                "content"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "alg": {
+                  "$ref": "#/$defs/cyclonedx-common-2.0/$defs/hashAlgorithm"
+                },
+                "content": {
+                  "$ref": "#/$defs/cyclonedx-common-2.0/$defs/hashValue"
+                }
+              }
+            },
+            {
+              "title": "Custom Fingerprint",
+              "description": "A fingerprint computed with a custom or non-standard algorithm not covered by the standard hash algorithms.",
+              "required": [
+                "customAlg",
+                "customContent"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "customAlg": {
+                  "type": "string",
+                  "title": "Custom Fingerprint Algorithm",
+                  "description": "The name of the custom algorithm used to compute the fingerprint."
+                },
+                "customContent": {
+                  "type": "string",
+                  "title": "Custom Fingerprint Content",
+                  "description": "The value of the fingerprint computed using the custom algorithm."
+                }
+              }
+            }
+          ]
+        },
+        "securedBy": {
+          "type": "object",
+          "title": "Secured By",
+          "description": "Specifies the mechanism by which the cryptographic asset is secured by.",
+          "additionalProperties": false,
+          "properties": {
+            "mechanism": {
+              "type": "string",
+              "title": "Mechanism",
+              "description": "Specifies the mechanism by which the cryptographic asset is secured by.",
+              "examples": [
+                "HSM",
+                "TPM",
+                "SGX",
+                "Software",
+                "None"
+              ]
+            },
+            "algorithmRef": {
+              "type": "array",
+              "title": "References",
+              "description": "The bom-refs to the assets securing this asset (e.g., algorithms, hardware, keys).",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType"
+              }
+            }
+          }
+        }
+      }
+    },
+    "cyclonedx-data-2.0": {
+      "type": "null",
+      "title": "CycloneDX Data Model",
+      "$defs": {
+        "dataClassification": {
+          "type": "string",
+          "title": "Data Classification",
+          "description": "Data classification tags data according to its type, sensitivity, and value if altered, stolen, or destroyed."
+        },
+        "dataGovernance": {
+          "type": "object",
+          "title": "Data Governance",
+          "description": "Data governance captures information regarding data ownership, stewardship, and custodianship, providing insights into the individuals or entities responsible for managing, overseeing, and safeguarding the data throughout its lifecycle.",
+          "additionalProperties": false,
+          "properties": {
+            "custodians": {
+              "type": "array",
+              "title": "Data Custodians",
+              "description": "Data custodians are responsible for the safe custody, transport, and storage of data.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-data-2.0/$defs/dataGovernanceResponsibleParty"
+              }
+            },
+            "stewards": {
+              "type": "array",
+              "title": "Data Stewards",
+              "description": "Data stewards are responsible for data content, context, and associated business rules.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-data-2.0/$defs/dataGovernanceResponsibleParty"
+              }
+            },
+            "owners": {
+              "type": "array",
+              "title": "Data Owners",
+              "description": "Data owners are concerned with risk and appropriate access to data.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-data-2.0/$defs/dataGovernanceResponsibleParty"
+              }
+            }
+          }
+        },
+        "dataGovernanceResponsibleParty": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "organization": {
+              "title": "Organization",
+              "description": "The organization that is responsible for specific data governance role(s).",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalEntity"
+            },
+            "contact": {
+              "title": "Individual",
+              "description": "The individual that is responsible for specific data governance role(s).",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalContact"
+            }
+          },
+          "oneOf": [
+            {
+              "required": [
+                "organization"
+              ]
+            },
+            {
+              "required": [
+                "contact"
+              ]
+            }
+          ]
+        },
+        "dataFlowDirection": {
+          "type": "string",
+          "enum": [
+            "inbound",
+            "outbound",
+            "bi-directional",
+            "unknown"
+          ],
+          "meta:enum": {
+            "inbound": "Data that enters a service.",
+            "outbound": "Data that exits a service.",
+            "bi-directional": "Data flows in and out of the service.",
+            "unknown": "The directional flow of data is not known."
+          },
+          "title": "Data flow direction",
+          "description": "Specifies the flow direction of the data. Direction is relative to the service."
+        }
+      }
+    },
+    "cyclonedx-declaration-2.0": {
+      "type": "null",
+      "title": "CycloneDX Declaration Model",
+      "$defs": {
+        "declarations": {
+          "type": "object",
+          "title": "Declarations",
+          "description": "The list of declarations which describe the conformance to standards. Each declaration may include attestations, claims, and evidence.",
+          "additionalProperties": false,
+          "properties": {
+            "assessors": {
+              "type": "array",
+              "title": "Assessors",
+              "description": "The list of assessors evaluating claims and determining conformance to requirements and confidence in that assessment.",
+              "items": {
+                "type": "object",
+                "title": "Assessor",
+                "description": "The assessor who evaluates claims and determines conformance to requirements and confidence in that assessment.",
+                "additionalProperties": false,
+                "properties": {
+                  "bom-ref": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+                    "title": "BOM Reference",
+                    "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+                  },
+                  "thirdParty": {
+                    "type": "boolean",
+                    "title": "Third Party",
+                    "description": "The boolean indicating if the assessor is outside the organization generating claims. A value of false indicates a self assessor."
+                  },
+                  "organization": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalEntity",
+                    "title": "Organization",
+                    "description": "The entity issuing the assessment."
+                  }
+                }
+              }
+            },
+            "attestations": {
+              "type": "array",
+              "title": "Attestations",
+              "description": "The list of attestations asserted by an assessor that maps requirements to claims.",
+              "items": {
+                "type": "object",
+                "title": "Attestation",
+                "additionalProperties": false,
+                "properties": {
+                  "summary": {
+                    "type": "string",
+                    "title": "Summary",
+                    "description": "The short description explaining the main points of the attestation."
+                  },
+                  "assessor": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType",
+                    "title": "Assessor",
+                    "description": "The `bom-ref` to the assessor asserting the attestation."
+                  },
+                  "map": {
+                    "type": "array",
+                    "title": "Map",
+                    "description": "The grouping of requirements to claims and the attestors declared conformance and confidence thereof.",
+                    "items": {
+                      "type": "object",
+                      "title": "Map",
+                      "additionalProperties": false,
+                      "properties": {
+                        "requirement": {
+                          "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType",
+                          "title": "Requirement",
+                          "description": "The `bom-ref` to the requirement being attested to."
+                        },
+                        "claims": {
+                          "type": "array",
+                          "title": "Claims",
+                          "description": "The list of `bom-ref` to the claims being attested to.",
+                          "items": {
+                            "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType"
+                          }
+                        },
+                        "counterClaims": {
+                          "type": "array",
+                          "title": "Counter Claims",
+                          "description": "The list of  `bom-ref` to the counter claims being attested to.",
+                          "items": {
+                            "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType"
+                          }
+                        },
+                        "conformance": {
+                          "type": "object",
+                          "title": "Conformance",
+                          "description": "The conformance of the claim meeting a requirement.",
+                          "additionalProperties": false,
+                          "properties": {
+                            "score": {
+                              "type": "number",
+                              "minimum": 0,
+                              "maximum": 1,
+                              "title": "Score",
+                              "description": "The conformance of the claim between and inclusive of 0 and 1, where 1 is 100% conformance."
+                            },
+                            "rationale": {
+                              "type": "string",
+                              "title": "Rationale",
+                              "description": "The rationale for the conformance score."
+                            },
+                            "mitigationStrategies": {
+                              "type": "array",
+                              "title": "Mitigation Strategies",
+                              "description": "The list of  `bom-ref` to the evidence provided describing the mitigation strategies.",
+                              "items": {
+                                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType"
+                              }
+                            }
+                          }
+                        },
+                        "confidence": {
+                          "type": "object",
+                          "title": "Confidence",
+                          "description": "The confidence of the claim meeting the requirement.",
+                          "additionalProperties": false,
+                          "properties": {
+                            "score": {
+                              "type": "number",
+                              "minimum": 0,
+                              "maximum": 1,
+                              "title": "Score",
+                              "description": "The confidence of the claim between and inclusive of 0 and 1, where 1 is 100% confidence."
+                            },
+                            "rationale": {
+                              "type": "string",
+                              "title": "Rationale",
+                              "description": "The rationale for the confidence score."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "signatures": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/signatures"
+                  }
+                }
+              }
+            },
+            "claims": {
+              "type": "array",
+              "title": "Claims",
+              "description": "The list of claims.",
+              "items": {
+                "type": "object",
+                "title": "Claim",
+                "additionalProperties": false,
+                "properties": {
+                  "bom-ref": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+                    "title": "BOM Reference",
+                    "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+                  },
+                  "target": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType",
+                    "title": "Target",
+                    "description": "The `bom-ref` to a target representing a specific system, application, API, module, team, person, process, business unit, company, etc...  that this claim is being applied to."
+                  },
+                  "predicate": {
+                    "type": "string",
+                    "title": "Predicate",
+                    "description": "The specific statement or assertion about the target."
+                  },
+                  "mitigationStrategies": {
+                    "type": "array",
+                    "title": "Mitigation Strategies",
+                    "description": "The list of  `bom-ref` to the evidence provided describing the mitigation strategies. Each mitigation strategy should include an explanation of how any weaknesses in the evidence will be mitigated.",
+                    "items": {
+                      "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType"
+                    }
+                  },
+                  "reasoning": {
+                    "type": "string",
+                    "title": "Reasoning",
+                    "description": "The written explanation of why the evidence provided substantiates the claim."
+                  },
+                  "evidence": {
+                    "type": "array",
+                    "title": "Evidence",
+                    "description": "The list of `bom-ref` to evidence that supports this claim.",
+                    "items": {
+                      "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType"
+                    }
+                  },
+                  "counterEvidence": {
+                    "type": "array",
+                    "title": "Counter Evidence",
+                    "description": "The list of `bom-ref` to counterEvidence that supports this claim.",
+                    "items": {
+                      "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType"
+                    }
+                  },
+                  "externalReferences": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReferences"
+                  },
+                  "signatures": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/signatures"
+                  }
+                }
+              }
+            },
+            "evidence": {
+              "type": "array",
+              "title": "Evidence",
+              "description": "The list of evidence",
+              "items": {
+                "type": "object",
+                "title": "Evidence",
+                "additionalProperties": false,
+                "properties": {
+                  "bom-ref": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+                    "title": "BOM Reference",
+                    "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+                  },
+                  "propertyName": {
+                    "type": "string",
+                    "title": "Property Name",
+                    "description": "The reference to the property name as defined in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy/)."
+                  },
+                  "description": {
+                    "type": "string",
+                    "title": "Description",
+                    "description": "The written description of what this evidence is and how it was created."
+                  },
+                  "data": {
+                    "type": "array",
+                    "title": "Data",
+                    "description": "The output or analysis that supports claims.",
+                    "items": {
+                      "type": "object",
+                      "title": "Data",
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "title": "Data Name",
+                          "description": "The name of the data.",
+                          "type": "string"
+                        },
+                        "contents": {
+                          "type": "object",
+                          "title": "Data Contents",
+                          "description": "The contents or references to the contents of the data being described.",
+                          "additionalProperties": false,
+                          "properties": {
+                            "attachment": {
+                              "title": "Data Attachment",
+                              "description": "A way to include textual or encoded data.",
+                              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/attachment"
+                            },
+                            "url": {
+                              "type": "string",
+                              "title": "Data URL",
+                              "description": "The URL to where the data can be retrieved.",
+                              "format": "iri-reference"
+                            }
+                          }
+                        },
+                        "classification": {
+                          "$ref": "#/$defs/cyclonedx-data-2.0/$defs/dataClassification"
+                        },
+                        "sensitiveData": {
+                          "type": "array",
+                          "title": "Sensitive Data",
+                          "description": "A description of any sensitive data included.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "governance": {
+                          "title": "Data Governance",
+                          "$ref": "#/$defs/cyclonedx-data-2.0/$defs/dataGovernance"
+                        }
+                      }
+                    }
+                  },
+                  "created": {
+                    "type": "string",
+                    "format": "date-time",
+                    "title": "Created",
+                    "description": "The date and time (timestamp) when the evidence was created."
+                  },
+                  "expires": {
+                    "type": "string",
+                    "format": "date-time",
+                    "title": "Expires",
+                    "description": "The date and time (timestamp) when the evidence is no longer valid."
+                  },
+                  "author": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalContact",
+                    "title": "Author",
+                    "description": "The author of the evidence."
+                  },
+                  "reviewer": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalContact",
+                    "title": "Reviewer",
+                    "description": "The reviewer of the evidence."
+                  },
+                  "signatures": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/signatures"
+                  }
+                }
+              }
+            },
+            "targets": {
+              "type": "object",
+              "title": "Targets",
+              "description": "The list of targets which claims are made against.",
+              "additionalProperties": false,
+              "properties": {
+                "organizations": {
+                  "type": "array",
+                  "title": "Organizations",
+                  "description": "The list of organizations which claims are made against.",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalEntity"
+                  }
+                },
+                "components": {
+                  "type": "array",
+                  "title": "Components",
+                  "description": "The list of components which claims are made against.",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-component-2.0/$defs/component"
+                  }
+                },
+                "services": {
+                  "type": "array",
+                  "title": "Services",
+                  "description": "The list of services which claims are made against.",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-service-2.0/$defs/service"
+                  }
+                }
+              }
+            },
+            "affirmation": {
+              "type": "object",
+              "title": "Affirmation",
+              "description": "A concise statement affirmed by an individual regarding all declarations, often used for third-party auditor acceptance or recipient acknowledgment. It includes a list of authorized signatories who assert the validity of the document on behalf of the organization.",
+              "additionalProperties": false,
+              "properties": {
+                "statement": {
+                  "type": "string",
+                  "title": "Statement",
+                  "description": "The brief statement affirmed by an individual regarding all declarations.\n*- Notes This could be an affirmation of acceptance by a third-party auditor or receiving individual of a file.",
+                  "examples": [
+                    "I certify, to the best of my knowledge, that all information is correct."
+                  ]
+                },
+                "signatories": {
+                  "type": "array",
+                  "title": "Signatories",
+                  "description": "The list of signatories authorized on behalf of an organization to assert validity of this document.",
+                  "items": {
+                    "type": "object",
+                    "title": "Signatory",
+                    "additionalProperties": false,
+                    "oneOf": [
+                      {
+                        "required": [
+                          "signature"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "externalReference",
+                          "organization"
+                        ]
+                      }
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "title": "Name",
+                        "description": "The signatory's name."
+                      },
+                      "role": {
+                        "type": "string",
+                        "title": "Role",
+                        "description": "The signatory's role within an organization."
+                      },
+                      "signatures": {
+                        "$ref": "#/$defs/cyclonedx-common-2.0/$defs/signatures"
+                      },
+                      "organization": {
+                        "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalEntity",
+                        "title": "Organization",
+                        "description": "The signatory's organization."
+                      },
+                      "externalReference": {
+                        "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReference"
+                      }
+                    }
+                  }
+                },
+                "signatures": {
+                  "$ref": "#/$defs/cyclonedx-common-2.0/$defs/signatures"
+                }
+              }
+            },
+            "signatures": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/signatures"
+            }
+          }
+        }
+      }
+    },
+    "cyclonedx-definition-2.0": {
+      "type": "null",
+      "title": "CycloneDX Definition Model",
+      "$defs": {
+        "definitions": {
+          "type": "object",
+          "title": "Definitions",
+          "description": "A collection of reusable objects that are defined and may be used elsewhere in the BOM.",
+          "additionalProperties": false,
+          "properties": {
+            "standards": {
+              "$ref": "#/$defs/cyclonedx-standard-2.0/$defs/standards"
+            },
+            "patents": {
+              "$ref": "#/$defs/cyclonedx-patent-2.0/$defs/patents"
+            }
+          }
+        }
+      }
+    },
+    "cyclonedx-dependency-2.0": {
+      "type": "null",
+      "title": "CycloneDX Dependency Model",
+      "$defs": {
+        "dependencies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-dependency-2.0/$defs/dependency"
+          },
+          "uniqueItems": true,
+          "title": "Dependencies",
+          "description": "Provides the ability to document dependency relationships including provided & implemented components."
+        },
+        "dependency": {
+          "type": "object",
+          "title": "Dependency",
+          "description": "Defines the direct dependencies of a component, service, or the components provided/implemented by a given component. Components or services that do not have their own dependencies must be declared as empty elements within the graph. Components or services that are not represented in the dependency graph may have unknown dependencies. It is recommended that implementations assume this to be opaque and not an indicator of an object being dependency-free. It is recommended to leverage compositions to indicate unknown dependency graphs.",
+          "required": [
+            "ref"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType",
+              "title": "Reference",
+              "description": "References a component or service by its bom-ref attribute"
+            },
+            "dependsOn": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType"
+              },
+              "title": "Depends On",
+              "description": "The bom-ref identifiers of the components or services that are dependencies of this dependency object."
+            },
+            "provides": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType"
+              },
+              "title": "Provides",
+              "description": "The bom-ref identifiers of the components or services that define a given specification or standard, which are provided or implemented by this dependency object.\nFor example, a cryptographic library which implements a cryptographic algorithm. A component which implements another component does not imply that the implementation is in use."
+            }
+          }
+        }
+      }
+    },
+    "cyclonedx-formulation-2.0": {
+      "type": "null",
+      "title": "CycloneDX Formulation Model",
+      "$defs": {
+        "formulation": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/formula"
+          },
+          "uniqueItems": true,
+          "title": "Formulation",
+          "description": "Describes the formulation of any referencable object within the BOM, including components, services, metadata, declarations, or the BOM itself. This may encompass how the object was created, assembled, deployed, tested, certified, or otherwise brought into its present form. Common examples include software build pipelines, deployment processes, AI/ML model training, cryptographic key generation or certification, and third-party audits. Processes are modeled using declared and observed formulas, composed of workflows, tasks, and individual steps."
+        },
+        "formula": {
+          "title": "Formula",
+          "description": "Describes workflows and resources that captures rules and other aspects of how the associated BOM component or service was formed.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the formula elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType"
+            },
+            "components": {
+              "title": "Components",
+              "description": "Transient components that are used in tasks that constitute one or more of this formula's workflows",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-component-2.0/$defs/component"
+              },
+              "uniqueItems": true
+            },
+            "services": {
+              "title": "Services",
+              "description": "Transient services that are used in tasks that constitute one or more of this formula's workflows",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-service-2.0/$defs/service"
+              },
+              "uniqueItems": true
+            },
+            "workflows": {
+              "title": "Workflows",
+              "description": "List of workflows that can be declared to accomplish specific orchestrated goals and independently triggered.",
+              "$comment": "Different workflows can be designed to work together to perform end-to-end CI/CD builds and deployments.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/workflow"
+              },
+              "uniqueItems": true
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "workflow": {
+          "title": "Workflow",
+          "description": "A specialized orchestration task.",
+          "$comment": "Workflow are as task themselves and can trigger other workflow tasks.  These relationships can be modeled in the taskDependencies graph.",
+          "type": "object",
+          "required": [
+            "bom-ref",
+            "uid",
+            "taskTypes"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the workflow elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType"
+            },
+            "uid": {
+              "title": "Unique Identifier (UID)",
+              "description": "The unique identifier for the resource instance within its deployment context.",
+              "type": "string"
+            },
+            "name": {
+              "title": "Name",
+              "description": "The name of the resource instance.",
+              "type": "string"
+            },
+            "description": {
+              "title": "Description",
+              "description": "A description of the resource instance.",
+              "type": "string"
+            },
+            "resourceReferences": {
+              "title": "Resource references",
+              "description": "References to component or service resources that are used to realize the resource instance.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/resourceReferenceChoice"
+              }
+            },
+            "tasks": {
+              "title": "Tasks",
+              "description": "The tasks that comprise the workflow.",
+              "$comment": "Note that tasks can appear more than once as different instances (by name or UID).",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/task"
+              }
+            },
+            "taskDependencies": {
+              "title": "Task dependency graph",
+              "description": "The graph of dependencies between tasks within the workflow.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/cyclonedx-dependency-2.0/$defs/dependency"
+              }
+            },
+            "taskTypes": {
+              "title": "Task types",
+              "description": "Indicates the types of activities performed by the set of workflow tasks.",
+              "$comment": "Currently, these types reflect common CI/CD actions.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/taskType"
+              }
+            },
+            "trigger": {
+              "title": "Trigger",
+              "description": "The trigger that initiated the task.",
+              "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/trigger"
+            },
+            "steps": {
+              "title": "Steps",
+              "description": "The sequence of steps for the task.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/step"
+              },
+              "uniqueItems": true
+            },
+            "inputs": {
+              "title": "Inputs",
+              "description": "Represents resources and data brought into a task at runtime by executor or task commands",
+              "examples": [
+                "a `configuration` file which was declared as a local `component` or `externalReference`"
+              ],
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/inputType"
+              },
+              "uniqueItems": true
+            },
+            "outputs": {
+              "title": "Outputs",
+              "description": "Represents resources and data output from a task at runtime by executor or task commands",
+              "examples": [
+                "a log file or metrics data produced by the task"
+              ],
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/outputType"
+              },
+              "uniqueItems": true
+            },
+            "timeStart": {
+              "title": "Time start",
+              "description": "The date and time (timestamp) when the task started.",
+              "type": "string",
+              "format": "date-time"
+            },
+            "timeEnd": {
+              "title": "Time end",
+              "description": "The date and time (timestamp) when the task ended.",
+              "type": "string",
+              "format": "date-time"
+            },
+            "workspaces": {
+              "title": "Workspaces",
+              "description": "A set of named filesystem or data resource shareable by workflow tasks.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/workspace"
+              }
+            },
+            "runtimeTopology": {
+              "title": "Runtime topology",
+              "description": "A graph of the component runtime topology for workflow's instance.",
+              "$comment": "A description of the runtime component and service topology.  This can describe a partial or complete topology used to host and execute the task (e.g., hardware, operating systems, configurations, etc.),",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/cyclonedx-dependency-2.0/$defs/dependency"
+              }
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "task": {
+          "title": "Task",
+          "description": "Describes the inputs, sequence of steps and resources used to accomplish a task and its output.",
+          "$comment": "Tasks are building blocks for constructing assemble CI/CD workflows or pipelines.",
+          "type": "object",
+          "required": [
+            "bom-ref",
+            "uid",
+            "taskTypes"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the task elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType"
+            },
+            "uid": {
+              "title": "Unique Identifier (UID)",
+              "description": "The unique identifier for the resource instance within its deployment context.",
+              "type": "string"
+            },
+            "name": {
+              "title": "Name",
+              "description": "The name of the resource instance.",
+              "type": "string"
+            },
+            "description": {
+              "title": "Description",
+              "description": "A description of the resource instance.",
+              "type": "string"
+            },
+            "resourceReferences": {
+              "title": "Resource references",
+              "description": "References to component or service resources that are used to realize the resource instance.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/resourceReferenceChoice"
+              }
+            },
+            "taskTypes": {
+              "title": "Task types",
+              "description": "Indicates the types of activities performed by the set of workflow tasks.",
+              "$comment": "Currently, these types reflect common CI/CD actions.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/taskType"
+              }
+            },
+            "trigger": {
+              "title": "Trigger",
+              "description": "The trigger that initiated the task.",
+              "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/trigger"
+            },
+            "steps": {
+              "title": "Steps",
+              "description": "The sequence of steps for the task.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/step"
+              },
+              "uniqueItems": true
+            },
+            "inputs": {
+              "title": "Inputs",
+              "description": "Represents resources and data brought into a task at runtime by executor or task commands",
+              "examples": [
+                "a `configuration` file which was declared as a local `component` or `externalReference`"
+              ],
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/inputType"
+              },
+              "uniqueItems": true
+            },
+            "outputs": {
+              "title": "Outputs",
+              "description": "Represents resources and data output from a task at runtime by executor or task commands",
+              "examples": [
+                "a log file or metrics data produced by the task"
+              ],
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/outputType"
+              },
+              "uniqueItems": true
+            },
+            "timeStart": {
+              "title": "Time start",
+              "description": "The date and time (timestamp) when the task started.",
+              "type": "string",
+              "format": "date-time"
+            },
+            "timeEnd": {
+              "title": "Time end",
+              "description": "The date and time (timestamp) when the task ended.",
+              "type": "string",
+              "format": "date-time"
+            },
+            "workspaces": {
+              "title": "Workspaces",
+              "description": "A set of named filesystem or data resource shareable by workflow tasks.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/workspace"
+              },
+              "uniqueItems": true
+            },
+            "runtimeTopology": {
+              "title": "Runtime topology",
+              "description": "A graph of the component runtime topology for task's instance.",
+              "$comment": "A description of the runtime component and service topology.  This can describe a partial or complete topology used to host and execute the task (e.g., hardware, operating systems, configurations, etc.),",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-dependency-2.0/$defs/dependency"
+              },
+              "uniqueItems": true
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "step": {
+          "type": "object",
+          "description": "Executes specific commands or tools in order to accomplish its owning task as part of a sequence.",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "title": "Name",
+              "description": "A name for the step.",
+              "type": "string"
+            },
+            "description": {
+              "title": "Description",
+              "description": "A description of the step.",
+              "type": "string"
+            },
+            "commands": {
+              "title": "Commands",
+              "description": "Ordered list of commands or directives for the step",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/command"
+              }
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "command": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "executed": {
+              "title": "Executed",
+              "description": "A text representation of the executed command.",
+              "type": "string"
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "workspace": {
+          "title": "Workspace",
+          "description": "A named filesystem or data resource shareable by workflow tasks.",
+          "type": "object",
+          "required": [
+            "bom-ref",
+            "uid"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the workspace elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType"
+            },
+            "uid": {
+              "title": "Unique Identifier (UID)",
+              "description": "The unique identifier for the resource instance within its deployment context.",
+              "type": "string"
+            },
+            "name": {
+              "title": "Name",
+              "description": "The name of the resource instance.",
+              "type": "string"
+            },
+            "aliases": {
+              "title": "Aliases",
+              "description": "The names for the workspace as referenced by other workflow tasks. Effectively, a name mapping so other tasks can use their own local name in their steps.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": {
+              "title": "Description",
+              "description": "A description of the resource instance.",
+              "type": "string"
+            },
+            "resourceReferences": {
+              "title": "Resource references",
+              "description": "References to component or service resources that are used to realize the resource instance.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/resourceReferenceChoice"
+              }
+            },
+            "accessMode": {
+              "title": "Access mode",
+              "description": "Describes the read-write access control for the workspace relative to the owning resource instance.",
+              "type": "string",
+              "enum": [
+                "read-only",
+                "read-write",
+                "read-write-once",
+                "write-once",
+                "write-only"
+              ]
+            },
+            "mountPath": {
+              "title": "Mount path",
+              "description": "A path to a location on disk where the workspace will be available to the associated task's steps.",
+              "type": "string"
+            },
+            "managedDataType": {
+              "title": "Managed data type",
+              "description": "The name of a domain-specific data type the workspace represents.",
+              "$comment": "This property is for CI/CD frameworks that are able to provide access to structured, managed data at a more granular level than a filesystem.",
+              "examples": [
+                "ConfigMap",
+                "Secret"
+              ],
+              "type": "string"
+            },
+            "volumeRequest": {
+              "title": "Volume request",
+              "description": "Identifies the reference to the request for a specific volume type and parameters.",
+              "examples": [
+                "a kubernetes Persistent Volume Claim (PVC) name"
+              ],
+              "type": "string"
+            },
+            "volume": {
+              "title": "Volume",
+              "description": "Information about the actual volume instance allocated to the workspace.",
+              "$comment": "The actual volume allocated may be different than the request.",
+              "examples": [
+                "see https://kubernetes.io/docs/concepts/storage/persistent-volumes/"
+              ],
+              "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/volume"
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "volume": {
+          "title": "Volume",
+          "description": "An identifiable, logical unit of data storage tied to a physical device.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "uid": {
+              "title": "Unique Identifier (UID)",
+              "description": "The unique identifier for the volume instance within its deployment context.",
+              "type": "string"
+            },
+            "name": {
+              "title": "Name",
+              "description": "The name of the volume instance",
+              "type": "string"
+            },
+            "mode": {
+              "title": "Mode",
+              "description": "The mode for the volume instance.",
+              "type": "string",
+              "enum": [
+                "filesystem",
+                "block"
+              ],
+              "default": "filesystem"
+            },
+            "path": {
+              "title": "Path",
+              "description": "The underlying path created from the actual volume.",
+              "type": "string"
+            },
+            "sizeAllocated": {
+              "title": "Size allocated",
+              "description": "The allocated size of the volume accessible to the associated workspace. This should include the scalar size as well as IEC standard unit in either decimal or binary form.",
+              "examples": [
+                "10GB",
+                "2Ti",
+                "1Pi"
+              ],
+              "type": "string"
+            },
+            "persistent": {
+              "title": "Persistent",
+              "description": "Indicates if the volume persists beyond the life of the resource it is associated with.",
+              "type": "boolean"
+            },
+            "remote": {
+              "title": "Remote",
+              "description": "Indicates if the volume is remotely (i.e., network) attached.",
+              "type": "boolean"
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "trigger": {
+          "title": "Trigger",
+          "description": "Represents a resource that can conditionally activate (or fire) tasks based upon associated events and their data.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "bom-ref",
+            "uid"
+          ],
+          "properties": {
+            "bom-ref": {
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the trigger elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType"
+            },
+            "uid": {
+              "title": "Unique Identifier (UID)",
+              "description": "The unique identifier for the resource instance within its deployment context.",
+              "type": "string"
+            },
+            "name": {
+              "title": "Name",
+              "description": "The name of the resource instance.",
+              "type": "string"
+            },
+            "description": {
+              "title": "Description",
+              "description": "A description of the resource instance.",
+              "type": "string"
+            },
+            "resourceReferences": {
+              "title": "Resource references",
+              "description": "References to component or service resources that are used to realize the resource instance.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/resourceReferenceChoice"
+              }
+            },
+            "type": {
+              "title": "Type",
+              "description": "The source type of event which caused the trigger to fire.",
+              "type": "string",
+              "enum": [
+                "manual",
+                "api",
+                "webhook",
+                "scheduled"
+              ]
+            },
+            "event": {
+              "title": "Event",
+              "description": "The event data that caused the associated trigger to activate.",
+              "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/event"
+            },
+            "conditions": {
+              "type": "array",
+              "title": "Conditions",
+              "description": "A list of conditions used to determine if a trigger should be activated.",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/condition"
+              }
+            },
+            "timeActivated": {
+              "title": "Time activated",
+              "description": "The date and time (timestamp) when the trigger was activated.",
+              "type": "string",
+              "format": "date-time"
+            },
+            "inputs": {
+              "title": "Inputs",
+              "description": "Represents resources and data brought into a task at runtime by executor or task commands",
+              "examples": [
+                "a `configuration` file which was declared as a local `component` or `externalReference`"
+              ],
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/inputType"
+              },
+              "uniqueItems": true
+            },
+            "outputs": {
+              "title": "Outputs",
+              "description": "Represents resources and data output from a task at runtime by executor or task commands",
+              "examples": [
+                "a log file or metrics data produced by the task"
+              ],
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/outputType"
+              },
+              "uniqueItems": true
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "event": {
+          "title": "Event",
+          "description": "Represents something that happened that may trigger a response.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "uid": {
+              "title": "Unique Identifier (UID)",
+              "description": "The unique identifier of the event.",
+              "type": "string"
+            },
+            "description": {
+              "title": "Description",
+              "description": "A description of the event.",
+              "type": "string"
+            },
+            "timeReceived": {
+              "title": "Time Received",
+              "description": "The date and time (timestamp) when the event was received.",
+              "type": "string",
+              "format": "date-time"
+            },
+            "data": {
+              "title": "Data",
+              "description": "Encoding of the raw event data.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/attachment"
+            },
+            "source": {
+              "title": "Source",
+              "description": "References the component or service that was the source of the event",
+              "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/resourceReferenceChoice"
+            },
+            "target": {
+              "title": "Target",
+              "description": "References the component or service that was the target of the event",
+              "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/resourceReferenceChoice"
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "inputType": {
+          "title": "Input type",
+          "description": "Type that represents various input data types and formats.",
+          "type": "object",
+          "oneOf": [
+            {
+              "required": [
+                "resource"
+              ]
+            },
+            {
+              "required": [
+                "parameters"
+              ]
+            },
+            {
+              "required": [
+                "environmentVars"
+              ]
+            },
+            {
+              "required": [
+                "data"
+              ]
+            }
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "source": {
+              "title": "Source",
+              "description": "A reference to the component or service that provided the input to the task (e.g., reference to a service with data flow value of `inbound`)",
+              "examples": [
+                "source code repository",
+                "database"
+              ],
+              "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/resourceReferenceChoice"
+            },
+            "target": {
+              "title": "Target",
+              "description": "A reference to the component or service that received or stored the input if not the task itself (e.g., a local, named storage workspace)",
+              "examples": [
+                "workspace",
+                "directory"
+              ],
+              "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/resourceReferenceChoice"
+            },
+            "resource": {
+              "title": "Resource",
+              "description": "A reference to an independent resource provided as an input to a task by the workflow runtime.",
+              "examples": [
+                "a reference to a configuration file in a repository (i.e., a bom-ref)",
+                "a reference to a scanning service used in a task (i.e., a bom-ref)"
+              ],
+              "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/resourceReferenceChoice"
+            },
+            "parameters": {
+              "title": "Parameters",
+              "description": "Inputs that have the form of parameters with names and values.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/parameter"
+              }
+            },
+            "environmentVars": {
+              "title": "Environment variables",
+              "description": "Inputs that have the form of parameters with names and values.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/property"
+                  },
+                  {
+                    "type": "string",
+                    "title": "String-Based Environment Variables",
+                    "description": "In addition to the more common key–value pair format, some environment variables may consist of a single string without an explicit value assignment. These string-based environment variables typically act as flags or signals to software, indicating that a feature should be enabled, a mode should be activated, or a specific condition is present. Their presence alone conveys meaning."
+                  }
+                ]
+              }
+            },
+            "data": {
+              "title": "Data",
+              "description": "Inputs that have the form of data.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/attachment"
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "outputType": {
+          "type": "object",
+          "oneOf": [
+            {
+              "required": [
+                "resource"
+              ]
+            },
+            {
+              "required": [
+                "environmentVars"
+              ]
+            },
+            {
+              "required": [
+                "data"
+              ]
+            }
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "title": "Type",
+              "description": "Describes the type of data output.",
+              "type": "string",
+              "enum": [
+                "artifact",
+                "attestation",
+                "log",
+                "evidence",
+                "metrics",
+                "other"
+              ]
+            },
+            "source": {
+              "title": "Source",
+              "description": "Component or service that generated or provided the output from the task (e.g., a build tool)",
+              "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/resourceReferenceChoice"
+            },
+            "target": {
+              "title": "Target",
+              "description": "Component or service that received the output from the task (e.g., reference to an artifactory service with data flow value of `outbound`)",
+              "examples": [
+                "a log file described as an `externalReference` within its target domain."
+              ],
+              "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/resourceReferenceChoice"
+            },
+            "resource": {
+              "title": "Resource",
+              "description": "A reference to an independent resource generated as output by the task.",
+              "examples": [
+                "configuration file",
+                "source code",
+                "scanning service"
+              ],
+              "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/resourceReferenceChoice"
+            },
+            "data": {
+              "title": "Data",
+              "description": "Outputs that have the form of data.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/attachment"
+            },
+            "environmentVars": {
+              "title": "Environment variables",
+              "description": "Outputs that have the form of environment variables.",
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/property"
+                  },
+                  {
+                    "type": "string",
+                    "title": "String-Based Environment Variables",
+                    "description": "In addition to the more common key–value pair format, some environment variables may consist of a single string without an explicit value assignment. These string-based environment variables typically act as flags or signals to software, indicating that a feature should be enabled, a mode should be activated, or a specific condition is present. Their presence alone conveys meaning."
+                  }
+                ]
+              },
+              "uniqueItems": true
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "resourceReferenceChoice": {
+          "title": "Resource reference choice",
+          "description": "A reference to a locally defined resource (e.g., a bom-ref) or an externally accessible resource.",
+          "$comment": "Enables reference to a resource that participates in a workflow; using either internal (bom-ref) or external (externalReference) types.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "ref": {
+              "title": "BOM Reference",
+              "description": "References an object by its bom-ref attribute",
+              "anyOf": [
+                {
+                  "title": "Ref",
+                  "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType"
+                },
+                {
+                  "title": "BOM-Link Element",
+                  "$ref": "#/$defs/cyclonedx-common-2.0/$defs/bomLinkElementType"
+                }
+              ]
+            },
+            "externalReference": {
+              "title": "External reference",
+              "description": "Reference to an externally accessible resource.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReference"
+            }
+          },
+          "oneOf": [
+            {
+              "required": [
+                "ref"
+              ]
+            },
+            {
+              "required": [
+                "externalReference"
+              ]
+            }
+          ]
+        },
+        "condition": {
+          "title": "Condition",
+          "description": "A condition that was used to determine a trigger should be activated.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "title": "Description",
+              "description": "Describes the set of conditions which cause the trigger to activate.",
+              "type": "string"
+            },
+            "expression": {
+              "title": "Expression",
+              "description": "The logical expression that was evaluated that determined the trigger should be fired.",
+              "type": "string"
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "taskType": {
+          "type": "string",
+          "enum": [
+            "copy",
+            "clone",
+            "lint",
+            "scan",
+            "merge",
+            "build",
+            "test",
+            "deliver",
+            "deploy",
+            "release",
+            "clean",
+            "other"
+          ],
+          "meta:enum": {
+            "copy": "A task that copies software or data used to accomplish other tasks in the workflow.",
+            "clone": "A task that clones a software repository into the workflow in order to retrieve its source code or data for use in a build step.",
+            "lint": "A task that checks source code for programmatic and stylistic errors.",
+            "scan": "A task that performs a scan against source code, or built or deployed components and services. Scans are typically run to gather or test for security vulnerabilities or policy compliance.",
+            "merge": "A task that merges changes or fixes into source code prior to a build step in the workflow.",
+            "build": "A task that builds the source code, dependencies and/or data into an artifact that can be deployed to and executed on target systems.",
+            "test": "A task that verifies the functionality of a component or service.",
+            "deliver": "A task that delivers a built artifact to one or more target repositories or storage systems.",
+            "deploy": "A task that deploys a built artifact for execution on one or more target systems.",
+            "release": "A task that releases a built, versioned artifact to a target repository or distribution system.",
+            "clean": "A task that cleans unnecessary tools, build artifacts and/or data from workflow storage.",
+            "other": "A workflow task that does not match current task type definitions."
+          }
+        },
+        "parameter": {
+          "title": "Parameter",
+          "description": "A representation of a functional parameter.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "title": "Name",
+              "description": "The name of the parameter.",
+              "type": "string"
+            },
+            "value": {
+              "title": "Value",
+              "description": "The value of the parameter.",
+              "type": "string"
+            },
+            "dataType": {
+              "title": "Data type",
+              "description": "The data type of the parameter.",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "cyclonedx-jss_X590_2023_10-2.0": {
+      "type": "null",
+      "title": "CycloneDX Model for JSON Signature Scheme (JSS)",
+      "description": "JSON Schema implementing ITU-T X.590 (10/2023) – JSON Signature Scheme (JSS). Defines the structure for digitally signing JSON objects while keeping the payload in JSON format. Supports single signatures, multiple independent signatures, and chained counter-signatures. Intended for use as a $defs import in CycloneDX 2.0.",
+      "$defs": {
+        "timestamp": {
+          "title": "Timestamp",
+          "description": "An RFC 3339 timestamp in the UTC+0 time zone. Must use the 'Z' suffix. Sub-second precision, when present, MUST be exactly three digits (millisecond precision). If no sub-second digits are included, the decimal point MUST NOT be present. Matches the pattern: yyyy-mm-ddThh:mm:ss[.sss]Z",
+          "$comment": "Normative source: ITU-T X.590 clause 6.1",
+          "type": "string",
+          "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](?:\\.[0-9]+)?Z$",
+          "examples": [
+            "2023-10-29T13:56:08Z",
+            "2023-10-29T13:56:08.000Z",
+            "2023-11-15T08:30:00.123Z"
+          ]
+        },
+        "identifier": {
+          "title": "Identifier",
+          "description": "A Universally Unique Identifier (UUID) conformant with RFC 4122. Used to uniquely identify a signature object. Signatures sharing the same 'id' are treated as versions of the same logical signature, differentiated by their 'modified' timestamp.",
+          "$comment": "Normative source: ITU-T X.590 clause 6.1",
+          "type": "string",
+          "format": "uuid",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "examples": [
+            "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+          ]
+        },
+        "hashAlgorithm": {
+          "title": "Hash Algorithm",
+          "description": "This property identifies the hashing algorithm, as defined by the Internet Assigned Numbers Authority (IANA)…, that was used to hash the JCS version of the full JSON object (JSON Object + JSS Signature) and is a case-sensitive ASCII string. Implementations MAY use any current and widely accepted hashing algorithm (e.g., sha-256, sha-512) that is defined in the IANA registry. The actual signing process, defined in the algorithm property, sometimes uses an internal hashing algorithm inside the signing process itself, this property MAY identify the same hashing algorithm as the signing process or MAY identify a different hashing algorithm.",
+          "$comment": "Normative source: ITU-T X.590 clause 6.2.1",
+          "type": "string",
+          "pattern": "^[a-z0-9-]+$",
+          "examples": [
+            "sha-256",
+            "sha-384",
+            "sha-512",
+            "sha3-256",
+            "sha3-512"
+          ]
+        },
+        "algorithmVocabulary": {
+          "title": "Signature Algorithm Type Vocabulary (signature-algorithm-type-ov)",
+          "description": "NOTE – At the time of this writing quantum safe algorithms could come from those defined in XMSS [IETF RFC 8391] section 5.3 or LMS [IETF RFC 8554] section 5.1 and other algorithms could come from those defined in JWA [IETF RFC 7518] section 3.1 or [IETF RFC 8037] section 3.1 (see the table below for a list of values from those RFCs). While JWA [IETF RFC 7518] section 3.1 defines the following symmetric algorithms: HS256, HS384, and HS512, these algorithms SHOULD NOT be used. If one of these three symmetric algorithms is used, the sharing and transmission of those keys is out of scope for this Recommendation.",
+          "$comment": "Normative source: ITU-T X.590 clause 6.2.2 and Table 1",
+          "type": "string",
+          "enum": [
+            "XMSS-SHA2_10_256",
+            "XMSS-SHA2_16_256",
+            "XMSS-SHA2_20_256",
+            "LMS_SHA256_M32_H5",
+            "LMS_SHA256_M32_H10",
+            "LMS_SHA256_M32_H15",
+            "LMS_SHA256_M32_H20",
+            "LMS_SHA256_M32_H25",
+            "RS256",
+            "RS384",
+            "RS512",
+            "ES256",
+            "ES384",
+            "ES512",
+            "PS256",
+            "PS384",
+            "PS512",
+            "Ed25519",
+            "Ed448"
+          ]
+        },
+        "algorithm": {
+          "title": "Signing Algorithm",
+          "description": "This property identifies the algorithm that was used to sign the JSON data and is a case-sensitive ASCII string. The value for this property SHOULD come from the signature-algorithm-type-ov vocabulary (see clause 6.2.2) and SHOULD be a current and widely accepted quantum safe algorithm, but MAY use any currently accepted safe algorithm.",
+          "$comment": "Normative source: ITU-T X.590 clause 6.2.1",
+          "type": "string",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/cyclonedx-jss_X590_2023_10-2.0/$defs/algorithmVocabulary"
+            },
+            {
+              "type": "string",
+              "title": "Other algorithm identifier",
+              "description": "Any other current, widely accepted, safe algorithm identifier not present in the signature-algorithm-type-ov vocabulary (X.590 clause 6.2.2 makes that vocabulary a SHOULD, not a MUST)."
+            }
+          ],
+          "examples": [
+            "Ed25519",
+            "ES256",
+            "XMSS-SHA2_10_256",
+            "LMS_SHA256_M32_H5",
+            "PS512"
+          ]
+        },
+        "publicKey": {
+          "title": "Public Key (PEM, header-stripped)",
+          "description": "This property contains a privacy enhanced mail (PEM) encoded public key without the header and footer for the algorithm selected in the algorithm property.",
+          "$comment": "Normative source: ITU-T X.590 clause 6.2.1",
+          "type": "string",
+          "pattern": "^[A-Za-z0-9+/]+={0,2}$",
+          "examples": [
+            "MCowBQYDK2VwAyEAubMonBfU9pvIbj5RCiWQLD45Jvu6mKr+kQXjvjW8ZkU="
+          ]
+        },
+        "publicCertChain": {
+          "title": "Public Certificate Chain",
+          "description": "This property contains a public key certificate for the algorithm selected in the algorithm property and MUST follow the requirements defined in section 4.7 of [IETF RFC 7517] as quoted here. This property \"contains a chain (X.509 certificate chain) of one or more PKIX certificates [IETF RFC 5280]. The certificate chain is represented as a JSON array of certificate value strings. Each string in the array is a base64-encoded (section 4 of [IETF RFC 4648] – not base64URL.encoded) DER [b-ITU-T X.690] PKIX certificate value. The PKIX certificate containing the key value MUST be the first certificate. This MAY be followed by additional certificates, with each subsequent certificate being the one used to certify the previous one. The key in the first certificate MUST match the public key.\" This property is called \"x5c\" in section 4.7 of [IETF RFC 7517].",
+          "$comment": "Normative source: ITU-T X.590 clause 6.2.1",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Base64-encoded (standard, not base64URL) DER-encoded PKIX certificate value (RFC 5280)."
+          },
+          "minItems": 1
+        },
+        "certUrl": {
+          "title": "Certificate URL",
+          "description": "This property contains a uniform resource identifier (URI) [IETF RFC 3986] that refers to a resource for an X.509 public key certificate or certificate chain [IETF RFC 5280] for the algorithm selected in the algorithm property and MUST follow the requirements defined in section 4.6 of [IETF RFC 7517] as quoted here. \"The identified resource MUST provide a representation of the certificate or certificate chain that conforms to RFC 5280 [IETF RFC 5280] in PEM-encoded form, with each certificate delimited as specified in section 6.1 of RFC 4945 [IETF RFC 4945]. The key in the first certificate MUST match the public key. The protocol used to acquire the resource MUST provide integrity protection; an HTTP GET request to retrieve the certificate MUST use TLS [IETF RFC 2818] [IETF RFC 5246]; the identity of the server MUST be validated, as per section 6 of RFC 6125 [IETF RFC 6125].\" This property is called \"x5u\" in section 4.6 of [IETF RFC 7517].",
+          "$comment": "Normative source: ITU-T X.590 clause 6.2.1",
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://",
+          "examples": [
+            "https://pki.example.com/certs/signing-cert.pem"
+          ]
+        },
+        "thumbprint": {
+          "title": "Certificate Thumbprint",
+          "description": "This property contains a fingerprint of a public key or public key certificate for the algorithm selected in the algorithm property and MUST follow the requirements defined in section 4.9 of [IETF RFC 7517] as quoted here. This property \"is a base64URL.encoded SHA-256 thumbprint (a.k.a. digest, X.509 certificate SHA-256 thumbprint) of the DER encoding of an X.509 certificate [IETF RFC 5280]. Note that certificate thumbprints are also sometimes known as certificate fingerprints. The key in the certificate MUST match the public key.\" This property is called \"x5t#S256\" in section 4.9 of [IETF RFC 7517].",
+          "$comment": "Normative source: ITU-T X.590 clause 6.2.1",
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_-]{43}$",
+          "examples": [
+            "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"
+          ]
+        },
+        "signatureObject": {
+          "title": "Signature Object",
+          "description": "A JSS signature object as defined in ITU-T X.590 clause 6.2. Captures the hashing algorithm, signing algorithm, public key material (in one of four forms), the base64URL-encoded digital signature value, and optional metadata. May nest a child 'signature' property to form a counter-signature chain.",
+          "$comment": "unevaluatedProperties: true is intentional. ITU-T X.590 clause 6.2 explicitly states that implementers MAY add additional properties to satisfy meta-data requirements for their application. The clause 6.3 properties (type, id, related_to, etc.) are themselves defined as non-exhaustive examples of such extensions.",
+          "type": "object",
+          "properties": {
+            "hash_algorithm": {
+              "$ref": "#/$defs/cyclonedx-jss_X590_2023_10-2.0/$defs/hashAlgorithm"
+            },
+            "algorithm": {
+              "$ref": "#/$defs/cyclonedx-jss_X590_2023_10-2.0/$defs/algorithm"
+            },
+            "public_key": {
+              "$ref": "#/$defs/cyclonedx-jss_X590_2023_10-2.0/$defs/publicKey"
+            },
+            "public_cert_chain": {
+              "$ref": "#/$defs/cyclonedx-jss_X590_2023_10-2.0/$defs/publicCertChain"
+            },
+            "cert_url": {
+              "$ref": "#/$defs/cyclonedx-jss_X590_2023_10-2.0/$defs/certUrl"
+            },
+            "thumbprint": {
+              "$ref": "#/$defs/cyclonedx-jss_X590_2023_10-2.0/$defs/thumbprint"
+            },
+            "value": {
+              "title": "Signature Value",
+              "description": "A base64URL.encoded signature that was created using the signature algorithm defined in the algorithm property and a key. In pseudo code it is defined as: base64URL.encode(sign(algorithm, key, hash(jcs(<JSONObject with Signature Object>)))).",
+              "$comment": "Normative source: ITU-T X.590 clause 6.2.1",
+              "type": "string",
+              "pattern": "^[A-Za-z0-9_-]+={0,2}$"
+            },
+            "signature": {
+              "$ref": "#/$defs/cyclonedx-jss_X590_2023_10-2.0/$defs/signatureObject",
+              "title": "Counter-Signature",
+              "description": "This property enables a signature to be countersigned, meaning a signature can be signed by another signature.",
+              "$comment": "Normative source: ITU-T X.590 clause 6.2.1"
+            },
+            "type": {
+              "title": "Type Indicator",
+              "description": "The value of this property MUST be jss.",
+              "$comment": "Normative source: ITU-T X.590 clause 6.3.1",
+              "type": "string",
+              "const": "jss"
+            },
+            "id": {
+              "$ref": "#/$defs/cyclonedx-jss_X590_2023_10-2.0/$defs/identifier",
+              "title": "Signature Identifier",
+              "description": "A value that uniquely identifies the signature. All signatures with the same ID are considered different versions of the same signature and the version of the signature is identified by its modified property.",
+              "$comment": "Normative source: ITU-T X.590 clause 6.3.1"
+            },
+            "related_to": {
+              "title": "Related Object Reference",
+              "description": "A value that can identify the original JSON object that was signed with this signature. If the signature is detached from the original JSON object this property SHOULD be populated.",
+              "$comment": "Normative source: ITU-T X.590 clause 6.3.1",
+              "type": "string"
+            },
+            "related_version": {
+              "title": "Related Object Version",
+              "description": "A value that can identify the version of the original JSON object that was signed with this signature. If the signature is detached from the original JSON object this property SHOULD be populated.",
+              "$comment": "Normative source: ITU-T X.590 clause 6.3.1",
+              "type": "string"
+            },
+            "created": {
+              "$ref": "#/$defs/cyclonedx-jss_X590_2023_10-2.0/$defs/timestamp",
+              "title": "Created Timestamp",
+              "description": "The time at which this signature was originally created. The creator can use any time it deems most appropriate as the time the signature was created, but it MUST be precise to the nearest millisecond (exactly three digits after the decimal place in seconds). The created property MUST NOT be changed when creating a new version of the signature.",
+              "$comment": "Normative source: ITU-T X.590 clause 6.3.1",
+              "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\\.[0-9]{3}Z$"
+            },
+            "modified": {
+              "$ref": "#/$defs/cyclonedx-jss_X590_2023_10-2.0/$defs/timestamp",
+              "title": "Modified Timestamp",
+              "description": "The time that this particular version of the signature was last modified. The creator can use any time it deems most appropriate as the time that this version of the signature was modified, but it MUST be precise to the nearest millisecond (exactly three digits after the decimal place in seconds). The modified property MUST be later than or equal to the value of the created property. If the created and modified properties are the same, then this is the first version of the signature.",
+              "$comment": "Normative source: ITU-T X.590 clause 6.3.1. Cross-field invariant: 'modified' MUST be greater than or equal to 'created'. JSON Schema 2020-12 cannot compare two sibling property values, so this constraint is NOT enforced by this schema and MUST be validated by the consuming tool or conformance suite.",
+              "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\\.[0-9]{3}Z$"
+            },
+            "revoked": {
+              "title": "Revoked Flag",
+              "description": "A boolean that identifies if the signature creator deems that this signature is no longer valid. The default value is false.",
+              "$comment": "Normative source: ITU-T X.590 clause 6.3.1",
+              "type": "boolean",
+              "default": false
+            },
+            "signee": {
+              "title": "Signee",
+              "description": "An unstructured string value for the name of the entity or organization that produced this signature.",
+              "$comment": "Normative source: ITU-T X.590 clause 6.3.1",
+              "type": "string"
+            },
+            "valid_from": {
+              "$ref": "#/$defs/cyclonedx-jss_X590_2023_10-2.0/$defs/timestamp",
+              "title": "Valid From",
+              "description": "The time from which this signature is considered valid. If omitted, the signature is valid at all times or until the timestamp defined by valid_until. If the revoked property is true then this property MUST be ignored.",
+              "$comment": "Normative source: ITU-T X.590 clause 6.3.1"
+            },
+            "valid_until": {
+              "$ref": "#/$defs/cyclonedx-jss_X590_2023_10-2.0/$defs/timestamp",
+              "title": "Valid Until",
+              "description": "The time at which this signature is no longer considered valid. If the valid_until property is omitted, then there is no constraint on the latest time for which the signature is valid. This property MUST be greater than the timestamp in the valid_from property if the valid_from property is defined. If the revoked property is true then this property MUST be ignored.",
+              "$comment": "Normative source: ITU-T X.590 clause 6.3.1. Cross-field invariant: when 'valid_from' is present, 'valid_until' MUST be greater than 'valid_from'. JSON Schema 2020-12 cannot compare two sibling property values, so this constraint is NOT enforced by this schema and MUST be validated by the consuming tool or conformance suite."
+            }
+          },
+          "required": [
+            "hash_algorithm",
+            "algorithm",
+            "value"
+          ],
+          "anyOf": [
+            {
+              "required": [
+                "public_key"
+              ],
+              "description": "Public key material provided as PEM-encoded public key (header/footer stripped)."
+            },
+            {
+              "required": [
+                "public_cert_chain"
+              ],
+              "description": "Public key material provided as a base64-encoded DER X.509 certificate chain."
+            },
+            {
+              "required": [
+                "cert_url"
+              ],
+              "description": "Public key material provided by reference to a TLS-accessible certificate URI."
+            },
+            {
+              "required": [
+                "thumbprint"
+              ],
+              "description": "Public key material referenced by a base64URL-encoded SHA-256 certificate thumbprint."
+            }
+          ],
+          "unevaluatedProperties": true
+        },
+        "signatures": {
+          "title": "Signatures Array",
+          "description": "A JSON array of one or more signature objects. MUST be located at the top-level of the signed JSON object. The property name used to hold this array SHOULD be 'signatures', but implementations MAY use a different name provided it does not conflict with any other top-level property name in the host JSON object. All signature objects in this array are independent parallel signatures over the same JSON object; for chained counter-signatures, use the nested 'signature' property within an individual signature object.",
+          "$comment": "Normative source: ITU-T X.590 clause 6 – 'The property that holds the signature MUST be a JSON list property and MUST be located at the top-level of the original JSON object.'",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-jss_X590_2023_10-2.0/$defs/signatureObject"
+          },
+          "minItems": 1
+        }
+      }
+    },
+    "cyclonedx-license-2.0": {
+      "type": "null",
+      "title": "CycloneDX License Model",
+      "$defs": {
+        "licenseChoice": {
+          "title": "License Choice",
+          "description": "A list of SPDX licenses and/or named licenses and/or SPDX License Expression.",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "object",
+                "title": "License",
+                "required": [
+                  "license"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "license": {
+                    "$ref": "#/$defs/cyclonedx-license-2.0/$defs/license"
+                  }
+                }
+              },
+              {
+                "title": "License Expression",
+                "description": "Specifies the details and attributes related to a software license.\nIt must be a valid SPDX license expression, along with additional properties such as license acknowledgment.",
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "expression"
+                ],
+                "properties": {
+                  "expression": {
+                    "type": "string",
+                    "title": "SPDX License Expression",
+                    "description": "A valid SPDX license expression.\nRefer to https://spdx.org/specifications for syntax requirements.",
+                    "examples": [
+                      "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+                      "GPL-3.0-only WITH Classpath-exception-2.0"
+                    ]
+                  },
+                  "expressionDetails": {
+                    "title": "Expression Details",
+                    "description": "Details for parts of the `expression`.",
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "description": "This document specifies the details and attributes related to a software license identifier. An SPDX expression may be a compound of license identifiers.\nThe `license_identifier` property serves as the key that identifies each record. Note that this key is not required to be unique, as the same license identifier could apply to multiple, different but similar license details, texts, etc.",
+                      "required": [
+                        "licenseIdentifier"
+                      ],
+                      "properties": {
+                        "licenseIdentifier": {
+                          "title": "License Identifier",
+                          "description": "The valid SPDX license identifier. Refer to https://spdx.org/specifications for syntax requirements.\nThis property serves as the primary key, which uniquely identifies each record.",
+                          "type": "string",
+                          "examples": [
+                            "Apache-2.0",
+                            "GPL-3.0-only WITH Classpath-exception-2.0",
+                            "LicenseRef-my-custom-license"
+                          ]
+                        },
+                        "bom-ref": {
+                          "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+                          "title": "BOM Reference",
+                          "description": "An identifier which can be used to reference the license elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+                        },
+                        "text": {
+                          "title": "License texts",
+                          "description": "A way to include the textual content of the license.",
+                          "$ref": "#/$defs/cyclonedx-common-2.0/$defs/attachment"
+                        },
+                        "url": {
+                          "type": "string",
+                          "title": "License URL",
+                          "description": "The URL to the license file. If specified, a 'license' externalReference should also be specified for completeness",
+                          "examples": [
+                            "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                          ],
+                          "format": "iri-reference"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "acknowledgement": {
+                    "$ref": "#/$defs/cyclonedx-license-2.0/$defs/licenseAcknowledgementEnumeration"
+                  },
+                  "bom-ref": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+                    "title": "BOM Reference",
+                    "description": "An identifier which can be used to reference the license elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+                  },
+                  "licensing": {
+                    "$ref": "#/$defs/cyclonedx-license-2.0/$defs/licensing"
+                  },
+                  "properties": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "license": {
+          "type": "object",
+          "title": "License",
+          "description": "Specifies the details and attributes related to a software license. It can either include a valid SPDX license identifier or a named license, along with additional properties such as license acknowledgment, comprehensive commercial licensing information, and the full text of the license.",
+          "oneOf": [
+            {
+              "required": [
+                "id"
+              ]
+            },
+            {
+              "required": [
+                "name"
+              ]
+            }
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the license elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+            },
+            "id": {
+              "$ref": "../spdx.schema.json",
+              "title": "License ID (SPDX)",
+              "description": "A valid SPDX license identifier. If specified, this value must be one of the enumeration of valid SPDX license identifiers defined in the spdx.schema.json (or spdx.xml) subschema which is synchronized with the official SPDX license list.",
+              "examples": [
+                "Apache-2.0"
+              ]
+            },
+            "name": {
+              "type": "string",
+              "title": "License Name",
+              "description": "The name of the license. This may include the name of a commercial or proprietary license or an open source license that may not be defined by SPDX.",
+              "examples": [
+                "Acme Software License"
+              ]
+            },
+            "acknowledgement": {
+              "$ref": "#/$defs/cyclonedx-license-2.0/$defs/licenseAcknowledgementEnumeration"
+            },
+            "text": {
+              "title": "License text",
+              "description": "A way to include the textual content of a license.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/attachment"
+            },
+            "url": {
+              "type": "string",
+              "title": "License URL",
+              "description": "The URL to the license file. If specified, a 'license' externalReference should also be specified for completeness",
+              "examples": [
+                "https://www.apache.org/licenses/LICENSE-2.0.txt"
+              ],
+              "format": "iri-reference"
+            },
+            "licensing": {
+              "$ref": "#/$defs/cyclonedx-license-2.0/$defs/licensing"
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "licenseAcknowledgementEnumeration": {
+          "title": "License Acknowledgement",
+          "description": "Declared licenses and concluded licenses represent two different stages in the licensing process within software development. Declared licenses refer to the initial intention of the software authors regarding the licensing terms under which their code is released. On the other hand, concluded licenses are the result of a comprehensive analysis of the project's codebase to identify and confirm the actual licenses of the components used, which may differ from the initially declared licenses. While declared licenses provide an upfront indication of the licensing intentions, concluded licenses offer a more thorough understanding of the actual licensing within a project, facilitating proper compliance and risk management. Observed licenses are defined in `@.evidence.licenses`. Observed licenses form the evidence necessary to substantiate a concluded license.",
+          "type": "string",
+          "enum": [
+            "declared",
+            "concluded"
+          ],
+          "meta:enum": {
+            "declared": "Declared licenses represent the initial intentions of authors regarding the licensing terms of their code.",
+            "concluded": "Concluded licenses are verified and confirmed."
+          }
+        },
+        "licensing": {
+          "type": "object",
+          "title": "Licensing information",
+          "description": "Licensing details describing the licensor/licensee, license type, renewal and expiration dates, and other important metadata",
+          "additionalProperties": false,
+          "properties": {
+            "altIds": {
+              "type": "array",
+              "title": "Alternate License Identifiers",
+              "description": "License identifiers that may be used to manage licenses and their lifecycle",
+              "items": {
+                "type": "string"
+              }
+            },
+            "licensor": {
+              "title": "Licensor",
+              "description": "The individual or organization that grants a license to another individual or organization",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "organization": {
+                  "title": "Licensor (Organization)",
+                  "description": "The organization that granted the license",
+                  "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalEntity"
+                },
+                "individual": {
+                  "title": "Licensor (Individual)",
+                  "description": "The individual, not associated with an organization, that granted the license",
+                  "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalContact"
+                }
+              },
+              "oneOf": [
+                {
+                  "required": [
+                    "organization"
+                  ]
+                },
+                {
+                  "required": [
+                    "individual"
+                  ]
+                }
+              ]
+            },
+            "licensee": {
+              "title": "Licensee",
+              "description": "The individual or organization for which a license was granted to",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "organization": {
+                  "title": "Licensee (Organization)",
+                  "description": "The organization that was granted the license",
+                  "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalEntity"
+                },
+                "individual": {
+                  "title": "Licensee (Individual)",
+                  "description": "The individual, not associated with an organization, that was granted the license",
+                  "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalContact"
+                }
+              },
+              "oneOf": [
+                {
+                  "required": [
+                    "organization"
+                  ]
+                },
+                {
+                  "required": [
+                    "individual"
+                  ]
+                }
+              ]
+            },
+            "purchaser": {
+              "title": "Purchaser",
+              "description": "The individual or organization that purchased the license",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "organization": {
+                  "title": "Purchaser (Organization)",
+                  "description": "The organization that purchased the license",
+                  "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalEntity"
+                },
+                "individual": {
+                  "title": "Purchaser (Individual)",
+                  "description": "The individual, not associated with an organization, that purchased the license",
+                  "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalContact"
+                }
+              },
+              "oneOf": [
+                {
+                  "required": [
+                    "organization"
+                  ]
+                },
+                {
+                  "required": [
+                    "individual"
+                  ]
+                }
+              ]
+            },
+            "purchaseOrder": {
+              "type": "string",
+              "title": "Purchase Order",
+              "description": "The purchase order identifier the purchaser sent to a supplier or vendor to authorize a purchase"
+            },
+            "licenseTypes": {
+              "type": "array",
+              "title": "License Type",
+              "description": "The type of license(s) that was granted to the licensee.",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "academic",
+                  "appliance",
+                  "client-access",
+                  "concurrent-user",
+                  "core-points",
+                  "custom-metric",
+                  "device",
+                  "evaluation",
+                  "named-user",
+                  "node-locked",
+                  "oem",
+                  "perpetual",
+                  "processor-points",
+                  "subscription",
+                  "user",
+                  "other"
+                ],
+                "meta:enum": {
+                  "academic": "A license that grants use of software solely for the purpose of education or research.",
+                  "appliance": "A license covering use of software embedded in a specific piece of hardware.",
+                  "client-access": "A Client Access License (CAL) allows client computers to access services provided by server software.",
+                  "concurrent-user": "A Concurrent User license (aka floating license) limits the number of licenses for a software application and licenses are shared among a larger number of users.",
+                  "core-points": "A license where the core of a computer's processor is assigned a specific number of points.",
+                  "custom-metric": "A license for which consumption is measured by non-standard metrics.",
+                  "device": "A license that covers a defined number of installations on computers and other types of devices.",
+                  "evaluation": "A license that grants permission to install and use software for trial purposes.",
+                  "named-user": "A license that grants access to the software to one or more pre-defined users.",
+                  "node-locked": "A license that grants access to the software on one or more pre-defined computers or devices.",
+                  "oem": "An Original Equipment Manufacturer license that is delivered with hardware, cannot be transferred to other hardware, and is valid for the life of the hardware.",
+                  "perpetual": "A license where the software is sold on a one-time basis and the licensee can use a copy of the software indefinitely.",
+                  "processor-points": "A license where each installation consumes points per processor.",
+                  "subscription": "A license where the licensee pays a fee to use the software or service.",
+                  "user": "A license that grants access to the software or service by a specified number of users.",
+                  "other": "Another license type."
+                }
+              }
+            },
+            "lastRenewal": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Last Renewal",
+              "description": "The timestamp indicating when the license was last renewed. For new purchases, this is often the purchase or acquisition date. For non-perpetual licenses or subscriptions, this is the timestamp of when the license was last renewed."
+            },
+            "expiration": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Expiration",
+              "description": "The timestamp indicating when the current license expires (if applicable)."
+            }
+          }
+        }
+      }
+    },
+    "cyclonedx-metadata-2.0": {
+      "type": "null",
+      "title": "CycloneDX Metadata Model",
+      "$defs": {
+        "metadata": {
+          "type": "object",
+          "title": "BOM Metadata",
+          "description": "Provides additional information about a BOM.",
+          "additionalProperties": false,
+          "properties": {
+            "timestamp": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Timestamp",
+              "description": "The date and time (timestamp) when the BOM was created."
+            },
+            "lifecycles": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/lifecycles"
+            },
+            "tools": {
+              "type": "object",
+              "title": "Tools",
+              "description": "The tool(s) used in the creation, enrichment, and validation of the BOM.",
+              "additionalProperties": false,
+              "properties": {
+                "components": {
+                  "$ref": "#/$defs/cyclonedx-component-2.0/$defs/components",
+                  "description": "A list of software and hardware components used as tools."
+                },
+                "services": {
+                  "$ref": "#/$defs/cyclonedx-service-2.0/$defs/services",
+                  "description": "A list of services used as tools. This may include microservices, function-as-a-service, and other types of network or intra-process services."
+                }
+              }
+            },
+            "manufacturer": {
+              "title": "BOM Manufacturer",
+              "description": "The organization that created the BOM.\nManufacturer is common in BOMs created through automated processes. BOMs created through manual means may have `@.authors` instead.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalEntity"
+            },
+            "authors": {
+              "type": "array",
+              "title": "BOM Authors",
+              "description": "The person(s) who created the BOM.\nAuthors are common in BOMs created through manual processes. BOMs created through automated means may have `@.manufacturer` instead.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalContact"
+              }
+            },
+            "component": {
+              "description": "The component that the BOM describes.",
+              "$ref": "#/$defs/cyclonedx-component-2.0/$defs/component"
+            },
+            "supplier": {
+              "title": "Supplier",
+              "description": " The organization that supplied the component that the BOM describes. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalEntity"
+            },
+            "licenses": {
+              "title": "BOM License(s)",
+              "description": "The license information for the BOM document.\nThis may be different from the license(s) of the component(s) that the BOM describes.",
+              "$ref": "#/$defs/cyclonedx-license-2.0/$defs/licenseChoice"
+            },
+            "distributionConstraints": {
+              "$ref": "#/$defs/cyclonedx-metadata-2.0/$defs/distributionConstraints"
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "distributionConstraints": {
+          "title": "Distribution Constraints",
+          "description": "Conditions and constraints governing the sharing and distribution of the data or components described by this BOM.",
+          "type": "object",
+          "properties": {
+            "tlp": {
+              "$ref": "#/$defs/cyclonedx-metadata-2.0/$defs/tlpClassification",
+              "description": "The Traffic Light Protocol (TLP) classification that controls the sharing and distribution of the data that the BOM describes."
+            }
+          }
+        },
+        "tlpClassification": {
+          "title": "Traffic Light Protocol (TLP) Classification",
+          "description": "Traffic Light Protocol (TLP) is a classification system for identifying the potential risk associated with artefact, including whether it is subject to certain types of legal, financial, or technical threats. Refer to [https://www.first.org/tlp/](https://www.first.org/tlp/) for further information.\nThe default classification is \"CLEAR\"",
+          "type": "string",
+          "default": "CLEAR",
+          "enum": [
+            "CLEAR",
+            "GREEN",
+            "AMBER",
+            "AMBER_AND_STRICT",
+            "RED"
+          ],
+          "meta:enum": {
+            "CLEAR": "The information is not subject to any restrictions as regards the sharing.",
+            "GREEN": "The information is subject to limited disclosure, and recipients can share it within their community but not via publicly accessible channels.",
+            "AMBER": "The information is subject to limited disclosure, and recipients can only share it on a need-to-know basis within their organization and with clients.",
+            "AMBER_AND_STRICT": "The information is subject to limited disclosure, and recipients can only share it on a need-to-know basis within their organization.",
+            "RED": "The information is subject to restricted distribution to individual recipients only and must not be shared."
+          }
+        }
+      }
+    },
+    "cyclonedx-party-2.0": {
+      "type": "null",
+      "title": "CycloneDX Party Model",
+      "$defs": {
+        "party": {
+          "type": "object",
+          "title": "Party",
+          "description": "Identifies an organization, individual, system, or abstract archetype that participates in supplying, producing, attesting, operating, owning, regulating, or otherwise relating to the subject. Each party plays one or more named roles. Roles may carry preference order (`role.order`) to express primary, alternate, and secondary rankings among parties sharing the same role.\n\nExactly one identity sub-shape (`organization`, `person`, `system`, or `persona`) shall be present. Optional sub-objects layer inter-party relationships and standard extension data.",
+          "required": [
+            "roles"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType"
+            },
+            "roles": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/cyclonedx-party-2.0/$defs/role"
+              },
+              "title": "Roles",
+              "description": "One or more roles the party fulfils. Each role may carry an `order` indicating preference among parties sharing the same role (for example, primary versus alternate supplier)."
+            },
+            "organization": {
+              "$ref": "#/$defs/cyclonedx-party-2.0/$defs/organization",
+              "description": "Identity attributes valid when the party is an organization, company, government body, or other collective."
+            },
+            "person": {
+              "$ref": "#/$defs/cyclonedx-party-2.0/$defs/person",
+              "description": "Identity attributes valid when the party is an individual person."
+            },
+            "system": {
+              "$ref": "#/$defs/cyclonedx-party-2.0/$defs/system",
+              "title": "System",
+              "description": "Identity attributes valid when the party is a software system, hardware system, service account, automation, or autonomous agent."
+            },
+            "persona": {
+              "$ref": "#/$defs/cyclonedx-party-2.0/$defs/persona",
+              "title": "Persona",
+              "description": "Identity attributes valid when the party is an abstract archetype rather than a specific named instance."
+            },
+            "relations": {
+              "$ref": "#/$defs/cyclonedx-party-2.0/$defs/partyRelations",
+              "title": "Relations",
+              "description": "Links from this party to other parties."
+            },
+            "tags": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/tags"
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            },
+            "externalReferences": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReferences"
+            }
+          },
+          "oneOf": [
+            {
+              "required": [
+                "organization"
+              ]
+            },
+            {
+              "required": [
+                "person"
+              ]
+            },
+            {
+              "required": [
+                "system"
+              ]
+            },
+            {
+              "required": [
+                "persona"
+              ]
+            }
+          ]
+        },
+        "parties": {
+          "type": "array",
+          "title": "Parties",
+          "description": "Parties associated with the subject. Each item identifies an organization, individual, system, or abstract archetype playing one or more named roles such as manufacturer, supplier, author, integrator, quality-control, or any custom role. The same party can hold multiple roles, each independently ranked via `role.order` to express preference (for example, primary supplier with order 1 and alternate supplier with order 2). Items may be inline party objects or references to parties declared elsewhere.",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-party-2.0/$defs/partyChoice"
+          }
+        },
+        "partyChoice": {
+          "title": "Party Choice",
+          "description": "A party represented either as a complete object or as a reference to a previously declared party.",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/cyclonedx-party-2.0/$defs/party"
+            },
+            {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType",
+              "title": "Reference",
+              "description": "A refLinkType pointing to a previously declared party."
+            }
+          ]
+        },
+        "role": {
+          "title": "Role",
+          "description": "A role that a party fulfils. May be a predefined role from the CycloneDX role taxonomy or a custom role definition. The optional `order` property ranks parties that share the same role, supporting use cases such as primary versus alternate suppliers in hardware manufacturing supply chains.",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/cyclonedx-party-2.0/$defs/preDefinedRole"
+            },
+            {
+              "title": "Custom Role",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "title": "Name",
+                  "description": "The name of the custom role.",
+                  "examples": [
+                    "Chief Executive Officer",
+                    "Data Protection Officer",
+                    "Release Manager"
+                  ]
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "description": "A description of the custom role, including its responsibilities and scope."
+                },
+                "order": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "title": "Order",
+                  "description": "Preference order among parties sharing this role. Lower values indicate higher preference. Ties are permitted. Absence means unranked."
+                }
+              }
+            }
+          ]
+        },
+        "preDefinedRole": {
+          "title": "Pre-Defined Role",
+          "type": "object",
+          "required": [
+            "role"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "role": {
+              "type": "string",
+              "title": "Role",
+              "description": "A predefined role from the CycloneDX role taxonomy.",
+              "enum": [
+                "agent",
+                "assembler",
+                "asserter",
+                "attacker",
+                "auditor",
+                "author",
+                "broker",
+                "carrier",
+                "certificate-authority",
+                "committer",
+                "competitor",
+                "consignee",
+                "consignor",
+                "contributor",
+                "customer",
+                "custodian",
+                "customs-broker",
+                "data-controller",
+                "data-processor",
+                "data-recipient",
+                "data-subject",
+                "delegate",
+                "developer",
+                "distributor",
+                "end-user",
+                "engineer",
+                "exporter",
+                "freight-forwarder",
+                "holder",
+                "importer",
+                "insider-threat",
+                "inspector",
+                "insurer",
+                "integrator",
+                "issuer",
+                "key-escrow-agent",
+                "legal-contact",
+                "licensee",
+                "licensor",
+                "maintainer",
+                "manufacturer",
+                "operator",
+                "owner",
+                "packager",
+                "partner",
+                "principal",
+                "publisher",
+                "purchaser",
+                "quality-control",
+                "regulator",
+                "relying-party",
+                "repackager",
+                "researcher",
+                "reviewer",
+                "security-contact",
+                "signatory",
+                "steward",
+                "subject",
+                "supplier",
+                "support-contact",
+                "third-party-logistics",
+                "timestamp-authority",
+                "validation-authority",
+                "verifier",
+                "warehouse-operator"
+              ],
+              "meta:enum": {
+                "agent": "Software or AI agent acting autonomously or semi-autonomously, typically on behalf of a principal.",
+                "assembler": "The party that assembles or integrates constituent parts into the subject. Common in hardware manufacturing and software build pipelines.",
+                "asserter": "The party making assertions about the subject, such as patent ownership or compliance claims.",
+                "attacker": "A hostile party targeting the subject.",
+                "auditor": "The party that conducted an audit or assessment of the subject.",
+                "author": "The party that created the subject. Common when the subject is created through manual processes.",
+                "broker": "The party that acts as an intermediary in commercial transactions.",
+                "carrier": "The party that physically transports goods, such as shipping lines, airlines, or trucking companies.",
+                "certificate-authority": "The party that issues, signs, and manages digital certificates within a public key infrastructure.",
+                "committer": "The party who committed or pushed changes to a version control system.",
+                "competitor": "A competing party in the same market or domain as the subject's organization.",
+                "consignee": "The party designated to receive a shipment of goods.",
+                "consignor": "The party that sends or ships goods to a consignee.",
+                "contributor": "A party that contributed to the development of the subject without being the primary author.",
+                "customer": "Customer of the organization that owns the subject.",
+                "custodian": "The party responsible for the safe custody, transport, and storage of the subject.",
+                "customs-broker": "The party that facilitates the clearance of goods through customs barriers.",
+                "data-controller": "The party that determines the purposes and means of processing personal data.",
+                "data-processor": "The party that processes personal data on behalf of a data controller.",
+                "data-recipient": "The party to which personal data is disclosed.",
+                "data-subject": "The natural person whose personal data is processed.",
+                "delegate": "A party exercising authority on behalf of another party identified via relations.delegatedBy.",
+                "developer": "Software developer or platform engineer.",
+                "distributor": "The party that distributes the subject to downstream consumers or customers.",
+                "end-user": "The end user of a system, service, or product.",
+                "engineer": "Engineer responsible for designing, implementing, or operating a system.",
+                "exporter": "The party that sends goods to another country for trade or sale.",
+                "freight-forwarder": "The party that arranges the shipment and logistics of goods on behalf of shippers.",
+                "holder": "The party that holds a verifiable credential, claim, or asset.",
+                "importer": "The party that brings goods into a country from abroad for trade or sale.",
+                "insider-threat": "A hostile or negligent party with legitimate access.",
+                "inspector": "The party that inspects goods for quality, safety, or regulatory compliance.",
+                "insurer": "The party that provides insurance coverage.",
+                "integrator": "The party that integrates the subject into a larger system or product.",
+                "issuer": "The party that issues a credential, claim, identifier, or asset.",
+                "key-escrow-agent": "The party that holds copies of cryptographic keys in escrow.",
+                "legal-contact": "The designated party to contact for legal matters.",
+                "licensee": "The party to which a license for the subject has been granted.",
+                "licensor": "The party that grants a license for the subject.",
+                "maintainer": "The party responsible for ongoing maintenance, including updates, patches, and security fixes.",
+                "manufacturer": "The party that manufactured or produced the subject. Common when the subject is produced through automated processes.",
+                "operator": "The party responsible for operating or running the subject in a production environment.",
+                "owner": "The party that holds ownership rights over the subject.",
+                "packager": "The party that packages goods for storage, shipment, or retail sale.",
+                "partner": "Business partner with a defined relationship.",
+                "principal": "The party on whose behalf another party acts, paired with delegate.",
+                "publisher": "The party that published the subject, making it available for consumption.",
+                "purchaser": "The party that purchased the subject or a license for its use.",
+                "quality-control": "The party responsible for quality control activities, including inspection, testing, and verification.",
+                "regulator": "Government or industry regulator with administrative authority over the subject.",
+                "relying-party": "The party that relies on credentials, claims, or attestations issued by another party.",
+                "repackager": "The party that repackages the subject, potentially combining it with other components.",
+                "researcher": "Security researcher, bug bounty hunter, or academic conducting authorized study.",
+                "reviewer": "The party that reviewed the subject or its associated evidence.",
+                "security-contact": "The designated party to contact in the event of a security incident.",
+                "signatory": "The party authorized to sign on behalf of an organization, affirming the validity or accuracy of statements or attestations.",
+                "steward": "The party responsible for the content, context, and associated business rules of the subject.",
+                "subject": "The party to whom an issued credential, claim, or identifier is bound.",
+                "supplier": "The party that supplied the subject. The supplier may often be the manufacturer, but may also be a distributor or repackager.",
+                "support-contact": "The designated party to contact for technical support.",
+                "third-party-logistics": "The party that provides outsourced logistics services.",
+                "timestamp-authority": "The party that issues trusted timestamps.",
+                "validation-authority": "The party that provides certificate validation services.",
+                "verifier": "The party that verifies credentials, claims, or attestations.",
+                "warehouse-operator": "The party responsible for storing, handling, and managing inventory within a warehouse or distribution centre."
+              }
+            },
+            "order": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Order",
+              "description": "Preference order among parties sharing this role. Lower values indicate higher preference. Ties are permitted. Absence means unranked. For example, a primary supplier may have `order: 1` while an alternate supplier has `order: 2`.",
+              "examples": [
+                1,
+                2,
+                3
+              ]
+            }
+          }
+        },
+        "organization": {
+          "type": "object",
+          "title": "Organization Identity",
+          "description": "Identity attributes for a party that is an organization, company, government body, or other collective.",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The common display or trading name of the organization. Use when the registered legal name is unknown or when the everyday name differs from the legal one.",
+              "examples": [
+                "Acme",
+                "Globex"
+              ]
+            },
+            "legalName": {
+              "type": "string",
+              "title": "Legal Name",
+              "description": "The registered legal name of the organization, including any suffix such as Inc., S.r.l., GmbH, or LLC.",
+              "examples": [
+                "Acme Microcontrollers S.r.l.",
+                "Acme Holdings, Inc."
+              ]
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "A description of the organization itself, distinct from any role-specific or contextual description applied at the party wrapper level."
+            },
+            "logo": {
+              "type": "string",
+              "format": "iri-reference",
+              "title": "Logo",
+              "description": "URL to an image representing the organization. Useful for catalog, datasheet, and user interface views."
+            },
+            "foundingDate": {
+              "type": "string",
+              "format": "date",
+              "title": "Founding Date",
+              "description": "The date the organization was founded. Supports supplier due diligence and age-of-organization signals."
+            },
+            "dissolutionDate": {
+              "type": "string",
+              "format": "date",
+              "title": "Dissolution Date",
+              "description": "The date the organization was dissolved or wound down. When present, the organization is no longer active."
+            },
+            "jurisdiction": {
+              "type": "string",
+              "title": "Jurisdiction",
+              "description": "Country of registration as an ISO 3166-1 alpha-2 or alpha-3 code, optionally followed by an ISO 3166-2 subdivision separated by a hyphen.",
+              "examples": [
+                "US-DE",
+                "IT-BO",
+                "CHE"
+              ]
+            },
+            "identifiers": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/cyclonedx-party-2.0/$defs/identifier"
+              },
+              "title": "Identifiers",
+              "description": "Identifiers issued to or associated with the organization. May include legal and registration identifiers (LEI, DUNS, CAGE, NCAGE, EORI, VAT, tax identifiers) and non-legal identifiers such as workload or machine identities."
+            },
+            "formerNames": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Former Names",
+              "description": "Prior names of the organization. Use when the entity has been renamed, merged, or acquired. Distinct from `aliases`, which captures concurrent alternate designations.",
+              "examples": [
+                [
+                  "Atmel Corporation"
+                ]
+              ]
+            },
+            "aliases": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true,
+              "title": "Aliases",
+              "description": "Concurrent alternate designations for the organization. Distinct from `formerNames`, which captures historical names. Common when modeling tracked threat-actor groups that are known by different designations across threat-intelligence vendors.",
+              "examples": [
+                [
+                  "Fancy Bear",
+                  "STRONTIUM",
+                  "Sofacy",
+                  "Sednit",
+                  "Pawn Storm"
+                ]
+              ]
+            },
+            "url": {
+              "type": "array",
+              "title": "URLs",
+              "description": "URLs associated with the organization. Each entry carries a `name` label and a `url` value so producers can describe homepage, support portal, press, status, code repository, and similar without ambiguity.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "Label describing the URL, such as `homepage`, `support`, `press`, `status`, or `repository`.",
+                    "examples": [
+                      "homepage",
+                      "support",
+                      "press",
+                      "status",
+                      "repository"
+                    ]
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "iri-reference",
+                    "title": "URL"
+                  }
+                }
+              }
+            },
+            "addresses": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-party-2.0/$defs/postalAddress"
+              },
+              "title": "Addresses",
+              "description": "Physical addresses associated with the organization."
+            }
+          }
+        },
+        "person": {
+          "type": "object",
+          "title": "Person Identity",
+          "description": "Identity attributes for a party that is an individual person. The name model is intentionally unstructured: a single freeform `name` captures the full name as the person wishes to be known, accommodating the wide variation of naming conventions across cultures. See https://www.w3.org/International/questions/qa-personal-names for background.",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "title": "Name",
+              "description": "The person's full name as they wish to be known. A single freeform string. No assumption is made about given-versus-family ordering, mononym versus multi-component names, patronymics, or honorific embedding. Producers should use the form the person uses themselves.",
+              "examples": [
+                "Ada Lovelace",
+                "Suharto",
+                "Maria del Carmen García López",
+                "Nguyễn Văn An"
+              ]
+            },
+            "sortName": {
+              "type": "string",
+              "title": "Sort Name",
+              "description": "Optional sortable form of the name for catalog and index views. Use when the natural form of `name` does not sort intuitively, for example a comma-separated last-name-first form.",
+              "examples": [
+                "Lovelace, Ada",
+                "García López, Maria del Carmen"
+              ]
+            },
+            "honorificPrefix": {
+              "type": "string",
+              "title": "Honorific Prefix",
+              "description": "Honorific or title preceding the name, used in forms of address. Distinct from the name itself.",
+              "examples": [
+                "Dr.",
+                "Prof."
+              ]
+            },
+            "honorificSuffix": {
+              "type": "string",
+              "title": "Honorific Suffix",
+              "description": "Honorific or post-nominal letters following the name, used in forms of address. Distinct from the name itself.",
+              "examples": [
+                "PhD",
+                "Esq."
+              ]
+            },
+            "jobTitle": {
+              "type": "string",
+              "title": "Job Title",
+              "description": "The person's job title. Useful for credit lines and attribution.",
+              "examples": [
+                "Chief Information Security Officer",
+                "Data Protection Officer",
+                "Senior Software Engineer"
+              ]
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "A description of the person, distinct from any role-specific or contextual description applied at the party wrapper level."
+            },
+            "email": {
+              "type": "array",
+              "title": "Email",
+              "description": "Email addresses associated with the person. Each entry carries a `name` label and an `address` value so producers can describe work, personal, support, and similar contexts without ambiguity.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "address"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "Label describing the email, such as `work`, `personal`, `support`, or `security`.",
+                    "examples": [
+                      "work",
+                      "personal",
+                      "support",
+                      "security"
+                    ]
+                  },
+                  "address": {
+                    "type": "string",
+                    "format": "idn-email",
+                    "title": "Address"
+                  }
+                }
+              }
+            },
+            "phone": {
+              "type": "array",
+              "title": "Phone",
+              "description": "Phone numbers associated with the person. Each entry carries a `name` label and a `number` value. Numbers should be expressed in E.164 form where possible.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "number"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "Label describing the phone, such as `office`, `mobile`, `fax`, or `pager`.",
+                    "examples": [
+                      "office",
+                      "mobile",
+                      "fax",
+                      "pager"
+                    ]
+                  },
+                  "number": {
+                    "type": "string",
+                    "title": "Number",
+                    "examples": [
+                      "+1-555-0100",
+                      "+44 20 7946 0958"
+                    ]
+                  }
+                }
+              }
+            },
+            "url": {
+              "type": "array",
+              "title": "URLs",
+              "description": "URLs associated with the person. Each entry carries a `name` label and a `url` value so producers can describe homepage, social profiles, code repositories, and similar without ambiguity.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "Label describing the URL, such as `homepage`, `github`, `linkedin`, `mastodon`, or `orcid`.",
+                    "examples": [
+                      "homepage",
+                      "github",
+                      "linkedin",
+                      "orcid"
+                    ]
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "iri-reference",
+                    "title": "URL"
+                  }
+                }
+              }
+            },
+            "address": {
+              "$ref": "#/$defs/cyclonedx-party-2.0/$defs/postalAddress",
+              "title": "Address"
+            },
+            "affiliation": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType",
+              "title": "Affiliation",
+              "description": "Reference using bom-link or bom-ref to an organization party with which the person is affiliated."
+            }
+          }
+        },
+        "system": {
+          "type": "object",
+          "title": "System Identity",
+          "description": "Identity attributes for a party that is a software system, hardware system, service account, automation, or autonomous agent.",
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "title": "Kind",
+              "description": "The kind of system the party represents. May be a predefined kind from the CycloneDX system-kind taxonomy expressed as a plain string, or a custom kind expressed as an object with `name` and optional `description`.",
+              "oneOf": [
+                {
+                  "title": "Pre-Defined Kind",
+                  "type": "string",
+                  "enum": [
+                    "software-system",
+                    "hardware-system",
+                    "service-account",
+                    "machine-identity",
+                    "automation",
+                    "agent",
+                    "bot",
+                    "oracle",
+                    "smart-contract",
+                    "device",
+                    "robot"
+                  ],
+                  "meta:enum": {
+                    "software-system": "Application, service, or platform that performs actions as itself.",
+                    "hardware-system": "Physical device or appliance that performs actions. Includes vehicles, drones, satellites, medical devices, network equipment, and industrial controllers unless a more specific kind applies.",
+                    "service-account": "Non-human identity used by automation to authenticate.",
+                    "machine-identity": "Cryptographic identity such as a certificate principal or workload identity.",
+                    "automation": "Pipeline, job, or scheduled task that performs actions deterministically.",
+                    "agent": "Autonomous or semi-autonomous agent that can plan and execute. Includes AI agents.",
+                    "bot": "Scripted automation that interacts with an interface. Includes chatbots, robotic process automation bots, and scraping bots.",
+                    "oracle": "External data feed or oracle, including blockchain oracles that bridge off-chain data into on-chain systems.",
+                    "smart-contract": "On-chain program that executes deterministically.",
+                    "device": "Physical end user device such as a phone or IoT device acting as a party in its own right.",
+                    "robot": "Physical robot or autonomous mechanical system. For software-only counterparts, see `bot`, `agent`, or `automation`."
+                  }
+                },
+                {
+                  "title": "Custom Kind",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1,
+                      "title": "Name",
+                      "description": "The name of the custom kind."
+                    },
+                    "description": {
+                      "type": "string",
+                      "title": "Description",
+                      "description": "A description of the custom kind."
+                    }
+                  }
+                }
+              ]
+            },
+            "ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType",
+              "title": "Reference",
+              "description": "Reference to any bom-ref'd object that represents this system. The referenced object provides the underlying identity (component, service, blueprint asset, or other object type). Use to associate the party with its concrete representation declared elsewhere."
+            },
+            "identifiers": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-party-2.0/$defs/identifier"
+              },
+              "title": "Identifiers",
+              "description": "Machine identifiers for the system, such as service principal, workload identity, certificate subject, or device serial."
+            },
+            "permissions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true,
+              "title": "Permissions",
+              "description": "Capabilities or duties the system possesses."
+            }
+          }
+        },
+        "persona": {
+          "type": "object",
+          "title": "Persona Identity",
+          "description": "Identity attributes for a party that is an abstract archetype rather than a specific named instance. Use for generic users, generic suppliers, or hypothesized attackers when a specific party is intentionally not named. When the specific instance is known (for example a tracked APT group), use `organization` instead.",
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "Free-text description of the persona instance. Use to refine the archetype with details relevant to the threat model, such as the persona's assumed context, history, or behavioral pattern.",
+              "examples": [
+                "Disgruntled administrator with elevated access to the payment gateway and motive driven by recent performance review."
+              ]
+            },
+            "archetype": {
+              "title": "Archetype",
+              "description": "The persona archetype. May be a predefined archetype from the CycloneDX persona-archetype taxonomy expressed as a plain string, or a custom archetype expressed as an object with `name` and optional `description`.",
+              "oneOf": [
+                {
+                  "title": "Pre-Defined Archetype",
+                  "type": "string",
+                  "enum": [
+                    "end-user",
+                    "power-user",
+                    "administrator",
+                    "developer",
+                    "operator",
+                    "internal",
+                    "external",
+                    "anonymous",
+                    "guest",
+                    "customer",
+                    "partner",
+                    "supplier",
+                    "vendor",
+                    "contractor",
+                    "third-party",
+                    "auditor",
+                    "researcher",
+                    "regulator",
+                    "law-enforcement",
+                    "attacker",
+                    "insider-threat",
+                    "hacktivist",
+                    "nation-state",
+                    "organized-crime",
+                    "competitor",
+                    "public"
+                  ],
+                  "meta:enum": {
+                    "end-user": "Typical end user of the system.",
+                    "power-user": "Advanced user with higher than average privileges.",
+                    "administrator": "Administrative or privileged user.",
+                    "developer": "Application developer or platform engineer.",
+                    "operator": "Operational staff running the system.",
+                    "internal": "Generic internal party.",
+                    "external": "Generic external party without an account or operational relationship.",
+                    "anonymous": "Unauthenticated visitor interacting with the system.",
+                    "guest": "Semi-authenticated user with restricted privileges.",
+                    "customer": "Customer of the organization that owns the subject.",
+                    "partner": "Business partner with a defined relationship.",
+                    "supplier": "Generic supplier providing goods or services on a transactional basis.",
+                    "vendor": "Vendor delivering and operating goods or services with operational access to the subject.",
+                    "contractor": "Third party with operational access under contract.",
+                    "third-party": "Generic third party that does not fit partner, supplier, vendor, or contractor.",
+                    "auditor": "External auditor or assessor.",
+                    "researcher": "Security researcher, bug bounty hunter, or academic. Authorized probing party.",
+                    "regulator": "Government or industry regulator with administrative authority over the subject.",
+                    "law-enforcement": "Law enforcement entity with investigative authority.",
+                    "attacker": "Generic hostile external party.",
+                    "insider-threat": "Hostile or negligent party with legitimate access.",
+                    "hacktivist": "Hostile party motivated by ideology or activism.",
+                    "nation-state": "Hostile party sponsored or directed by a national government.",
+                    "organized-crime": "Hostile party operating as part of an organized criminal enterprise.",
+                    "competitor": "Generic competitor.",
+                    "public": "General public not in direct interaction with the subject."
+                  }
+                },
+                {
+                  "title": "Custom Archetype",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1,
+                      "title": "Name"
+                    },
+                    "description": {
+                      "type": "string",
+                      "title": "Description"
+                    }
+                  }
+                }
+              ]
+            },
+            "scope": {
+              "type": "string",
+              "title": "Scope",
+              "enum": [
+                "internal",
+                "external",
+                "mixed"
+              ],
+              "meta:enum": {
+                "internal": "Persona is internal to the organization that owns the subject.",
+                "external": "Persona is external to the organization that owns the subject.",
+                "mixed": "Persona may appear in either internal or external contexts."
+              }
+            },
+            "permissions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true,
+              "title": "Permissions",
+              "description": "Capabilities the persona is assumed to hold."
+            },
+            "assumedPosture": {
+              "type": "string",
+              "title": "Assumed Security Posture",
+              "description": "Assumed security posture of the persona in this context.",
+              "examples": [
+                "authenticated",
+                "unauthenticated",
+                "authorized",
+                "privileged"
+              ]
+            }
+          }
+        },
+        "partyRelations": {
+          "type": "object",
+          "title": "Party Relations",
+          "description": "Links from this party to other parties. Captures hierarchical, organizational, and delegation relationships. Order ranking is on the role itself (`role.order`), not here.",
+          "additionalProperties": false,
+          "properties": {
+            "parent": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType",
+              "title": "Parent",
+              "description": "Reference to a parent party. Models organizational hierarchy, group membership, and corporate parent or subsidiary relationships."
+            },
+            "delegatedBy": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType",
+              "title": "Delegated By",
+              "description": "Reference to another party that delegated authority to this one. Models situations such as an autonomous agent acting on behalf of a human user, a contractor acting on behalf of a principal, or a service account assuming a role."
+            }
+          }
+        },
+        "identifier": {
+          "type": "object",
+          "title": "Identifier",
+          "description": "An identifier issued by a recognized authority. Includes legal and registration identifiers as well as machine and workload identities.",
+          "required": [
+            "scheme",
+            "value"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "scheme": {
+              "title": "Scheme",
+              "description": "The identifier scheme. May be a predefined scheme from the CycloneDX identifier-scheme taxonomy expressed as a plain string, or a custom scheme expressed as an object with `name` and optional `description` and `url`.",
+              "oneOf": [
+                {
+                  "title": "Pre-Defined Scheme",
+                  "type": "string",
+                  "enum": [
+                    "lei",
+                    "duns",
+                    "ncage",
+                    "cage",
+                    "eori",
+                    "vat",
+                    "gst",
+                    "ein",
+                    "tin",
+                    "ruc",
+                    "bvd",
+                    "swift-bic",
+                    "sec-cik",
+                    "isin",
+                    "figi",
+                    "opencorporates",
+                    "gln",
+                    "gtin",
+                    "iso6523",
+                    "ofac-sdn",
+                    "un-lm",
+                    "oidc-sub",
+                    "spiffe",
+                    "did",
+                    "vc-id"
+                  ],
+                  "meta:enum": {
+                    "lei": "Legal Entity Identifier per ISO 17442.",
+                    "duns": "Dun and Bradstreet D-U-N-S Number.",
+                    "ncage": "NATO Commercial and Government Entity code.",
+                    "cage": "United States Commercial and Government Entity code.",
+                    "eori": "Economic Operator Registration and Identification number used in European Union customs.",
+                    "vat": "Value Added Tax registration number.",
+                    "gst": "Goods and Services Tax registration number.",
+                    "ein": "United States Employer Identification Number.",
+                    "tin": "Generic Taxpayer Identification Number.",
+                    "ruc": "Registro Unico de Contribuyentes used in several Latin American countries.",
+                    "bvd": "Bureau van Dijk identifier.",
+                    "swift-bic": "Business Identifier Code per ISO 9362.",
+                    "sec-cik": "United States Securities and Exchange Commission Central Index Key.",
+                    "isin": "International Securities Identification Number per ISO 6166.",
+                    "figi": "Financial Instrument Global Identifier.",
+                    "opencorporates": "OpenCorporates company identifier.",
+                    "gln": "GS1 Global Location Number.",
+                    "gtin": "GS1 Global Trade Item Number when the party is also a registered trade entity.",
+                    "iso6523": "ISO 6523 organization identifier. The value should encode the four-digit International Code Designator (ICD) followed by the organization identifier per the registry referenced by the ICD.",
+                    "ofac-sdn": "United States Office of Foreign Assets Control Specially Designated Nationals list identifier.",
+                    "un-lm": "United Nations Locode for a specific facility or jurisdiction.",
+                    "oidc-sub": "OpenID Connect subject identifier for a machine or service identity.",
+                    "spiffe": "SPIFFE ID for a workload identity.",
+                    "did": "W3C Decentralized Identifier (DID) per https://www.w3.org/TR/did-core/. Common for autonomous agents, federated services, and verifiable-credential subjects.",
+                    "vc-id": "W3C Verifiable Credential identifier per https://www.w3.org/TR/vc-data-model/."
+                  }
+                },
+                {
+                  "title": "Custom Scheme",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 1,
+                      "title": "Name"
+                    },
+                    "description": {
+                      "type": "string",
+                      "title": "Description"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "iri-reference",
+                      "title": "URL",
+                      "description": "URL of the scheme registry or specification."
+                    }
+                  }
+                }
+              ]
+            },
+            "schemeVersion": {
+              "type": "string",
+              "title": "Scheme Version",
+              "description": "The version of the scheme that issued this identifier, if applicable."
+            },
+            "value": {
+              "type": "string",
+              "title": "Value",
+              "description": "The value of the identifier."
+            },
+            "issuedDate": {
+              "type": "string",
+              "format": "date",
+              "title": "Issued Date"
+            },
+            "expirationDate": {
+              "type": "string",
+              "format": "date",
+              "title": "Expiration Date"
+            },
+            "issuer": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType",
+              "title": "Issuer",
+              "description": "Reference using bom-link or bom-ref to the party that issued the identifier."
+            }
+          }
+        },
+        "postalAddress": {
+          "type": "object",
+          "title": "Postal Address",
+          "description": "An address used to identify a contactable or operational location.",
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "Reference Identifier",
+              "description": "An optional identifier that can be used to reference the address from elsewhere. Every bom-ref shall be unique within the containing instance. The value should not start with the prefix 'urn:cdx:' to avoid conflicts with BOM-Link identifiers."
+            },
+            "country": {
+              "type": "string",
+              "title": "Country",
+              "description": "The country name or the two-letter ISO 3166-1 country code. When the isoCode property is present, the value of isoCode is authoritative."
+            },
+            "region": {
+              "type": "string",
+              "title": "Region",
+              "description": "The region or state in the country. When the isoCode property carries an ISO 3166-2 subdivision, the value of isoCode is authoritative.",
+              "examples": [
+                "Texas"
+              ]
+            },
+            "isoCode": {
+              "type": "string",
+              "pattern": "^[A-Z]{2}(-[A-Z0-9]{1,3})?$",
+              "title": "ISO Code",
+              "description": "An ISO 3166-1 alpha-2 country code, optionally followed by an ISO 3166-2 subdivision code separated by a hyphen. When present, this property is authoritative over the free-text country and region properties.",
+              "examples": [
+                "IT-BO",
+                "US-CA",
+                "DE-BY"
+              ]
+            },
+            "locality": {
+              "type": "string",
+              "title": "Locality",
+              "description": "The locality or city within the country.",
+              "examples": [
+                "Austin"
+              ]
+            },
+            "postOfficeBoxNumber": {
+              "type": "string",
+              "title": "Post Office Box Number",
+              "description": "The post office box number.",
+              "examples": [
+                "901"
+              ]
+            },
+            "postalCode": {
+              "type": "string",
+              "title": "Postal Code",
+              "description": "The postal code.",
+              "examples": [
+                "78758"
+              ]
+            },
+            "streetAddress": {
+              "type": "string",
+              "title": "Street Address",
+              "description": "The street address. Multi-line addresses are expressed as a single string with line breaks (`\\n`) between lines. Implementations and serialization formats are not required to preserve the order of elements in an array, so a multi-line address shall not be modeled as an array.",
+              "examples": [
+                "100 Main Street",
+                "Acme Tower\nSuite 1200\n100 Main Street"
+              ]
+            },
+            "coordinates": {
+              "type": "object",
+              "title": "Geographic Coordinates",
+              "description": "Geographic coordinates of the address.",
+              "additionalProperties": false,
+              "required": [
+                "latitude",
+                "longitude"
+              ],
+              "properties": {
+                "latitude": {
+                  "type": "number",
+                  "minimum": -90,
+                  "maximum": 90,
+                  "title": "Latitude",
+                  "description": "Latitude in decimal degrees. Four or more decimal places are recommended for facility-level precision."
+                },
+                "longitude": {
+                  "type": "number",
+                  "minimum": -180,
+                  "maximum": 180,
+                  "title": "Longitude",
+                  "description": "Longitude in decimal degrees. Four or more decimal places are recommended for facility-level precision."
+                },
+                "altitude": {
+                  "type": "number",
+                  "title": "Altitude",
+                  "description": "Altitude in meters above the reference ellipsoid identified by the datum property."
+                },
+                "datum": {
+                  "type": "string",
+                  "title": "Datum",
+                  "description": "The geodetic datum used for the coordinates. WGS84 is assumed when omitted.",
+                  "default": "WGS84",
+                  "examples": [
+                    "WGS84",
+                    "NAD83",
+                    "ETRS89"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "cyclonedx-patent-2.0": {
+      "type": "null",
+      "title": "CycloneDX Patent Model",
+      "$defs": {
+        "patents": {
+          "type": "array",
+          "title": "Patents",
+          "description": "The list of either individual patents or patent families.",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/cyclonedx-patent-2.0/$defs/patent"
+              },
+              {
+                "$ref": "#/$defs/cyclonedx-patent-2.0/$defs/patentFamily"
+              }
+            ]
+          }
+        },
+        "patent": {
+          "type": "object",
+          "title": "Patent",
+          "description": "A patent is a legal instrument, granted by an authority, that confers certain rights over an invention for a specified period, contingent on public disclosure and adherence to relevant legal requirements. The summary information in this object is aligned with [WIPO ST.96](https://www.wipo.int/standards/en/st96/) principles where applicable.",
+          "required": [
+            "patentNumber",
+            "jurisdiction",
+            "patentLegalStatus"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+            },
+            "patentNumber": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9\\-/.()\\s]{0,28}[A-Za-z0-9]$",
+              "title": "Patent Number",
+              "description": "The unique number assigned to the granted patent by the issuing authority. Aligned with `PatentNumber` in WIPO ST.96. Refer to [PatentNumber in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/PatentNumber.xsd).",
+              "examples": [
+                "US987654321",
+                "EP1234567B1"
+              ]
+            },
+            "applicationNumber": {
+              "$ref": "#/$defs/cyclonedx-patent-2.0/$defs/patentApplicationNumber"
+            },
+            "jurisdiction": {
+              "$ref": "#/$defs/cyclonedx-patent-2.0/$defs/patentJurisdiction"
+            },
+            "priorityApplication": {
+              "$ref": "#/$defs/cyclonedx-patent-2.0/$defs/priorityApplication"
+            },
+            "publicationNumber": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9\\-/.()\\s]{0,28}[A-Za-z0-9]$",
+              "title": "Patent Publication Number",
+              "description": "This is the number assigned to a patent application once it is published. Patent applications are generally published 18 months after filing (unless an applicant requests non-publication). This number is distinct from the application number. \n\nPurpose: Identifies the publicly available version of the application. \n\nFormat: Varies by jurisdiction, often similar to application numbers but includes an additional suffix indicating publication. \n\nExample:\n - US: US20240000123A1 (indicates the first publication of application US20240000123) \n - Europe: EP23123456A1 (first publication of European application EP23123456). \n\nWIPO ST.96 v8.0: \n - Publication Number field: https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/PublicationNumber.xsd"
+            },
+            "title": {
+              "type": "string",
+              "title": "Patent Title",
+              "description": "The title of the patent, summarising the invention it protects. Aligned with `InventionTitle` in WIPO ST.96. Refer to [InventionTitle in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/InventionTitle.xsd)."
+            },
+            "abstract": {
+              "type": "string",
+              "title": "Patent Abstract",
+              "description": "A brief summary of the invention described in the patent. Aligned with `Abstract` and `P` in WIPO ST.96. Refer to [Abstract in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/Abstract.xsd)."
+            },
+            "filingDate": {
+              "type": "string",
+              "format": "date",
+              "title": "Filing Date",
+              "description": "The date the patent application was filed with the jurisdiction. Aligned with `FilingDate` in WIPO ST.96. Refer to [FilingDate in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/FilingDate.xsd)."
+            },
+            "grantDate": {
+              "type": "string",
+              "format": "date",
+              "title": "Grant Date",
+              "description": "The date the patent was granted by the jurisdiction. Aligned with `GrantDate` in WIPO ST.96. Refer to [GrantDate in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/GrantDate.xsd)."
+            },
+            "patentExpirationDate": {
+              "type": "string",
+              "format": "date",
+              "title": "Expiration Date",
+              "description": "The date the patent expires. Derived from grant or filing date according to jurisdiction-specific rules."
+            },
+            "patentLegalStatus": {
+              "type": "string",
+              "title": "Legal Status",
+              "description": "Indicates the current legal status of the patent or patent application, based on the WIPO ST.27 standard. This status reflects administrative, procedural, or legal events. Values include both active and inactive states and are useful for determining enforceability, procedural history, and maintenance status.",
+              "enum": [
+                "pending",
+                "granted",
+                "revoked",
+                "expired",
+                "lapsed",
+                "withdrawn",
+                "abandoned",
+                "suspended",
+                "reinstated",
+                "opposed",
+                "terminated",
+                "invalidated",
+                "in-force"
+              ],
+              "meta:enum": {
+                "pending": "The patent application has been filed but not yet examined or granted.",
+                "granted": "The patent application has been examined and a patent has been issued.",
+                "revoked": "The patent has been declared invalid through a legal or administrative process.",
+                "expired": "The patent has reached the end of its enforceable term.",
+                "lapsed": "The patent is no longer in force due to non-payment of maintenance fees or other requirements.",
+                "withdrawn": "The patent application was voluntarily withdrawn by the applicant.",
+                "abandoned": "The patent application was abandoned, often due to lack of action or response.",
+                "suspended": "Processing of the patent application has been temporarily halted.",
+                "reinstated": "A previously abandoned or lapsed patent has been reinstated.",
+                "opposed": "The patent application or granted patent is under formal opposition proceedings.",
+                "terminated": "The patent or application has been officially terminated.",
+                "invalidated": "The patent has been invalidated, either in part or in full.",
+                "in-force": "The granted patent is active and enforceable."
+              }
+            },
+            "patentAssignee": {
+              "type": "array",
+              "title": "Patent Assignees",
+              "description": "A collection of organisations or individuals to whom the patent rights are assigned. This supports joint ownership and allows for flexible representation of both corporate entities and individual inventors.",
+              "items": {
+                "oneOf": [
+                  {
+                    "title": "Person",
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalContact"
+                  },
+                  {
+                    "title": "Organizational Entity",
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalEntity"
+                  }
+                ]
+              }
+            },
+            "externalReferences": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReferences"
+            }
+          }
+        },
+        "patentFamily": {
+          "type": "object",
+          "title": "Patent Family",
+          "description": "A patent family is a group of related patent applications or granted patents that cover the same or similar invention. These patents are filed in multiple jurisdictions to protect the invention across different regions or countries. A patent family typically includes patents that share a common priority date, originating from the same initial application, and may vary slightly in scope or claims to comply with regional legal frameworks. Fields align with WIPO ST.96 standards where applicable.",
+          "required": [
+            "familyId"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM. \n\nFor a patent, it might be a good idea to use a patent number as the BOM reference ID."
+            },
+            "familyId": {
+              "type": "string",
+              "title": "Patent Family ID",
+              "description": "The unique identifier for the patent family, aligned with the `id` attribute in WIPO ST.96 v8.0's `PatentFamilyType`. Refer to [PatentFamilyType in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/PatentFamilyType.xsd)."
+            },
+            "priorityApplication": {
+              "$ref": "#/$defs/cyclonedx-patent-2.0/$defs/priorityApplication"
+            },
+            "members": {
+              "type": "array",
+              "title": "Family Members",
+              "description": "A collection of patents or applications that belong to this family, each identified by a `bom-ref` pointing to a patent object defined elsewhere in the BOM.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType",
+                "title": "BOM Reference",
+                "description": "A `bom-ref` linking to a patent or application object within the BOM."
+              }
+            },
+            "externalReferences": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReferences"
+            }
+          }
+        },
+        "patentAssertions": {
+          "type": "array",
+          "title": "Patent Assertions",
+          "description": "A list of assertions made regarding patents associated with this component or service. Assertions distinguish between ownership, licensing, and other relevant interactions with patents.",
+          "items": {
+            "type": "object",
+            "title": "Patent Assertion",
+            "description": "An assertion linking a patent or patent family to this component or service.",
+            "required": [
+              "assertionType",
+              "asserter"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "bom-ref": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+                "title": "BOM Reference",
+                "description": "A reference to the patent or patent family object within the BOM. This must match the `bom-ref` of a `patent` or `patentFamily` object."
+              },
+              "assertionType": {
+                "type": "string",
+                "title": "Assertion Type",
+                "description": "The type of assertion being made about the patent or patent family. Examples include ownership, licensing, and standards inclusion.",
+                "enum": [
+                  "ownership",
+                  "license",
+                  "third-party-claim",
+                  "standards-inclusion",
+                  "prior-art",
+                  "exclusive-rights",
+                  "non-assertion",
+                  "research-or-evaluation"
+                ],
+                "meta:enum": {
+                  "ownership": "The manufacturer asserts ownership of the patent or patent family.",
+                  "license": "The manufacturer asserts they have a license to use the patent or patent family.",
+                  "third-party-claim": "A third party has asserted a claim or potential infringement against the manufacturer’s component or service.",
+                  "standards-inclusion": "The patent is part of a standard essential patent (SEP) portfolio relevant to the component or service.",
+                  "prior-art": "The manufacturer asserts the patent or patent family as prior art that invalidates another patent or claim.",
+                  "exclusive-rights": "The manufacturer asserts exclusive rights granted through a licensing agreement.",
+                  "non-assertion": "The manufacturer asserts they will not enforce the patent or patent family against certain uses or users.",
+                  "research-or-evaluation": "The patent or patent family is being used under a research or evaluation license."
+                }
+              },
+              "patentRefs": {
+                "type": "array",
+                "title": "Patent References",
+                "description": "A list of BOM references (`bom-ref`) linking to patents or patent families associated with this assertion.",
+                "items": {
+                  "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType"
+                }
+              },
+              "asserter": {
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalEntity",
+                    "title": "Organizational Entity"
+                  },
+                  {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalContact",
+                    "title": "Person"
+                  },
+                  {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType",
+                    "title": "Reference",
+                    "description": "A reference to a previously defined `organizationalContact` or `organizationalEntity` object in the BOM. The value must be a valid `bom-ref` pointing to one of these objects."
+                  }
+                ]
+              },
+              "notes": {
+                "type": "string",
+                "title": "Notes",
+                "description": "Additional notes or clarifications regarding the assertion, if necessary. For example, geographical restrictions, duration, or limitations of a license."
+              }
+            }
+          }
+        },
+        "patentApplicationNumber": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9\\-/.()\\s]{0,28}[A-Za-z0-9]$",
+          "title": "Patent Application Number",
+          "description": "The unique number assigned to a patent application when it is filed with a patent office. It is used to identify the specific application and track its progress through the examination process. Aligned with `ApplicationNumber` in ST.96. Refer to [ApplicationIdentificationType in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/ApplicationIdentificationType.xsd).",
+          "examples": [
+            "US20240000123",
+            "EP23123456"
+          ]
+        },
+        "patentJurisdiction": {
+          "type": "string",
+          "title": "Jurisdiction",
+          "description": "The jurisdiction or patent office where the priority application was filed, specified using WIPO ST.3 codes. Aligned with `IPOfficeCode` in ST.96. Refer to [IPOfficeCode in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Common/IPOfficeCode.xsd).",
+          "pattern": "^[A-Z]{2}$",
+          "examples": [
+            "US",
+            "EP",
+            "JP"
+          ]
+        },
+        "patentFilingDate": {
+          "type": "string",
+          "format": "date",
+          "title": "Filing Date",
+          "description": "The date the priority application was filed, aligned with `FilingDate` in ST.96. Refer to [FilingDate in ST.96](https://www.wipo.int/standards/XMLSchema/ST96/V8_0/Patent/FilingDate.xsd)."
+        },
+        "priorityApplication": {
+          "type": "object",
+          "title": "Priority Application",
+          "description": "The priorityApplication contains the essential data necessary to identify and reference an earlier patent filing for priority rights. In line with WIPO ST.96 guidelines, it includes the jurisdiction (office code), application number, and filing date-the three key elements that uniquely specify the priority application in a global patent context.",
+          "required": [
+            "applicationNumber",
+            "jurisdiction",
+            "filingDate"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "applicationNumber": {
+              "$ref": "#/$defs/cyclonedx-patent-2.0/$defs/patentApplicationNumber"
+            },
+            "jurisdiction": {
+              "$ref": "#/$defs/cyclonedx-patent-2.0/$defs/patentJurisdiction"
+            },
+            "filingDate": {
+              "$ref": "#/$defs/cyclonedx-patent-2.0/$defs/patentFilingDate"
+            }
+          }
+        }
+      }
+    },
+    "cyclonedx-perspective-2.0": {
+      "type": "null",
+      "title": "CycloneDX Perspective Model",
+      "$defs": {
+        "perspectives": {
+          "type": "array",
+          "title": "Perspectives",
+          "description": "Defines domain-specific views into the document, enabling different audiences to interpret and navigate the data through their own conceptual lens. Each perspective identifies relevant data types and may provide domain-specific terminology mappings.",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-perspective-2.0/$defs/perspective"
+          }
+        },
+        "perspective": {
+          "type": "object",
+          "title": "Perspective",
+          "description": "A domain-specific view that identifies the types of data relevant to a particular audience and provides optional terminology mappings to facilitate interpretation. Perspectives enable tooling to generate filtered views, translate terminology, and validate document completeness against audience-specific requirements.",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "mappings"
+          ],
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType"
+            },
+            "name": {
+              "type": "string",
+              "title": "Perspective Name",
+              "description": "The name of the perspective, typically indicating the target audience or domain.",
+              "examples": [
+                "AI/ML Transparency",
+                "Device Manufacturing Regulatory Compliance",
+                "Minimum Elements of an SBOM"
+              ]
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "A description of the perspective, its intended audience, and the use cases it supports."
+            },
+            "domains": {
+              "type": "array",
+              "title": "Domains",
+              "description": "The domains or disciplines to which this perspective applies. Allows selection of multiple pre-defined domains, custom domains, or a combination of both.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-perspective-2.0/$defs/perspectiveDomainChoice"
+              }
+            },
+            "mappings": {
+              "type": "array",
+              "title": "Data Type Mappings",
+              "description": "An array of mappings that identify the types of data relevant to this perspective using JSON path expressions. Each mapping may include domain-specific terminology.",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/cyclonedx-perspective-2.0/$defs/perspectiveMapping"
+              }
+            },
+            "externalReferences": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReferences"
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "perspectiveMapping": {
+          "type": "object",
+          "title": "Perspective Mapping",
+          "description": "Maps a JSON path expression to domain-specific terminology, enabling audiences to interpret CycloneDX data using familiar nomenclature. Each mapping identifies a data type within the document structure and may provide alternative names and descriptions used by the target audience.",
+          "additionalProperties": false,
+          "required": [
+            "expression"
+          ],
+          "properties": {
+            "expression": {
+              "type": "string",
+              "title": "Path Expression",
+              "description": "A [JSONPath](https://datatracker.ietf.org/doc/html/rfc9535) expression that identifies the types of data relevant to this perspective.",
+              "examples": [
+                "$.components[*].pedigree",
+                "$.components[?(@.type=='machine-learning-model')].modelCard",
+                "$.components[?(@.type=='cryptographic-asset')]",
+                "$.vulnerabilities"
+              ]
+            },
+            "nativeName": {
+              "type": "string",
+              "title": "Native Name",
+              "description": "The domain-specific term used by the target audience to describe the data identified by the expression.",
+              "examples": [
+                "Foundation Models",
+                "Training Corpus",
+                "Cryptographic Inventory",
+                "Component Provenance"
+              ]
+            },
+            "nativeDescription": {
+              "type": "string",
+              "title": "Native Description",
+              "description": "A domain-specific description of the data type, explaining its significance within the context of the perspective."
+            },
+            "relevance": {
+              "$ref": "#/$defs/cyclonedx-perspective-2.0/$defs/perspectiveRelevance"
+            },
+            "weight": {
+              "type": "number",
+              "title": "Weight",
+              "description": "Describes the importance of a field in relation to other fields. Values shall be between 0.0 and 1.0. This allows for relative ranking of mappings, where higher values indicate greater importance.",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "rationale": {
+              "type": "string",
+              "title": "Rationale",
+              "description": "Explains why this data type is relevant to the perspective and how it should be interpreted or used."
+            }
+          }
+        },
+        "perspectiveRelevance": {
+          "type": "string",
+          "title": "Perspective Relevance",
+          "description": "Indicates the importance of a data type to a perspective.",
+          "enum": [
+            "required",
+            "recommended",
+            "optional",
+            "informative"
+          ],
+          "meta:enum": {
+            "required": "This data type is essential for the perspective and should always be present.",
+            "recommended": "This data type is highly relevant and should be included when available.",
+            "optional": "This data type provides supplementary information that may be useful.",
+            "informative": "This data type provides background context but is not directly actionable."
+          }
+        },
+        "perspectiveDomainChoice": {
+          "title": "Perspective Domain Choice",
+          "description": "Allows selection of a pre-defined domain or specification of a custom domain.",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/cyclonedx-perspective-2.0/$defs/preDefinedPerspectiveDomain"
+            },
+            {
+              "type": "object",
+              "title": "Custom Domain",
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "Domain Name",
+                  "description": "The name of the custom domain."
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Domain Description",
+                  "description": "A description of the custom domain, its scope, and the concerns it addresses."
+                }
+              }
+            }
+          ]
+        },
+        "preDefinedPerspectiveDomain": {
+          "type": "string",
+          "title": "Pre-Defined Perspective Domain",
+          "description": "A pre-defined domain or discipline to which a perspective applies. Domains span security disciplines, safety engineering, industry verticals, technology areas, compliance frameworks, and cross-cutting concerns.",
+          "enum": [
+            "application-security",
+            "cloud-security",
+            "container-security",
+            "cryptographic-security",
+            "cyber-security",
+            "data-security",
+            "endpoint-security",
+            "firmware-security",
+            "hardware-security",
+            "identity-access-management",
+            "network-security",
+            "operational-security",
+            "physical-security",
+            "supply-chain-security",
+            "web-security",
+            "automotive-safety",
+            "aviation-safety",
+            "environmental-safety",
+            "functional-safety",
+            "machinery-safety",
+            "maritime-safety",
+            "nuclear-safety",
+            "patient-safety",
+            "process-safety",
+            "railway-safety",
+            "aerospace-defense",
+            "automotive",
+            "building-automation",
+            "consumer-electronics",
+            "critical-infrastructure",
+            "education",
+            "energy-utilities",
+            "financial-services",
+            "government",
+            "healthcare",
+            "insurance",
+            "legal",
+            "manufacturing",
+            "media-entertainment",
+            "pharmaceuticals",
+            "retail",
+            "telecommunications",
+            "transportation",
+            "artificial-intelligence",
+            "edge-computing",
+            "embedded-systems",
+            "industrial-control-systems",
+            "industrial-iot",
+            "internet-of-things",
+            "machine-learning",
+            "medical-devices",
+            "mobile",
+            "operational-technology",
+            "robotics",
+            "scada",
+            "smart-grid",
+            "data-protection",
+            "export-control",
+            "intellectual-property",
+            "legal-compliance",
+            "licensing",
+            "privacy",
+            "regulatory-compliance",
+            "maintainability",
+            "performance",
+            "quality-assurance",
+            "reliability",
+            "testability",
+            "incident-response",
+            "penetration-testing",
+            "red-team",
+            "risk-management",
+            "threat-intelligence",
+            "threat-modeling",
+            "vulnerability-management",
+            "accessibility",
+            "ethics",
+            "human-factors",
+            "interoperability",
+            "resilience",
+            "sustainability",
+            "transparency"
+          ],
+          "meta:enum": {
+            "application-security": "Security concerns related to software applications, including vulnerabilities, secure coding practices, input validation, and dependency management.",
+            "cloud-security": "Security concerns specific to cloud computing environments, including configuration, identity management, data protection, and shared responsibility models.",
+            "container-security": "Security concerns related to containerised applications, including image provenance, runtime protection, orchestration security, and supply chain integrity.",
+            "cryptographic-security": "Concerns related to cryptographic implementations, algorithm selection, key management, certificate handling, and post-quantum cryptography readiness.",
+            "cyber-security": "Broad security concerns encompassing threat detection, incident response, security operations, and defence-in-depth strategies.",
+            "data-security": "Concerns related to protecting data at rest, in transit, and in use, including encryption, access controls, and data loss prevention.",
+            "endpoint-security": "Security concerns for end-user devices including workstations, mobile devices, and peripherals, encompassing malware protection and device management.",
+            "firmware-security": "Security concerns specific to firmware, including secure boot, firmware updates, integrity verification, and protection against persistent threats.",
+            "hardware-security": "Security concerns related to physical hardware, including trusted platform modules, hardware security modules, side-channel attacks, and tamper resistance.",
+            "identity-access-management": "Concerns related to authentication, authorisation, identity lifecycle management, privileged access, and zero-trust architectures.",
+            "network-security": "Security concerns related to network infrastructure, including firewalls, intrusion detection, segmentation, and secure communications.",
+            "operational-security": "Security concerns related to the deployment, configuration, and day-to-day operation of systems in production environments.",
+            "physical-security": "Security concerns related to physical access controls, environmental protections, surveillance, and tamper evidence.",
+            "supply-chain-security": "Concerns related to the security, integrity, and trustworthiness of components, vendors, and processes throughout the supply chain.",
+            "web-security": "Security concerns specific to web applications and services, including OWASP Top 10 vulnerabilities, API security, and client-side protections.",
+            "automotive-safety": "Safety concerns for automotive systems aligned with ISO 26262, including hazard analysis, functional safety requirements, and ASIL classifications.",
+            "aviation-safety": "Safety concerns for aviation systems aligned with DO-178C, DO-254, and DO-326A, including design assurance levels and airworthiness requirements.",
+            "environmental-safety": "Concerns related to environmental protection, hazardous materials handling, emissions, and ecological impact assessment.",
+            "functional-safety": "Safety concerns aligned with IEC 61508 and derivative standards, focusing on systematic failures, safety integrity levels, and risk reduction.",
+            "machinery-safety": "Safety concerns for industrial machinery aligned with ISO 12100 and IEC 62443, including safeguarding, emergency stops, and risk assessment.",
+            "maritime-safety": "Safety concerns for maritime and offshore systems, including vessel automation, navigation systems, and compliance with maritime regulations.",
+            "nuclear-safety": "Safety concerns for nuclear facilities and systems, including defence-in-depth, safety classification, and regulatory compliance with nuclear standards.",
+            "patient-safety": "Safety concerns for medical devices and healthcare systems focusing on preventing harm to patients, including adverse event prevention and clinical risk management.",
+            "process-safety": "Safety concerns for industrial processes involving hazardous materials, including process hazard analysis, safety instrumented systems, and layers of protection.",
+            "railway-safety": "Safety concerns for railway systems aligned with EN 50126, EN 50128, and EN 50129, including signalling, train control, and safety cases.",
+            "aerospace-defense": "Concerns specific to aerospace and defence industries, including mission-critical systems, military standards, and classified information handling.",
+            "automotive": "Industry-specific concerns for automotive manufacturers and suppliers, including ISO/SAE 21434 cyber security and vehicle type approval.",
+            "building-automation": "Concerns related to building management systems, HVAC controls, access systems, and smart building infrastructure.",
+            "consumer-electronics": "Concerns specific to consumer electronic devices, including product safety, electromagnetic compatibility, and consumer protection regulations.",
+            "critical-infrastructure": "Concerns related to systems designated as critical infrastructure, including sector-specific requirements and national security considerations.",
+            "education": "Concerns specific to educational institutions and EdTech, including student data protection, FERPA compliance, and academic integrity.",
+            "energy-utilities": "Concerns specific to energy and utility sectors, including NERC CIP compliance, grid security, and operational continuity.",
+            "financial-services": "Concerns specific to financial institutions, including PCI DSS, SOX compliance, fraud prevention, and transaction integrity.",
+            "government": "Concerns specific to government agencies and contractors, including FedRAMP, FISMA, and public sector procurement requirements.",
+            "healthcare": "Concerns specific to healthcare organisations, including HIPAA compliance, electronic health records, and healthcare interoperability.",
+            "insurance": "Concerns specific to insurance industry, including actuarial data integrity, claims processing security, and regulatory compliance.",
+            "legal": "Concerns specific to legal industry, including attorney-client privilege, e-discovery, and legal hold requirements.",
+            "manufacturing": "Concerns specific to manufacturing environments, including production systems, quality management, and shop floor security.",
+            "media-entertainment": "Concerns specific to media and entertainment, including digital rights management, content protection, and broadcast systems.",
+            "pharmaceuticals": "Concerns specific to pharmaceutical industry, including FDA 21 CFR Part 11, GxP compliance, and drug safety systems.",
+            "retail": "Concerns specific to retail industry, including point-of-sale security, e-commerce platforms, and customer data protection.",
+            "telecommunications": "Concerns specific to telecommunications providers, including network infrastructure, subscriber data, and regulatory compliance.",
+            "transportation": "Concerns related to transportation systems beyond automotive and rail, including logistics, fleet management, and traffic control systems.",
+            "artificial-intelligence": "Concerns related to AI systems, including model transparency, algorithmic bias, explainability, and ethical considerations.",
+            "edge-computing": "Concerns specific to edge computing deployments, including distributed processing, local data handling, and remote device management.",
+            "embedded-systems": "Concerns specific to embedded systems development, including real-time constraints, resource limitations, and hardware-software integration.",
+            "industrial-control-systems": "Concerns specific to ICS environments, including PLCs, DCS, and industrial automation security aligned with IEC 62443.",
+            "industrial-iot": "Concerns specific to Industrial Internet of Things deployments, combining IT security with OT requirements and industrial protocols.",
+            "internet-of-things": "Concerns related to IoT devices and ecosystems, including device security, communication protocols, and fleet management.",
+            "machine-learning": "Concerns specific to ML models, including training data provenance, model lineage, performance metrics, and reproducibility.",
+            "medical-devices": "Concerns specific to medical device development aligned with IEC 62304, FDA guidance, and MDR/IVDR requirements.",
+            "mobile": "Concerns specific to mobile applications and devices, including app store requirements, mobile-specific vulnerabilities, and device management.",
+            "operational-technology": "Concerns specific to OT environments, bridging IT and industrial systems with focus on availability, safety, and legacy system integration.",
+            "robotics": "Concerns specific to robotic systems, including autonomous operation, human-robot interaction safety, and motion control security.",
+            "scada": "Concerns specific to Supervisory Control and Data Acquisition systems, including remote monitoring, control system security, and protocol vulnerabilities.",
+            "smart-grid": "Concerns specific to smart grid infrastructure, including advanced metering, grid automation, and distributed energy resource management.",
+            "data-protection": "Concerns related to data protection regulations such as GDPR, CCPA, and cross-border data transfer requirements.",
+            "export-control": "Concerns related to export control regulations, including EAR, ITAR, and dual-use technology restrictions.",
+            "intellectual-property": "Concerns related to patents, trade secrets, copyright, and other intellectual property rights and protections.",
+            "legal-compliance": "Regulatory and legal requirements, including contractual obligations, liability considerations, and legal holds.",
+            "licensing": "Concerns related to software licensing, licence compatibility, open source obligations, and commercial licensing terms.",
+            "privacy": "Concerns related to personal data protection, privacy by design, consent management, and individual rights.",
+            "regulatory-compliance": "Concerns related to compliance with industry-specific regulations, standards, and certification requirements.",
+            "maintainability": "Concerns related to the ease of maintaining, updating, and supporting software and systems over their lifecycle.",
+            "performance": "Concerns related to system performance, scalability, response times, and resource utilisation.",
+            "quality-assurance": "Concerns related to testing, validation, verification, and overall quality metrics and processes.",
+            "reliability": "Concerns related to system reliability, fault tolerance, mean time between failures, and degradation modes.",
+            "testability": "Concerns related to the ability to test components and systems, including test coverage, test automation, and test data management.",
+            "incident-response": "Concerns related to detecting, responding to, and recovering from security incidents and breaches.",
+            "penetration-testing": "Concerns related to authorised security testing, vulnerability assessment, and security validation activities.",
+            "red-team": "Concerns related to adversarial simulation, attack path analysis, and security control effectiveness testing.",
+            "risk-management": "Concerns related to risk identification, assessment, treatment, and ongoing risk monitoring.",
+            "threat-intelligence": "Concerns related to threat actor analysis, indicators of compromise, and proactive threat hunting.",
+            "threat-modeling": "Concerns related to identifying weaknesses, threats, countermeasures, attack surfaces, and trust boundaries.",
+            "vulnerability-management": "Concerns related to vulnerability identification, prioritisation, remediation tracking, and disclosure processes.",
+            "accessibility": "Concerns related to ensuring systems are usable by people with disabilities, including WCAG compliance.",
+            "ethics": "Concerns related to ethical considerations in technology development, including algorithmic fairness and responsible innovation.",
+            "human-factors": "Concerns related to human-system interaction, usability, operator error prevention, and ergonomic design.",
+            "interoperability": "Concerns related to the ability of systems to exchange and use information effectively across boundaries.",
+            "resilience": "Concerns related to system resilience, business continuity, disaster recovery, and graceful degradation.",
+            "sustainability": "Concerns related to environmental sustainability, energy efficiency, and responsible resource consumption.",
+            "transparency": "Concerns related to openness, auditability, and the ability for stakeholders to understand system behaviour and composition."
+          }
+        }
+      }
+    },
+    "cyclonedx-release-notes-2.0": {
+      "type": "null",
+      "title": "CycloneDX Release Notes Model",
+      "$defs": {
+        "releaseNotes": {
+          "type": "object",
+          "title": "Release notes",
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "$ref": "#/$defs/cyclonedx-release-notes-2.0/$defs/releaseType",
+              "title": "Type",
+              "description": "The software versioning type the release note describes."
+            },
+            "title": {
+              "type": "string",
+              "title": "Title",
+              "description": "The title of the release."
+            },
+            "featuredImage": {
+              "type": "string",
+              "format": "iri-reference",
+              "title": "Featured image",
+              "description": "The URL to an image that may be prominently displayed with the release note."
+            },
+            "socialImage": {
+              "type": "string",
+              "format": "iri-reference",
+              "title": "Social image",
+              "description": "The URL to an image that may be used in messaging on social media platforms."
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "A short description of the release."
+            },
+            "timestamp": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Timestamp",
+              "description": "The date and time (timestamp) when the release note was created."
+            },
+            "aliases": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Aliases",
+              "description": "One or more alternate names the release may be referred to. This may include unofficial terms used by development and marketing teams (e.g. code names)."
+            },
+            "tags": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/tags",
+              "title": "Tags"
+            },
+            "resolves": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/issue"
+              },
+              "title": "Resolves",
+              "description": "A collection of issues that have been resolved."
+            },
+            "notes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-release-notes-2.0/$defs/note"
+              },
+              "title": "Notes",
+              "description": "Zero or more release notes containing the locale and content. Multiple note objects may be specified to support release notes in a wide variety of languages."
+            },
+            "properties": {
+              "type": "array",
+              "title": "Properties",
+              "description": "Provides the ability to document properties in a name-value store. This provides flexibility to include data not officially supported in the standard without having to use additional namespaces or create extensions. Unlike key-value stores, properties support duplicate names, each potentially having different values. Property names of interest to the general public are encouraged to be registered in the [CycloneDX Property Taxonomy](https://github.com/CycloneDX/cyclonedx-property-taxonomy). Formal registration is optional.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/property"
+              }
+            }
+          }
+        },
+        "releaseType": {
+          "type": "string",
+          "examples": [
+            "major",
+            "minor",
+            "patch",
+            "pre-release",
+            "internal"
+          ],
+          "description": "The software versioning type. It is recommended that the release type use one of 'major', 'minor', 'patch', 'pre-release', or 'internal'. Representing all possible software release types is not practical, so standardizing on the recommended values, whenever possible, is strongly encouraged.\n\n* __major__ = A major release may contain significant changes or may introduce breaking changes.\n* __minor__ = A minor release, also known as an update, may contain a smaller number of changes than major releases.\n* __patch__ = Patch releases are typically unplanned and may resolve defects or important security issues.\n* __pre-release__ = A pre-release may include alpha, beta, or release candidates and typically have limited support. They provide the ability to preview a release prior to its general availability.\n* __internal__ = Internal releases are not for public consumption and are intended to be used exclusively by the project or manufacturer that produced it."
+        },
+        "note": {
+          "type": "object",
+          "title": "Note",
+          "description": "A note containing the locale and content.",
+          "required": [
+            "text"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "locale": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/locale",
+              "title": "Locale",
+              "description": "The ISO-639 (or higher) language code and optional ISO-3166 (or higher) country code. Examples include: \"en\", \"en-US\", \"fr\" and \"fr-CA\""
+            },
+            "text": {
+              "title": "Release note content",
+              "description": "Specifies the full content of the release note.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/attachment"
+            }
+          }
+        }
+      }
+    },
+    "cyclonedx-service-2.0": {
+      "type": "null",
+      "title": "CycloneDX Service Model",
+      "$defs": {
+        "services": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-service-2.0/$defs/service"
+          },
+          "uniqueItems": true,
+          "title": "Services"
+        },
+        "service": {
+          "type": "object",
+          "title": "Service",
+          "required": [
+            "name"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the service elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+            },
+            "provider": {
+              "title": "Provider",
+              "description": "The organization that provides the service.",
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalEntity"
+            },
+            "group": {
+              "type": "string",
+              "title": "Service Group",
+              "description": "The grouping name, namespace, or identifier. This will often be a shortened, single name of the company or project that produced the service or domain name. Whitespace and special characters should be avoided.",
+              "examples": [
+                "com.acme"
+              ]
+            },
+            "name": {
+              "type": "string",
+              "title": "Service Name",
+              "description": "The name of the service. This will often be a shortened, single name of the service.",
+              "examples": [
+                "ticker-service"
+              ]
+            },
+            "version": {
+              "$ref": "#/$defs/cyclonedx-component-2.0/$defs/version",
+              "title": "Service Version",
+              "description": "The service version."
+            },
+            "description": {
+              "type": "string",
+              "title": "Service Description",
+              "description": "Specifies a description for the service"
+            },
+            "endpoints": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "iri-reference"
+              },
+              "title": "Endpoints",
+              "description": "The endpoint URIs of the service. Multiple endpoints are allowed.",
+              "examples": [
+                "https://example.com/api/v1/ticker"
+              ]
+            },
+            "authenticated": {
+              "type": "boolean",
+              "title": "Authentication Required",
+              "description": "A boolean value indicating if the service requires authentication. A value of true indicates the service requires authentication prior to use. A value of false indicates the service does not require authentication."
+            },
+            "x-trust-boundary": {
+              "type": "boolean",
+              "title": "Crosses Trust Boundary",
+              "description": "A boolean value indicating if use of the service crosses a trust zone or boundary. A value of true indicates that by using the service, a trust boundary is crossed. A value of false indicates that by using the service, a trust boundary is not crossed."
+            },
+            "trustZone": {
+              "type": "string",
+              "title": "Trust Zone",
+              "description": "The name of the trust zone the service resides in."
+            },
+            "data": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-service-2.0/$defs/serviceData"
+              },
+              "title": "Data",
+              "description": "Specifies information about the data including the directional flow of data and the data classification."
+            },
+            "licenses": {
+              "$ref": "#/$defs/cyclonedx-license-2.0/$defs/licenseChoice",
+              "title": "Service License(s)"
+            },
+            "patentAssertions": {
+              "$ref": "#/$defs/cyclonedx-patent-2.0/$defs/patentAssertions",
+              "title": "Service Patent(s)"
+            },
+            "externalReferences": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReferences"
+            },
+            "services": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-service-2.0/$defs/service"
+              },
+              "uniqueItems": true,
+              "title": "Services",
+              "description": "A list of services included or deployed behind the parent service. This is not a dependency tree. It provides a way to specify a hierarchical representation of service assemblies."
+            },
+            "releaseNotes": {
+              "$ref": "#/$defs/cyclonedx-release-notes-2.0/$defs/releaseNotes",
+              "title": "Release notes",
+              "description": "Specifies release notes."
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            },
+            "tags": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/tags",
+              "title": "Tags"
+            },
+            "signatures": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/signatures"
+            }
+          }
+        },
+        "serviceData": {
+          "type": "object",
+          "title": "Hash Objects",
+          "required": [
+            "flow",
+            "classification"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "flow": {
+              "$ref": "#/$defs/cyclonedx-data-2.0/$defs/dataFlowDirection",
+              "title": "Directional Flow",
+              "description": "Specifies the flow direction of the data. Direction is relative to the service. Inbound flow states that data enters the service. Outbound flow states that data leaves the service. Bi-directional states that data flows both ways and unknown states that the direction is not known."
+            },
+            "classification": {
+              "$ref": "#/$defs/cyclonedx-data-2.0/$defs/dataClassification"
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "Name for the defined data",
+              "examples": [
+                "Credit card reporting"
+              ]
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "Short description of the data content and usage",
+              "examples": [
+                "Credit card information being exchanged in between the web app and the database"
+              ]
+            },
+            "governance": {
+              "title": "Data Governance",
+              "$ref": "#/$defs/cyclonedx-data-2.0/$defs/dataGovernance"
+            },
+            "source": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "title": "URL",
+                    "type": "string",
+                    "format": "iri-reference"
+                  },
+                  {
+                    "title": "BOM-Link Element",
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/bomLinkElementType"
+                  }
+                ]
+              },
+              "title": "Source",
+              "description": "The URI, URL, or BOM-Link of the components or services the data came in from"
+            },
+            "destination": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "title": "URL",
+                    "type": "string",
+                    "format": "iri-reference"
+                  },
+                  {
+                    "title": "BOM-Link Element",
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/bomLinkElementType"
+                  }
+                ]
+              },
+              "title": "Destination",
+              "description": "The URI, URL, or BOM-Link of the components or services the data is sent to"
+            }
+          }
+        }
+      }
+    },
+    "cyclonedx-standard-2.0": {
+      "type": "null",
+      "title": "CycloneDX Standard Model",
+      "$defs": {
+        "standards": {
+          "type": "array",
+          "title": "Standards",
+          "description": "The list of standards which may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to.",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-standard-2.0/$defs/standard"
+          }
+        },
+        "standard": {
+          "type": "object",
+          "title": "Standard",
+          "description": "A standard may consist of regulations, industry or organizational-specific standards, maturity models, best practices, or any other requirements which can be evaluated against or attested to.",
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The name of the standard. This will often be a shortened, single name of the standard."
+            },
+            "version": {
+              "type": "string",
+              "title": "Version",
+              "description": "The version of the standard."
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "The description of the standard."
+            },
+            "owner": {
+              "type": "string",
+              "title": "Owner",
+              "description": "The owner of the standard, often the entity responsible for its release."
+            },
+            "requirements": {
+              "$ref": "#/$defs/cyclonedx-standard-2.0/$defs/requirements"
+            },
+            "levels": {
+              "$ref": "#/$defs/cyclonedx-standard-2.0/$defs/levels"
+            },
+            "externalReferences": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReferences"
+            },
+            "signatures": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/signatures"
+            }
+          }
+        },
+        "requirements": {
+          "type": "array",
+          "title": "Requirements",
+          "description": "The list of requirements comprising the standard.",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-standard-2.0/$defs/requirement"
+          }
+        },
+        "requirement": {
+          "type": "object",
+          "title": "Requirement",
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+            },
+            "identifier": {
+              "type": "string",
+              "title": "Identifier",
+              "description": "The unique identifier used in the standard to identify a specific requirement. This should match what is in the standard and should not be the requirements bom-ref."
+            },
+            "title": {
+              "type": "string",
+              "title": "Title",
+              "description": "The title of the requirement."
+            },
+            "text": {
+              "type": "string",
+              "title": "Text",
+              "description": "The textual content of the requirement."
+            },
+            "descriptions": {
+              "type": "array",
+              "title": "Descriptions",
+              "description": "The supplemental text that provides additional guidance or context to the requirement, but is not directly part of the requirement.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "openCre": {
+              "type": "array",
+              "title": "OWASP OpenCRE Identifier(s)",
+              "description": "The Common Requirements Enumeration (CRE) identifier(s). CRE is a structured and standardized framework for uniting security standards and guidelines. CRE links each section of a resource to a shared topic identifier (a Common Requirement). Through this shared topic link, all resources map to each other. Use of CRE promotes clear and unambiguous communication among stakeholders.",
+              "items": {
+                "type": "string",
+                "pattern": "^CRE:[0-9]+-[0-9]+$",
+                "examples": [
+                  "CRE:764-507"
+                ]
+              }
+            },
+            "parent": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType",
+              "title": "Parent BOM Reference",
+              "description": "The `bom-ref` to a parent requirement. This establishes a hierarchy of requirements. Top-level requirements must not define a parent. Only child requirements should define parents."
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            },
+            "externalReferences": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReferences"
+            }
+          }
+        },
+        "levels": {
+          "type": "array",
+          "title": "Levels",
+          "description": "The list of levels associated with the standard. Some standards have different levels of compliance.",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-standard-2.0/$defs/level"
+          }
+        },
+        "level": {
+          "type": "object",
+          "title": "Level",
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the object elsewhere in the BOM. Every `bom-ref` must be unique within the BOM."
+            },
+            "identifier": {
+              "type": "string",
+              "title": "Identifier",
+              "description": "The identifier used in the standard to identify a specific level."
+            },
+            "title": {
+              "type": "string",
+              "title": "Title",
+              "description": "The title of the level."
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "The description of the level."
+            },
+            "requirements": {
+              "type": "array",
+              "title": "Requirements",
+              "description": "The list of requirement `bom-ref`s that comprise the level.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType"
+              }
+            }
+          }
+        }
+      }
+    },
+    "cyclonedx-vulnerability-2.0": {
+      "type": "null",
+      "title": "CycloneDX Vulnerability Model",
+      "$defs": {
+        "vulnerabilities": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/cyclonedx-vulnerability-2.0/$defs/vulnerability"
+          },
+          "uniqueItems": true,
+          "title": "Vulnerabilities",
+          "description": "Vulnerabilities identified in components or services."
+        },
+        "vulnerability": {
+          "type": "object",
+          "title": "Vulnerability",
+          "description": "Defines a weakness in a component or service that could be exploited or triggered by a threat source.",
+          "additionalProperties": false,
+          "properties": {
+            "bom-ref": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refType",
+              "title": "BOM Reference",
+              "description": "An identifier which can be used to reference the vulnerability elsewhere in the BOM. Every `bom-ref` must be unique within the BOM.\nValue SHOULD not start with the BOM-Link intro 'urn:cdx:' to avoid conflicts with BOM-Links."
+            },
+            "id": {
+              "type": "string",
+              "title": "ID",
+              "description": "The identifier that uniquely identifies the vulnerability.",
+              "examples": [
+                "CVE-2021-39182",
+                "GHSA-35m5-8cvj-8783",
+                "SNYK-PYTHON-ENROCRYPT-1912876"
+              ]
+            },
+            "source": {
+              "$ref": "#/$defs/cyclonedx-vulnerability-2.0/$defs/vulnerabilitySource",
+              "description": "The source that published the vulnerability."
+            },
+            "references": {
+              "type": "array",
+              "title": "References",
+              "description": "Zero or more pointers to vulnerabilities that are the equivalent of the vulnerability specified. Often times, the same vulnerability may exist in multiple sources of vulnerability intelligence, but have different identifiers. References provide a way to correlate vulnerabilities across multiple sources of vulnerability intelligence.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "source"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "title": "ID",
+                    "description": "An identifier that uniquely identifies the vulnerability.",
+                    "examples": [
+                      "CVE-2021-39182",
+                      "GHSA-35m5-8cvj-8783",
+                      "SNYK-PYTHON-ENROCRYPT-1912876"
+                    ]
+                  },
+                  "source": {
+                    "$ref": "#/$defs/cyclonedx-vulnerability-2.0/$defs/vulnerabilitySource",
+                    "description": "The source that published the vulnerability."
+                  }
+                }
+              }
+            },
+            "ratings": {
+              "type": "array",
+              "title": "Ratings",
+              "description": "List of vulnerability ratings. Consumers should consider ratings in prioritization decisions; source ratings may differ and aid prioritization.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-vulnerability-2.0/$defs/rating"
+              }
+            },
+            "cwes": {
+              "type": "array",
+              "title": "CWEs",
+              "description": "List of Common Weaknesses Enumerations (CWEs) codes that describes this vulnerability.",
+              "examples": [
+                399
+              ],
+              "items": {
+                "$ref": "#/$defs/cyclonedx-vulnerability-2.0/$defs/cwe"
+              }
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "A description of the vulnerability as provided by the source."
+            },
+            "detail": {
+              "type": "string",
+              "title": "Details",
+              "description": "If available, an in-depth description of the vulnerability as provided by the source organization. Details often include information useful in understanding root cause."
+            },
+            "recommendation": {
+              "type": "string",
+              "title": "Recommendation",
+              "description": "Recommendations of how the vulnerability can be remediated or mitigated."
+            },
+            "workaround": {
+              "type": "string",
+              "title": "Workarounds",
+              "description": "A bypass, usually temporary, of the vulnerability that reduces its likelihood and/or impact. Workarounds often involve changes to configuration or deployments."
+            },
+            "proofOfConcept": {
+              "type": "object",
+              "title": "Proof of Concept",
+              "description": "Evidence used to reproduce the vulnerability.",
+              "properties": {
+                "reproductionSteps": {
+                  "type": "string",
+                  "title": "Steps to Reproduce",
+                  "description": "Precise steps to reproduce the vulnerability."
+                },
+                "environment": {
+                  "type": "string",
+                  "title": "Environment",
+                  "description": "A description of the environment in which reproduction was possible."
+                },
+                "supportingMaterial": {
+                  "type": "array",
+                  "title": "Supporting Material",
+                  "description": "Supporting material that helps in reproducing or understanding how reproduction is possible. This may include screenshots, payloads, and PoC exploit code.",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/attachment"
+                  }
+                }
+              }
+            },
+            "advisories": {
+              "type": "array",
+              "title": "Advisories",
+              "description": "Published advisories of the vulnerability if provided.",
+              "items": {
+                "$ref": "#/$defs/cyclonedx-vulnerability-2.0/$defs/advisory"
+              }
+            },
+            "created": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Created",
+              "description": "The date and time (timestamp) when the vulnerability record was created in the vulnerability database."
+            },
+            "published": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Published",
+              "description": "The date and time (timestamp) when the vulnerability record was first published."
+            },
+            "updated": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Updated",
+              "description": "The date and time (timestamp) when the vulnerability record was last updated."
+            },
+            "rejected": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Rejected",
+              "description": "The date and time (timestamp) when the vulnerability record was rejected (if applicable)."
+            },
+            "credits": {
+              "type": "object",
+              "title": "Credits",
+              "description": "Individuals or organizations credited with the discovery of the vulnerability.",
+              "additionalProperties": false,
+              "properties": {
+                "organizations": {
+                  "type": "array",
+                  "title": "Organizations",
+                  "description": "The organizations credited with vulnerability discovery.",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalEntity"
+                  }
+                },
+                "individuals": {
+                  "type": "array",
+                  "title": "Individuals",
+                  "description": "The individuals, not associated with organizations, that are credited with vulnerability discovery.",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-common-2.0/$defs/organizationalContact"
+                  }
+                }
+              }
+            },
+            "tools": {
+              "type": "object",
+              "title": "Tools",
+              "description": "The tool(s) used to identify, confirm, or score the vulnerability.",
+              "additionalProperties": false,
+              "properties": {
+                "components": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-component-2.0/$defs/component"
+                  },
+                  "uniqueItems": true,
+                  "title": "Components",
+                  "description": "A list of software and hardware components used as tools."
+                },
+                "services": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/cyclonedx-service-2.0/$defs/service"
+                  },
+                  "uniqueItems": true,
+                  "title": "Services",
+                  "description": "A list of services used as tools. This may include microservices, function-as-a-service, and other types of network or intra-process services."
+                }
+              }
+            },
+            "analysis": {
+              "type": "object",
+              "title": "Impact Analysis",
+              "description": "An assessment of the impact and exploitability of the vulnerability.",
+              "additionalProperties": false,
+              "properties": {
+                "state": {
+                  "$ref": "#/$defs/cyclonedx-vulnerability-2.0/$defs/impactAnalysisState"
+                },
+                "justification": {
+                  "$ref": "#/$defs/cyclonedx-vulnerability-2.0/$defs/impactAnalysisJustification"
+                },
+                "response": {
+                  "type": "array",
+                  "title": "Response",
+                  "description": "A response to the vulnerability by the manufacturer, supplier, or project responsible for the affected component or service. More than one response is allowed. Responses are strongly encouraged for vulnerabilities where the analysis state is exploitable.",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "can_not_fix",
+                      "will_not_fix",
+                      "update",
+                      "rollback",
+                      "workaround_available"
+                    ],
+                    "meta:enum": {
+                      "can_not_fix": "Can not fix",
+                      "will_not_fix": "Will not fix",
+                      "update": "Update to a different revision or release",
+                      "rollback": "Revert to a previous revision or release",
+                      "workaround_available": "There is a workaround available"
+                    }
+                  }
+                },
+                "detail": {
+                  "type": "string",
+                  "title": "Detail",
+                  "description": "Detailed description of the impact including methods used during assessment. If a vulnerability is not exploitable, this field should include specific details on why the component or service is not impacted by this vulnerability."
+                },
+                "firstIssued": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "First Issued",
+                  "description": "The date and time (timestamp) when the analysis was first issued."
+                },
+                "lastUpdated": {
+                  "type": "string",
+                  "format": "date-time",
+                  "title": "Last Updated",
+                  "description": "The date and time (timestamp) when the analysis was last updated."
+                }
+              }
+            },
+            "affects": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "object",
+                "required": [
+                  "ref"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "ref": {
+                    "anyOf": [
+                      {
+                        "title": "Ref",
+                        "$ref": "#/$defs/cyclonedx-common-2.0/$defs/refLinkType"
+                      },
+                      {
+                        "title": "BOM-Link Element",
+                        "$ref": "#/$defs/cyclonedx-common-2.0/$defs/bomLinkElementType"
+                      }
+                    ],
+                    "title": "Reference",
+                    "description": "References a component or service by the objects bom-ref"
+                  },
+                  "versions": {
+                    "type": "array",
+                    "title": "Versions",
+                    "description": "Zero or more individual versions or range of versions.",
+                    "items": {
+                      "type": "object",
+                      "oneOf": [
+                        {
+                          "required": [
+                            "version"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "range"
+                          ]
+                        }
+                      ],
+                      "additionalProperties": false,
+                      "properties": {
+                        "version": {
+                          "title": "Version",
+                          "description": "A single version of a component or service.",
+                          "$ref": "#/$defs/cyclonedx-component-2.0/$defs/version"
+                        },
+                        "range": {
+                          "title": "Version Range",
+                          "description": "A version range specified in Package URL Version Range syntax (vers) which is defined at https://github.com/package-url/vers-spec",
+                          "$ref": "#/$defs/cyclonedx-component-2.0/$defs/versionRange"
+                        },
+                        "status": {
+                          "title": "Status",
+                          "description": "The vulnerability status for the version or range of versions.",
+                          "$ref": "#/$defs/cyclonedx-vulnerability-2.0/$defs/affectedStatus",
+                          "default": "affected"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "title": "Affects",
+              "description": "The components or services that are affected by the vulnerability."
+            },
+            "properties": {
+              "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+            }
+          }
+        },
+        "advisory": {
+          "type": "object",
+          "title": "Advisory",
+          "description": "Title and location where advisory information can be obtained. An advisory is a notification of a threat to a component, service, or system.",
+          "required": [
+            "url"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "title": {
+              "type": "string",
+              "title": "Title",
+              "description": "A name of the advisory."
+            },
+            "url": {
+              "type": "string",
+              "title": "URL",
+              "format": "iri-reference",
+              "description": "Location where the advisory can be obtained."
+            }
+          }
+        },
+        "cwe": {
+          "type": "integer",
+          "minimum": 1,
+          "title": "CWE",
+          "description": "Integer representation of a Common Weaknesses Enumerations (CWE). For example 399 (of https://cwe.mitre.org/data/definitions/399.html)"
+        },
+        "severity": {
+          "type": "string",
+          "title": "Severity",
+          "description": "Textual representation of the severity of the vulnerability adopted by the analysis method. If the analysis method uses values other than what is provided, the user is expected to translate appropriately.",
+          "enum": [
+            "critical",
+            "high",
+            "medium",
+            "low",
+            "info",
+            "none",
+            "unknown"
+          ],
+          "meta:enum": {
+            "critical": "Critical severity",
+            "high": "High severity",
+            "medium": "Medium severity",
+            "low": "Low severity",
+            "info": "Informational warning.",
+            "none": "None",
+            "unknown": "The severity is not known"
+          }
+        },
+        "scoreMethod": {
+          "type": "string",
+          "title": "Method",
+          "description": "Specifies the severity or risk scoring methodology or standard used.",
+          "enum": [
+            "CVSSv2",
+            "CVSSv3",
+            "CVSSv31",
+            "CVSSv4",
+            "OWASP",
+            "SSVC",
+            "other"
+          ],
+          "meta:enum": {
+            "CVSSv2": "Common Vulnerability Scoring System v2.0",
+            "CVSSv3": "Common Vulnerability Scoring System v3.0",
+            "CVSSv31": "Common Vulnerability Scoring System v3.1",
+            "CVSSv4": "Common Vulnerability Scoring System v4.0",
+            "OWASP": "OWASP Risk Rating Methodology",
+            "SSVC": "Stakeholder Specific Vulnerability Categorization",
+            "other": "Another severity or risk scoring methodology"
+          }
+        },
+        "impactAnalysisState": {
+          "type": "string",
+          "title": "Impact Analysis State",
+          "description": "Declares the current state of an occurrence of a vulnerability, after automated or manual analysis.",
+          "enum": [
+            "resolved",
+            "resolved_with_pedigree",
+            "exploitable",
+            "in_triage",
+            "false_positive",
+            "not_affected"
+          ],
+          "meta:enum": {
+            "resolved": "The vulnerability has been remediated.",
+            "resolved_with_pedigree": "The vulnerability has been remediated and evidence of the changes are provided in the affected components pedigree containing verifiable commit history and/or diff(s).",
+            "exploitable": "The vulnerability may be directly or indirectly exploitable.",
+            "in_triage": "The vulnerability is being investigated.",
+            "false_positive": "The vulnerability is not specific to the component or service and was falsely identified or associated.",
+            "not_affected": "The component or service is not affected by the vulnerability. Justification should be specified for all not_affected cases."
+          }
+        },
+        "impactAnalysisJustification": {
+          "type": "string",
+          "title": "Impact Analysis Justification",
+          "description": "The rationale of why the impact analysis state was asserted.",
+          "enum": [
+            "code_not_present",
+            "code_not_reachable",
+            "requires_configuration",
+            "requires_dependency",
+            "requires_environment",
+            "protected_by_compiler",
+            "protected_at_runtime",
+            "protected_at_perimeter",
+            "protected_by_mitigating_control"
+          ],
+          "meta:enum": {
+            "code_not_present": "The code has been removed or tree-shaked.",
+            "code_not_reachable": "The vulnerable code is not invoked at runtime.",
+            "requires_configuration": "Exploitability requires a configurable option to be set/unset.",
+            "requires_dependency": "Exploitability requires a dependency that is not present.",
+            "requires_environment": "Exploitability requires a certain environment which is not present.",
+            "protected_by_compiler": "Exploitability requires a compiler flag to be set/unset.",
+            "protected_at_runtime": "Exploits are prevented at runtime.",
+            "protected_at_perimeter": "Attacks are blocked at physical, logical, or network perimeter.",
+            "protected_by_mitigating_control": "Preventative measures have been implemented that reduce the likelihood and/or impact of the vulnerability."
+          }
+        },
+        "rating": {
+          "type": "object",
+          "title": "Rating",
+          "description": "Defines the severity or risk ratings of a vulnerability.",
+          "additionalProperties": false,
+          "properties": {
+            "source": {
+              "$ref": "#/$defs/cyclonedx-vulnerability-2.0/$defs/vulnerabilitySource",
+              "description": "The source that calculated the severity or risk rating of the vulnerability."
+            },
+            "score": {
+              "type": "number",
+              "title": "Score",
+              "description": "The numerical score of the rating."
+            },
+            "severity": {
+              "$ref": "#/$defs/cyclonedx-vulnerability-2.0/$defs/severity",
+              "description": "Textual representation of the severity that corresponds to the numerical score of the rating."
+            },
+            "method": {
+              "$ref": "#/$defs/cyclonedx-vulnerability-2.0/$defs/scoreMethod"
+            },
+            "vector": {
+              "type": "string",
+              "title": "Vector",
+              "description": "Textual representation of the metric values used to score the vulnerability"
+            },
+            "justification": {
+              "type": "string",
+              "title": "Justification",
+              "description": "A reason for rating the vulnerability as it was"
+            }
+          }
+        },
+        "vulnerabilitySource": {
+          "type": "object",
+          "title": "Source",
+          "description": "The source of vulnerability information. This is often the organization that published the vulnerability.",
+          "additionalProperties": false,
+          "properties": {
+            "url": {
+              "type": "string",
+              "title": "URL",
+              "description": "The url of the vulnerability documentation as provided by the source.",
+              "examples": [
+                "https://nvd.nist.gov/vuln/detail/CVE-2021-39182"
+              ]
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The name of the source.",
+              "examples": [
+                "NVD",
+                "National Vulnerability Database",
+                "OSS Index",
+                "VulnDB",
+                "GitHub Advisories"
+              ]
+            }
+          }
+        },
+        "affectedStatus": {
+          "description": "The vulnerability status of a given version or range of versions of a product. The statuses 'affected' and 'unaffected' indicate that the version is affected or unaffected by the vulnerability. The status 'unknown' indicates that it is unknown or unspecified whether the given version is affected. There can be many reasons for an 'unknown' status, including that an investigation has not been undertaken or that a vendor has not disclosed the status.",
+          "type": "string",
+          "enum": [
+            "affected",
+            "unaffected",
+            "unknown"
+          ],
+          "meta:enum": {
+            "affected": "The version is affected by the vulnerability.",
+            "unaffected": "The version is not affected by the vulnerability.",
+            "unknown": "It is unknown (or unspecified) whether the given version is affected."
+          }
+        }
+      }
+    },
+    "cyclonedx-2.0": {
+      "type": "object",
+      "title": "CycloneDX Transparency Expression Language",
+      "required": [
+        "specFormat",
+        "specVersion"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "specFormat": {
+          "type": "string",
+          "title": "Specification Format",
+          "description": "Specifies the format. This value shall be \"CycloneDX\".",
+          "enum": [
+            "CycloneDX"
+          ]
+        },
+        "specVersion": {
+          "type": "string",
+          "title": "Specification Version",
+          "description": "The version of the CycloneDX specification the BOM conforms to.",
+          "examples": [
+            "2.0"
+          ]
+        },
+        "serialNumber": {
+          "type": "string",
+          "title": "BOM Serial Number",
+          "description": "Every BOM generated SHOULD have a unique serial number, even if the contents of the BOM have not changed over time. If specified, the serial number must conform to [RFC 4122](https://www.ietf.org/rfc/rfc4122.html). Use of serial numbers is recommended.",
+          "examples": [
+            "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
+          ],
+          "pattern": "^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+        },
+        "version": {
+          "type": "integer",
+          "title": "BOM Version",
+          "description": "Whenever an existing BOM is modified, either manually or through automated processes, the version of the BOM SHOULD be incremented by 1. When a system is presented with multiple BOMs with identical serial numbers, the system SHOULD use the most recent version of the BOM. The default version is '1'.",
+          "minimum": 1,
+          "default": 1
+        },
+        "metadata": {
+          "$ref": "#/$defs/cyclonedx-metadata-2.0/$defs/metadata"
+        },
+        "components": {
+          "$ref": "#/$defs/cyclonedx-component-2.0/$defs/components",
+          "description": "A collection of components. When a metadata component is present, this array represents the inventory of components associated with that subject, forming a bill of materials. When the metadata component is omitted, the array provides component data for interchange purposes without establishing a compositional relationship."
+        },
+        "services": {
+          "$ref": "#/$defs/cyclonedx-service-2.0/$defs/services"
+        },
+        "dependencies": {
+          "$ref": "#/$defs/cyclonedx-dependency-2.0/$defs/dependencies"
+        },
+        "compositions": {
+          "$ref": "#/$defs/cyclonedx-composition-2.0/$defs/compositions"
+        },
+        "vulnerabilities": {
+          "$ref": "#/$defs/cyclonedx-vulnerability-2.0/$defs/vulnerabilities"
+        },
+        "annotations": {
+          "$ref": "#/$defs/cyclonedx-annotation-2.0/$defs/annotations"
+        },
+        "formulation": {
+          "$ref": "#/$defs/cyclonedx-formulation-2.0/$defs/formulation"
+        },
+        "declarations": {
+          "$ref": "#/$defs/cyclonedx-declaration-2.0/$defs/declarations"
+        },
+        "definitions": {
+          "$ref": "#/$defs/cyclonedx-definition-2.0/$defs/definitions"
+        },
+        "citations": {
+          "$ref": "#/$defs/cyclonedx-citation-2.0/$defs/citations"
+        },
+        "perspectives": {
+          "$ref": "#/$defs/cyclonedx-perspective-2.0/$defs/perspectives"
+        },
+        "properties": {
+          "$ref": "#/$defs/cyclonedx-common-2.0/$defs/properties"
+        },
+        "externalReferences": {
+          "$ref": "#/$defs/cyclonedx-common-2.0/$defs/externalReferences"
+        },
+        "signatures": {
+          "$ref": "#/$defs/cyclonedx-common-2.0/$defs/signatures"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/cyclonedx-common-2.0/$defs/extensibleProperties"
+        }
+      ]
+    }
+  }
+}

--- a/schema/bom.go
+++ b/schema/bom.go
@@ -227,6 +227,30 @@ func (bom *BOM) GetCdxSignature() (pSignature *JSFSignature) {
 	return pSignature
 }
 
+// GetCdxSpecFormat returns the v2.0 specFormat value (empty string for v1.x documents).
+func (bom *BOM) GetCdxSpecFormat() (specFormat string) {
+	if cdxBom := bom.GetCdxBom(); cdxBom != nil {
+		specFormat = cdxBom.SpecFormat
+	}
+	return specFormat
+}
+
+// GetCdxSignatures returns the v2.0 signatures array (nil for v1.x documents).
+func (bom *BOM) GetCdxSignatures() (pSignatures *[]JSFSignature) {
+	if cdxBom := bom.GetCdxBom(); cdxBom != nil {
+		pSignatures = cdxBom.Signatures
+	}
+	return pSignatures
+}
+
+// GetCdxPerspectives returns the v2.0 perspectives array (nil for v1.x documents).
+func (bom *BOM) GetCdxPerspectives() (pPerspectives *[]CDXPerspective) {
+	if cdxBom := bom.GetCdxBom(); cdxBom != nil {
+		pPerspectives = cdxBom.Perspectives
+	}
+	return pPerspectives
+}
+
 func (bom *BOM) GetCdxVulnerabilities() (pVulnerabilities *[]CDXVulnerability) {
 	if bom := bom.GetCdxBom(); bom != nil {
 		pVulnerabilities = bom.Vulnerabilities

--- a/schema/constants.go
+++ b/schema/constants.go
@@ -44,7 +44,9 @@ const (
 	// SPDX
 	PROPKEY_ID_SPDX      = "SPDXID"
 	PROPKEY_VERSION_SPDX = "spdxVersion"
-	// CycloneDX
+	// CycloneDX v1.x: top-level format identifier key is "bomFormat"
 	PROPKEY_ID_CYCLONEDX      = "bomFormat"
 	PROPKEY_VERSION_CYCLONEDX = "specVersion"
+	// CycloneDX v2.0: top-level format identifier key renamed to "specFormat"
+	PROPKEY_ID_CYCLONEDX_V2 = "specFormat"
 )

--- a/schema/cyclonedx.go
+++ b/schema/cyclonedx.go
@@ -37,8 +37,12 @@ var EMPTY_CDXLicense = CDXLicense{}
 // v1.4: added "vulnerabilities", "signature"
 // v1.5: added "annotations", "formulation", "properties"
 // v1.6: added "declarations", "definitions"
+// v2.0: "bomFormat" renamed to "specFormat"; "signature" (single) replaced by "signatures" (array);
+//
+//	"perspectives" added as a new top-level field.
 type CDXBom struct {
 	BOMFormat          string                  `json:"bomFormat,omitempty"`
+	SpecFormat         string                  `json:"specFormat,omitempty" cdx:"+2.0"`      // v2.0: replaces bomFormat
 	SpecVersion        string                  `json:"specVersion,omitempty"`
 	SerialNumber       string                  `json:"serialNumber,omitempty"`
 	Version            int                     `json:"version,omitempty"`
@@ -50,12 +54,14 @@ type CDXBom struct {
 	Compositions       *[]CDXCompositions      `json:"compositions,omitempty" cdx:"added:1.3"`
 	Vulnerabilities    *[]CDXVulnerability     `json:"vulnerabilities,omitempty" cdx:"added:1.4"`
 	Signature          *JSFSignature           `json:"signature,omitempty" cdx:"added:1.4"`
+	Signatures         *[]JSFSignature         `json:"signatures,omitempty" cdx:"+2.0"`      // v2.0: replaces Signature
 	Annotations        *[]CDXAnnotation        `json:"annotations,omitempty" cdx:"added:1.5"`
 	Formulation        *[]CDXFormula           `json:"formulation,omitempty" cdx:"added:1.5"`
 	Properties         *[]CDXProperty          `json:"properties,omitempty" cdx:"added:1.5"`
 	Declarations       *CDXDeclaration         `json:"declarations,omitempty" cdx:"added:1.6"`
 	Definitions        *CDXDefinition          `json:"definitions,omitempty" cdx:"added:1.6"`
 	Citations          *[]CDXCitation          `json:"citations,omitempty" cdx:"+1.7"`
+	Perspectives       *[]CDXPerspective       `json:"perspectives,omitempty" cdx:"+2.0"`    // v2.0: added
 }
 
 // v1.2: existed
@@ -125,6 +131,9 @@ type CDXComponent struct {
 	VersionRange       CDXComponentVersionRange    `json:"versionRange,omitempty" cdx:"+1.7"`
 	IsExternal         bool                        `json:"isExternal,omitempty" cdx:"+1.7"`
 	PatentAssertions   *[]CDXPatentAssertion       `json:"patentAssertions,omitempty" cdx:"+1.7"`
+	Identifiers        *[]CDXComponentIdentifier   `json:"identifiers,omitempty" cdx:"+2.0"`
+	Parties            *[]interface{}              `json:"parties,omitempty" cdx:"+2.0"`
+	Signatures         *[]JSFSignature             `json:"signatures,omitempty" cdx:"+2.0"`
 }
 
 // v1.5 added object
@@ -491,3 +500,43 @@ type CDXNameDescription struct {
 // v1.7
 // Note: CDXVulnerability already has a CDXVersionRange which is more than a simple string
 type CDXComponentVersionRange string
+
+// v2.0: added — top-level BOM perspective entry
+type CDXPerspective struct {
+	BOMRef             *CDXRefType             `json:"bom-ref,omitempty" cdx:"+2.0"`
+	Name               string                  `json:"name,omitempty" cdx:"+2.0"`
+	Description        string                  `json:"description,omitempty" cdx:"+2.0"`
+	Domains            *[]interface{}          `json:"domains,omitempty" cdx:"+2.0"` // oneOf: pre-defined enum string or custom object
+	Mappings           *[]CDXPerspectiveMapping `json:"mappings,omitempty" cdx:"+2.0"`
+	ExternalReferences *[]CDXExternalReference  `json:"externalReferences,omitempty" cdx:"+2.0"`
+	Properties         *[]CDXProperty           `json:"properties,omitempty" cdx:"+2.0"`
+}
+
+// v2.0: added — mapping of a perspective to a BOM element
+type CDXPerspectiveMapping struct {
+	Expression        string  `json:"expression,omitempty" cdx:"+2.0"`
+	NativeName        string  `json:"nativeName,omitempty" cdx:"+2.0"`
+	NativeDescription string  `json:"nativeDescription,omitempty" cdx:"+2.0"`
+	Relevance         string  `json:"relevance,omitempty" cdx:"+2.0"`
+	Weight            float64 `json:"weight,omitempty" cdx:"+2.0"`
+	Rationale         string  `json:"rationale,omitempty" cdx:"+2.0"`
+}
+
+// v2.0: added — identifier assertions made by a party for a component
+// sourced from the 2.0-dev component schema
+// Note: identity claims remain modeled in evidence; identifiers are positive assertions by an asserting party
+// NOTE: CDXRefType is a named `string` type as of v1.5
+// NOTE: CDXRefLinkType is a named `string` type as of v1.5
+type CDXComponentIdentifier struct {
+	BOMRef     *CDXRefType             `json:"bom-ref,omitempty" cdx:"+2.0"`
+	Party      *CDXRefLinkType         `json:"party,omitempty" cdx:"+2.0"`
+	Identities *[]CDXComponentIdentity `json:"identities,omitempty" cdx:"+2.0"`
+}
+
+type CDXComponentIdentity struct {
+	Field          string    `json:"field,omitempty" cdx:"+2.0"`
+	Confidence     float64   `json:"confidence,omitempty" cdx:"+2.0"`
+	ConcludedValue string    `json:"concludedValue,omitempty" cdx:"+2.0"`
+	Methods        *[]string `json:"methods,omitempty" cdx:"+2.0"`
+	Tools          *[]string `json:"tools,omitempty" cdx:"+2.0"`
+}

--- a/schema/cyclonedx.go
+++ b/schema/cyclonedx.go
@@ -534,6 +534,10 @@ type CDXComponentIdentifier struct {
 }
 
 type CDXComponentIdentity struct {
+	// v2.0 identifier identity fields (scheme+value pair under identifiers[].identities[])
+	Scheme string `json:"scheme,omitempty" cdx:"+2.0"`
+	Value  string `json:"value,omitempty" cdx:"+2.0"`
+	// evidence identity fields (v1.5+)
 	Field          string    `json:"field,omitempty" cdx:"+2.0"`
 	Confidence     float64   `json:"confidence,omitempty" cdx:"+2.0"`
 	ConcludedValue string    `json:"concludedValue,omitempty" cdx:"+2.0"`

--- a/schema/cyclonedx_abstractions.go
+++ b/schema/cyclonedx_abstractions.go
@@ -193,6 +193,7 @@ func (componentInfo *CDXComponentInfo) MapCDXComponentData(cdxComponent CDXCompo
 			componentInfo.ManufacturerUrl = cdxComponent.Manufacturer.Url[0]
 		}
 	}
+	componentInfo.Publisher = cdxComponent.Publisher
 	if cdxComponent.Pedigree != nil && !cdxComponent.Pedigree.isEmpty() {
 		componentInfo.HasPedigree = true
 	}

--- a/schema/cyclonedx_abstractions.go
+++ b/schema/cyclonedx_abstractions.go
@@ -59,6 +59,7 @@ type CDXResourceInfo struct {
 	Version        string `json:"version"`
 	Description    string `json:"description"`
 	BOMRef         string `json:"bom-ref"`
+	Purl           string `json:"purl"`
 	NumberLicenses int    `json:"number-licenses"`
 	Properties     *[]CDXProperty
 	Component      CDXComponent
@@ -136,6 +137,30 @@ func (componentInfo *CDXComponentInfo) MapCDXComponentData(cdxComponent CDXCompo
 	componentInfo.Copyright = cdxComponent.Copyright
 	componentInfo.Purl = cdxComponent.Purl
 	componentInfo.Cpe = cdxComponent.Cpe
+
+	// v2.0: purl/cpe moved into identifiers[].identities[] with scheme+value
+	if (componentInfo.Purl == "" || componentInfo.Cpe == "") && cdxComponent.Identifiers != nil {
+		for _, identifier := range *cdxComponent.Identifiers {
+			if identifier.Identities == nil {
+				continue
+			}
+			for _, identity := range *identifier.Identities {
+				switch identity.Scheme {
+				case "purl":
+					if componentInfo.Purl == "" {
+						componentInfo.Purl = identity.Value
+					}
+				case "cpe":
+					if componentInfo.Cpe == "" {
+						componentInfo.Cpe = identity.Value
+					}
+				}
+			}
+		}
+	}
+
+	// Mirror purl into the embedded CDXResourceInfo so resource list can surface it
+	componentInfo.CDXResourceInfo.Purl = componentInfo.Purl
 
 	// Surface SWID Tag ID field only
 	if cdxComponent.Swid != nil {

--- a/schema/cyclonedx_abstractions.go
+++ b/schema/cyclonedx_abstractions.go
@@ -194,6 +194,14 @@ func (componentInfo *CDXComponentInfo) MapCDXComponentData(cdxComponent CDXCompo
 		}
 	}
 	componentInfo.Publisher = cdxComponent.Publisher
+
+	// v2.0: supplier, manufacturer, and publisher moved to parties[].roles[]
+	// Fall back to parties extraction when direct fields are empty.
+	if cdxComponent.Parties != nil &&
+		(componentInfo.SupplierName == "" || componentInfo.ManufacturerName == "" || componentInfo.Publisher == "") {
+		mapPartiesRoleData(componentInfo, *cdxComponent.Parties)
+	}
+
 	if cdxComponent.Pedigree != nil && !cdxComponent.Pedigree.isEmpty() {
 		componentInfo.HasPedigree = true
 	}
@@ -215,6 +223,84 @@ func (componentInfo *CDXComponentInfo) MapCDXComponentData(cdxComponent CDXCompo
 	if cdxComponent.Signature != nil && *cdxComponent.Signature != (JSFSignature{}) {
 		componentInfo.HasSignature = true
 	}
+}
+
+// mapPartiesRoleData extracts supplier, manufacturer, and publisher information
+// from the v2.0 parties array ([]interface{}) and populates any empty fields on
+// componentInfo. Each party is a map with "roles" (array of {"role":"..."} objects)
+// and an "organization" map containing "name" and optionally "url" (array of
+// {"url":"..."} objects — v2.0 format).
+func mapPartiesRoleData(componentInfo *CDXComponentInfo, parties []interface{}) {
+	for _, raw := range parties {
+		party, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Collect the role strings declared for this party
+		roles, _ := party["roles"].([]interface{})
+		var hasSupplier, hasManufacturer, hasPublisher bool
+		for _, r := range roles {
+			roleObj, ok := r.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			switch roleObj["role"] {
+			case "supplier":
+				hasSupplier = true
+			case "manufacturer":
+				hasManufacturer = true
+			case "publisher":
+				hasPublisher = true
+			}
+		}
+
+		if !hasSupplier && !hasManufacturer && !hasPublisher {
+			continue
+		}
+
+		// Extract name and first URL from the organization sub-object
+		orgName, orgUrl := extractPartyOrgNameUrl(party)
+
+		if hasSupplier && componentInfo.SupplierName == "" {
+			componentInfo.SupplierName = orgName
+			if componentInfo.SupplierUrl == "" {
+				componentInfo.SupplierUrl = orgUrl
+			}
+		}
+		if hasManufacturer && componentInfo.ManufacturerName == "" {
+			componentInfo.ManufacturerName = orgName
+			if componentInfo.ManufacturerUrl == "" {
+				componentInfo.ManufacturerUrl = orgUrl
+			}
+		}
+		if hasPublisher && componentInfo.Publisher == "" {
+			componentInfo.Publisher = orgName
+		}
+	}
+}
+
+// extractPartyOrgNameUrl returns the organization name and first URL from a
+// party map. The v2.0 organization.url format is [{"name":"...", "url":"..."}].
+func extractPartyOrgNameUrl(party map[string]interface{}) (name, url string) {
+	org, ok := party["organization"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	name, _ = org["name"].(string)
+	// url is an array of objects: [{"name": "...", "url": "..."}]
+	urlEntries, _ := org["url"].([]interface{})
+	for _, entry := range urlEntries {
+		entryMap, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if u, ok := entryMap["url"].(string); ok && u != "" {
+			url = u
+			return
+		}
+	}
+	return
 }
 
 // -------------------

--- a/schema/cyclonedx_abstractions.go
+++ b/schema/cyclonedx_abstractions.go
@@ -120,14 +120,6 @@ func (componentInfo *CDXComponentInfo) MapCDXComponentData(cdxComponent CDXCompo
 	componentInfo.Version = cdxComponent.Version
 	componentInfo.Properties = cdxComponent.Properties
 
-	if cdxComponent.Supplier != nil {
-		componentInfo.SupplierName = cdxComponent.Supplier.Name
-		// NOTE: if multiple URLs exist, we only display the first
-		if len(cdxComponent.Supplier.Url) > 0 {
-			componentInfo.SupplierUrl = cdxComponent.Supplier.Url[0]
-		}
-	}
-
 	//---------------------
 	// Component-specific
 	//---------------------
@@ -185,21 +177,30 @@ func (componentInfo *CDXComponentInfo) MapCDXComponentData(cdxComponent CDXCompo
 		}
 	}
 
+	// v2.0: supplier, manufacturer, and publisher are declared via parties[].roles[].
+	// Populate from parties first so they take precedence over the legacy direct fields.
+	if cdxComponent.Parties != nil {
+		mapPartiesRoleData(componentInfo, *cdxComponent.Parties)
+	}
+
+	// Legacy (<v2.0) direct fields: fill any fields that parties did not populate.
+	if componentInfo.SupplierName == "" && cdxComponent.Supplier != nil {
+		componentInfo.SupplierName = cdxComponent.Supplier.Name
+		// NOTE: if multiple URLs exist, we only display the first
+		if len(cdxComponent.Supplier.Url) > 0 {
+			componentInfo.SupplierUrl = cdxComponent.Supplier.Url[0]
+		}
+	}
 	// Manufacturer field added v1.6
-	if cdxComponent.Manufacturer != nil {
+	if componentInfo.ManufacturerName == "" && cdxComponent.Manufacturer != nil {
 		componentInfo.ManufacturerName = cdxComponent.Manufacturer.Name
 		// NOTE: if multiple URLs exist, we only display the first
 		if len(cdxComponent.Manufacturer.Url) > 0 {
 			componentInfo.ManufacturerUrl = cdxComponent.Manufacturer.Url[0]
 		}
 	}
-	componentInfo.Publisher = cdxComponent.Publisher
-
-	// v2.0: supplier, manufacturer, and publisher moved to parties[].roles[]
-	// Fall back to parties extraction when direct fields are empty.
-	if cdxComponent.Parties != nil &&
-		(componentInfo.SupplierName == "" || componentInfo.ManufacturerName == "" || componentInfo.Publisher == "") {
-		mapPartiesRoleData(componentInfo, *cdxComponent.Parties)
+	if componentInfo.Publisher == "" {
+		componentInfo.Publisher = cdxComponent.Publisher
 	}
 
 	if cdxComponent.Pedigree != nil && !cdxComponent.Pedigree.isEmpty() {

--- a/schema/cyclonedx_crypto.go
+++ b/schema/cyclonedx_crypto.go
@@ -31,13 +31,18 @@ type CDXCryptoProperties struct {
 // v1.6: added
 // v1.7: Curve - deprecated
 // v1.7: Added: EllipticCurve
+// v2.0: ImplementationPlatform changed from a single string (v1.6/v1.7) to []string (v2.0).
+//
+//	interface{} is used so both forms unmarshal without error, matching the same
+//	pattern used for tools/identity elsewhere in this codebase.
+//
 // TODO: Test EllipticCurve; "$ref": "cryptography-defs.schema.json#/definitions/ellipticCurvesEnum"
 type CDXAlgorithmProperties struct {
-	Primitive                string    `json:"primitive,omitempty" cdx:"+1.6"`                // v1.6 added
-	ParameterSetIdentifier   string    `json:"parameterSetIdentifier,omitempty" cdx:"+1.6"`   // v1.6 added
-	Curve                    string    `json:"curve,omitempty" cdx:"+1.6"`                    // v1.6 added
-	ExecutionEnvironment     string    `json:"executionEnvironment,omitempty" cdx:"+1.6"`     // v1.6 added
-	ImplementationPlatform   string    `json:"implementationPlatform,omitempty" cdx:"+1.6"`   // v1.6 added
+	Primitive                string      `json:"primitive,omitempty" cdx:"+1.6"`                // v1.6 added
+	ParameterSetIdentifier   string      `json:"parameterSetIdentifier,omitempty" cdx:"+1.6"`   // v1.6 added
+	Curve                    string      `json:"curve,omitempty" cdx:"+1.6"`                    // v1.6 added
+	ExecutionEnvironment     string      `json:"executionEnvironment,omitempty" cdx:"+1.6"`     // v1.6 added
+	ImplementationPlatform   interface{} `json:"implementationPlatform,omitempty" cdx:"+1.6"`   // v1.6: string; v2.0: changed to []string
 	CertificationLevel       *[]string `json:"certificationLevel,omitempty" cdx:"+1.6"`       // v1.6 added
 	Mode                     string    `json:"mode,omitempty" cdx:"+1.6"`                     // v1.6 added
 	Padding                  string    `json:"padding,omitempty" cdx:"+1.6"`                  // v1.6 added

--- a/test/cyclonedx/2.0/cdx-2-0-min-required.json
+++ b/test/cyclonedx/2.0/cdx-2-0-min-required.json
@@ -1,0 +1,5 @@
+{
+  "specFormat": "CycloneDX",
+  "specVersion": "2.0",
+  "version": 1
+}

--- a/test/cyclonedx/2.0/cdx-2-0-valid-component.json
+++ b/test/cyclonedx/2.0/cdx-2-0-valid-component.json
@@ -4,20 +4,6 @@
   "serialNumber": "urn:uuid:7d4e1ae5-82d0-4b75-9c3f-f1ab7e6c29a0",
   "version": 1,
   "metadata": {
-    "supplier": {
-      "bom-ref": "org-supplier-acme",
-      "name": "Acme Supplier Ltd",
-      "url": [
-        "https://supplier.acme.example"
-      ]
-    },
-    "manufacturer": {
-      "bom-ref": "org-manufacturer-acme",
-      "name": "Acme Manufacturing Inc",
-      "url": [
-        "https://manufacturer.acme.example"
-      ]
-    },
     "component": {
       "bom-ref": "comp-acme-lib",
       "type": "library",

--- a/test/cyclonedx/2.0/cdx-2-0-valid-component.json
+++ b/test/cyclonedx/2.0/cdx-2-0-valid-component.json
@@ -1,0 +1,62 @@
+{
+  "specFormat": "CycloneDX",
+  "specVersion": "2.0",
+  "serialNumber": "urn:uuid:7d4e1ae5-82d0-4b75-9c3f-f1ab7e6c29a0",
+  "version": 1,
+  "components": [
+    {
+      "bom-ref": "comp-acme-lib",
+      "type": "library",
+      "group": "acme-corp",
+      "name": "acme-lib",
+      "version": "2.3.1",
+      "description": "CycloneDX v2.0 component fixture exercising v2.0-specific fields.",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "parties": [
+        {
+          "bom-ref": "party-acme-corp",
+          "roles": [
+            { "role": "supplier" }
+          ],
+          "organization": {
+            "name": "Acme Corp"
+          }
+        }
+      ],
+      "identifiers": [
+        {
+          "bom-ref": "ident-1",
+          "party": "party-acme-corp",
+          "identities": [
+            {
+              "scheme": "purl",
+              "value": "pkg:npm/acme-corp/acme-lib@2.3.1"
+            },
+            {
+              "scheme": "cpe",
+              "value": "cpe:2.3:a:acme-corp:acme-lib:2.3.1:*:*:*:*:*:*:*"
+            }
+          ]
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:v2.0:fixture",
+          "value": "true"
+        }
+      ]
+    }
+  ]
+}

--- a/test/cyclonedx/2.0/cdx-2-0-valid-component.json
+++ b/test/cyclonedx/2.0/cdx-2-0-valid-component.json
@@ -14,11 +14,17 @@
       "copyright": "Copyright (c) 2024 Acme Corp",
       "supplier": {
         "bom-ref": "org-supplier-acme",
-        "name": "Acme Supplier Ltd"
+        "name": "Acme Supplier Ltd",
+        "url": [
+          "https://supplier.acme.example"
+        ]
       },
       "manufacturer": {
         "bom-ref": "org-manufacturer-acme",
-        "name": "Acme Manufacturing Inc"
+        "name": "Acme Manufacturing Inc",
+        "url": [
+          "https://manufacturer.acme.example"
+        ]
       },
       "publisher": "Acme Publishing",
       "hashes": [

--- a/test/cyclonedx/2.0/cdx-2-0-valid-component.json
+++ b/test/cyclonedx/2.0/cdx-2-0-valid-component.json
@@ -3,8 +3,22 @@
   "specVersion": "2.0",
   "serialNumber": "urn:uuid:7d4e1ae5-82d0-4b75-9c3f-f1ab7e6c29a0",
   "version": 1,
-  "components": [
-    {
+  "metadata": {
+    "supplier": {
+      "bom-ref": "org-supplier-acme",
+      "name": "Acme Supplier Ltd",
+      "url": [
+        "https://supplier.acme.example"
+      ]
+    },
+    "manufacturer": {
+      "bom-ref": "org-manufacturer-acme",
+      "name": "Acme Manufacturing Inc",
+      "url": [
+        "https://manufacturer.acme.example"
+      ]
+    },
+    "component": {
       "bom-ref": "comp-acme-lib",
       "type": "library",
       "group": "acme-corp",
@@ -12,21 +26,6 @@
       "version": "2.3.1",
       "description": "CycloneDX v2.0 component fixture exercising v2.0-specific fields.",
       "copyright": "Copyright (c) 2024 Acme Corp",
-      "supplier": {
-        "bom-ref": "org-supplier-acme",
-        "name": "Acme Supplier Ltd",
-        "url": [
-          "https://supplier.acme.example"
-        ]
-      },
-      "manufacturer": {
-        "bom-ref": "org-manufacturer-acme",
-        "name": "Acme Manufacturing Inc",
-        "url": [
-          "https://manufacturer.acme.example"
-        ]
-      },
-      "publisher": "Acme Publishing",
       "hashes": [
         {
           "alg": "SHA-256",
@@ -74,5 +73,5 @@
         }
       ]
     }
-  ]
+  }
 }

--- a/test/cyclonedx/2.0/cdx-2-0-valid-component.json
+++ b/test/cyclonedx/2.0/cdx-2-0-valid-component.json
@@ -41,9 +41,33 @@
       ],
       "parties": [
         {
-          "bom-ref": "party-acme-corp",
+          "bom-ref": "party-supplier-acme",
           "roles": [
             { "role": "supplier" }
+          ],
+          "organization": {
+            "name": "Acme Supplier Ltd",
+            "url": [
+              { "name": "homepage", "url": "https://supplier.acme.example" }
+            ]
+          }
+        },
+        {
+          "bom-ref": "party-manufacturer-acme",
+          "roles": [
+            { "role": "manufacturer" }
+          ],
+          "organization": {
+            "name": "Acme Manufacturing Inc",
+            "url": [
+              { "name": "homepage", "url": "https://manufacturer.acme.example" }
+            ]
+          }
+        },
+        {
+          "bom-ref": "party-publisher-acme",
+          "roles": [
+            { "role": "publisher" }
           ],
           "organization": {
             "name": "Acme Corp"

--- a/test/cyclonedx/2.0/cdx-2-0-valid-component.json
+++ b/test/cyclonedx/2.0/cdx-2-0-valid-component.json
@@ -11,6 +11,16 @@
       "name": "acme-lib",
       "version": "2.3.1",
       "description": "CycloneDX v2.0 component fixture exercising v2.0-specific fields.",
+      "copyright": "Copyright (c) 2024 Acme Corp",
+      "supplier": {
+        "bom-ref": "org-supplier-acme",
+        "name": "Acme Supplier Ltd"
+      },
+      "manufacturer": {
+        "bom-ref": "org-manufacturer-acme",
+        "name": "Acme Manufacturing Inc"
+      },
+      "publisher": "Acme Publishing",
       "hashes": [
         {
           "alg": "SHA-256",


### PR DESCRIPTION
Primarily, we want the utility to be able to validate CycloneDX v2.0 BOMs (JSON format only) against the v2.0 "bundlied" JSON schema file (under development) using the `--variant development` flag to reflect its status.